### PR TITLE
feat: Add export methods for Markdown and JSON reports in SharedInvestigationContext

### DIFF
--- a/docs/shared-investigation-context.md
+++ b/docs/shared-investigation-context.md
@@ -233,6 +233,68 @@ Returns whether the underlying investigation has whitelist entries.
 ##### `get_global_level() -> Level`
 Returns the global level of the underlying investigation.
 
+##### `io_to_markdown() -> str`
+Generate a Markdown report of the shared investigation.
+
+Thread-safe: Uses lock to ensure consistent read of investigation state.
+
+**Returns:** Markdown formatted report as a string
+
+**Examples:**
+```python
+shared = SharedInvestigationContext(main_inv)
+markdown = shared.io_to_markdown()
+print(markdown)
+```
+
+##### `io_save_markdown(filepath: str | Path) -> str`
+Save the shared investigation as a Markdown report.
+
+Thread-safe: Uses lock to ensure consistent read. Relative paths are converted to absolute paths.
+
+**Parameters:**
+- `filepath`: Path to save the Markdown file (relative or absolute)
+
+**Returns:** Absolute path to the saved file as a string
+
+**Examples:**
+```python
+shared = SharedInvestigationContext(main_inv)
+path = shared.io_save_markdown("report.md")
+print(path)  # /absolute/path/to/report.md
+```
+
+##### `io_to_dict() -> dict[str, Any]`
+Serialize the shared investigation to a dictionary.
+
+Thread-safe: Uses lock to ensure consistent read of investigation state.
+
+**Returns:** Dictionary representation suitable for JSON export
+
+**Examples:**
+```python
+shared = SharedInvestigationContext(main_inv)
+data = shared.io_to_dict()
+print(data.keys())
+```
+
+##### `io_save_json(filepath: str | Path) -> str`
+Save the shared investigation to a JSON file.
+
+Thread-safe: Uses lock to ensure consistent read. Relative paths are converted to absolute paths.
+
+**Parameters:**
+- `filepath`: Path to save the JSON file (relative or absolute)
+
+**Returns:** Absolute path to the saved file as a string
+
+**Examples:**
+```python
+shared = SharedInvestigationContext(main_inv)
+path = shared.io_save_json("investigation.json")
+print(path)  # /absolute/path/to/investigation.json
+```
+
 > Access merged results by reusing the original `Investigation` instance you passed to `SharedInvestigationContext`; reconciliation mutates it in place.
 
 ### Cyvest Updates

--- a/src/cyvest/investigation.py
+++ b/src/cyvest/investigation.py
@@ -11,6 +11,7 @@ import threading
 from copy import deepcopy
 from dataclasses import dataclass
 from decimal import Decimal
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from logurich import logger
@@ -565,6 +566,123 @@ class SharedInvestigationContext:
 
         with self._lock:
             return key in self._check_registry
+
+    def io_to_markdown(self) -> str:
+        """
+        Generate a Markdown report of the shared investigation.
+
+        Thread-safe: Uses lock to ensure consistent read of investigation state.
+
+        Returns:
+            Markdown formatted report as a string
+
+        Example:
+            >>> shared = SharedInvestigationContext(main_inv)
+            >>> markdown = shared.io_to_markdown()
+            >>> print(markdown)
+            # Cybersecurity Investigation Report
+            ...
+        """
+        from cyvest import Cyvest
+        from cyvest.io_serialization import generate_markdown_report
+
+        with self._lock:
+            # Create temporary Cyvest wrapper for compatibility with generate_markdown_report
+            temp_cy = Cyvest.__new__(Cyvest)
+            temp_cy._investigation = self._main_investigation
+            return generate_markdown_report(temp_cy)
+
+    def io_save_markdown(self, filepath: str | Path) -> str:
+        """
+        Save the shared investigation as a Markdown report.
+
+        Thread-safe: Uses lock to ensure consistent read of investigation state.
+        Relative paths are converted to absolute paths before saving.
+
+        Args:
+            filepath: Path to save the Markdown file (relative or absolute)
+
+        Returns:
+            Absolute path to the saved file as a string
+
+        Raises:
+            PermissionError: If the file cannot be written
+            OSError: If there are file system issues
+
+        Example:
+            >>> shared = SharedInvestigationContext(main_inv)
+            >>> path = shared.io_save_markdown("report.md")
+            >>> print(path)  # /absolute/path/to/report.md
+        """
+        from pathlib import Path
+
+        from cyvest import Cyvest
+        from cyvest.io_serialization import save_investigation_markdown
+
+        with self._lock:
+            # Create temporary Cyvest wrapper for compatibility with save_investigation_markdown
+            temp_cy = Cyvest.__new__(Cyvest)
+            temp_cy._investigation = self._main_investigation
+            save_investigation_markdown(temp_cy, filepath)
+            return str(Path(filepath).resolve())
+
+    def io_to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the shared investigation to a dictionary.
+
+        Thread-safe: Uses lock to ensure consistent read of investigation state.
+
+        Returns:
+            Dictionary representation suitable for JSON export
+
+        Example:
+            >>> shared = SharedInvestigationContext(main_inv)
+            >>> data = shared.io_to_dict()
+            >>> print(data.keys())
+            dict_keys(['score', 'level', 'whitelisted', 'observables', 'checks', ...])
+        """
+        from cyvest import Cyvest
+        from cyvest.io_serialization import serialize_investigation
+
+        with self._lock:
+            # Create temporary Cyvest wrapper for compatibility with serialize_investigation
+            temp_cy = Cyvest.__new__(Cyvest)
+            temp_cy._investigation = self._main_investigation
+            return serialize_investigation(temp_cy)
+
+    def io_save_json(self, filepath: str | Path) -> str:
+        """
+        Save the shared investigation to a JSON file.
+
+        Thread-safe: Uses lock to ensure consistent read of investigation state.
+        Relative paths are converted to absolute paths before saving.
+
+        Args:
+            filepath: Path to save the JSON file (relative or absolute)
+
+        Returns:
+            Absolute path to the saved file as a string
+
+        Raises:
+            PermissionError: If the file cannot be written
+            OSError: If there are file system issues
+
+        Example:
+            >>> shared = SharedInvestigationContext(main_inv)
+            >>> path = shared.io_save_json("investigation.json")
+            >>> print(path)  # /absolute/path/to/investigation.json
+        """
+        from pathlib import Path
+
+        from cyvest import Cyvest
+        from cyvest.io_serialization import save_investigation_json
+
+        with self._lock:
+            # Create temporary Cyvest wrapper for compatibility with save_investigation_json
+            temp_cy = Cyvest.__new__(Cyvest)
+            temp_cy._investigation = self._main_investigation
+            save_investigation_json(temp_cy, filepath)
+            return str(Path(filepath).resolve())
 
 
 @dataclass

--- a/src/cyvest/io_rich.py
+++ b/src/cyvest/io_rich.py
@@ -72,12 +72,16 @@ def display_summary(
         f"Applied: {applied_checks}",
     ]
 
-    def sort_key_by_score(check: Any) -> Decimal:
+    def sort_key_by_score(check: Any) -> tuple[Decimal, str]:
         score = getattr(check, "score", 0)
         try:
-            return Decimal(score)
+            decimal_score = Decimal(score)
         except (TypeError, ValueError, InvalidOperation):
-            return Decimal(0)
+            decimal_score = Decimal(0)
+        
+        # Return tuple: (-score for descending, check_id for ascending alphabetically)
+        check_id = getattr(check, "check_id", "")
+        return (-decimal_score, check_id)
 
     table = Table(
         title="Investigation Report",
@@ -103,7 +107,7 @@ def display_summary(
     for scope_name, checks in checks_by_scope.items():
         scope_rule = Align(f"[bold magenta]{scope_name}[/bold magenta]", align="left")
         table.add_row(scope_rule, "-", "-")
-        checks = sorted(checks, key=sort_key_by_score, reverse=True)
+        checks = sorted(checks, key=sort_key_by_score)
         for check in checks:
             color_level = get_color_level(check.level)
             color_score = get_color_score(check.score)
@@ -140,7 +144,7 @@ def display_summary(
         checks = [
             c for c in cv.get_all_checks().values() if c.level == level_enum and c.level not in resolved_excluded_levels
         ]
-        checks = sorted(checks, key=sort_key_by_score, reverse=True)
+        checks = sorted(checks, key=sort_key_by_score)
         if checks:
             color_level = get_color_level(level_enum)
             level_rule = Align(

--- a/tests/test_shared_context.py
+++ b/tests/test_shared_context.py
@@ -1053,3 +1053,383 @@ def test_get_global_score_thread_safe():
     # All reads should return the same score and be Decimal type
     assert all(isinstance(s, Decimal) for s in scores)
     assert all(s == scores[0] for s in scores)
+
+
+# ==============================================================================
+# Tests for export methods (io_to_markdown, io_save_markdown, io_to_dict, io_save_json)
+# ==============================================================================
+
+
+def test_io_to_markdown_basic(tmp_path):
+    """Test basic markdown generation from shared context."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    with shared.create_cyvest() as cy:
+        obs = cy.observable(ObservableType.EMAIL_ADDR, "malicious@evil.com")
+        obs.add_ti("VT", Decimal("8.5"))
+        cy.check("email_reputation", "header", "Check sender reputation").link_observable(obs).with_score(
+            Decimal("7.0")
+        )
+
+    markdown = shared.io_to_markdown()
+
+    assert isinstance(markdown, str)
+    assert "# Cybersecurity Investigation Report" in markdown
+    assert "malicious@evil.com" in markdown
+    assert "email_reputation" in markdown
+    assert "Global Score:" in markdown
+    assert "Global Level:" in markdown
+
+
+def test_io_save_markdown_creates_file(tmp_path):
+    """Test that io_save_markdown creates a markdown file."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    with shared.create_cyvest() as cy:
+        cy.observable(ObservableType.DOMAIN_NAME, "malicious.com").add_ti("VT", Decimal("9.0"))
+
+    filepath = tmp_path / "shared_report.md"
+    result_path = shared.io_save_markdown(filepath)
+
+    assert filepath.exists()
+    assert result_path == str(filepath.resolve())
+
+    content = filepath.read_text()
+    assert "# Cybersecurity Investigation Report" in content
+    assert "malicious.com" in content
+
+
+def test_io_save_markdown_relative_path(tmp_path, monkeypatch):
+    """Test io_save_markdown with relative path."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    with shared.create_cyvest() as cy:
+        cy.check("test", "scope", "desc")
+
+    # Change to temp directory
+    monkeypatch.chdir(tmp_path)
+
+    result_path = shared.io_save_markdown("relative_report.md")
+
+    expected_path = tmp_path / "relative_report.md"
+    assert expected_path.exists()
+    assert result_path == str(expected_path.resolve())
+
+
+def test_io_to_dict_basic():
+    """Test basic dictionary serialization from shared context."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    with shared.create_cyvest() as cy:
+        cy.observable(ObservableType.IPV4_ADDR, "192.168.1.1").add_ti("SEKOIA", Decimal("6.0"))
+        cy.check("ip_reputation", "network", "Check IP reputation").with_score(Decimal("5.0"))
+
+    data = shared.io_to_dict()
+
+    assert isinstance(data, dict)
+    assert "score" in data
+    assert "level" in data
+    assert "observables" in data
+    assert "checks" in data
+    assert "stats" in data
+    assert "obs:ipv4-addr:192.168.1.1" in data["observables"]
+    assert "network" in data["checks"]  # checks are grouped by scope
+
+
+def test_io_save_json_creates_file(tmp_path):
+    """Test that io_save_json creates a JSON file."""
+    inv = Investigation({"email": "test@example.com"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    with shared.create_cyvest() as cy:
+        cy.observable(ObservableType.URL, "https://malicious.com/payload").add_ti("VT", Decimal("10.0"))
+        cy.check("url_check", "body", "Analyze URL")
+
+    filepath = tmp_path / "shared_investigation.json"
+    result_path = shared.io_save_json(filepath)
+
+    assert filepath.exists()
+    assert result_path == str(filepath.resolve())
+
+    # Verify JSON is valid and contains expected data
+    import json
+
+    with open(filepath) as f:
+        loaded = json.load(f)
+
+    assert "score" in loaded
+    assert "observables" in loaded
+    assert "obs:url:https://malicious.com/payload" in loaded["observables"]
+
+
+def test_io_save_json_relative_path(tmp_path, monkeypatch):
+    """Test io_save_json with relative path."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    with shared.create_cyvest() as cy:
+        cy.check("test", "scope", "desc")
+
+    monkeypatch.chdir(tmp_path)
+
+    result_path = shared.io_save_json("relative_investigation.json")
+
+    expected_path = tmp_path / "relative_investigation.json"
+    assert expected_path.exists()
+    assert result_path == str(expected_path.resolve())
+
+
+def test_export_methods_thread_safe():
+    """Test that export methods are thread-safe."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    with shared.create_cyvest() as cy:
+        cy.observable(ObservableType.DOMAIN_NAME, "test.com")
+        cy.check("test", "scope", "desc")
+
+    # Multiple threads calling export methods concurrently
+    def export_markdown():
+        return shared.io_to_markdown()
+
+    def export_dict():
+        return shared.io_to_dict()
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        md_futures = [executor.submit(export_markdown) for _ in range(5)]
+        dict_futures = [executor.submit(export_dict) for _ in range(5)]
+
+        md_results = [f.result() for f in md_futures]
+        dict_results = [f.result() for f in dict_futures]
+
+    # All markdown exports should be identical
+    assert all(md == md_results[0] for md in md_results)
+
+    # All dict exports should contain same data
+    assert all(d["score"] == dict_results[0]["score"] for d in dict_results)
+    assert all(len(d["observables"]) == len(dict_results[0]["observables"]) for d in dict_results)
+
+
+def test_export_methods_capture_latest_state(tmp_path):
+    """Test that export methods capture the latest investigation state."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    # Initial state
+    with shared.create_cyvest() as cy:
+        cy.observable(ObservableType.EMAIL_ADDR, "first@example.com")
+
+    markdown1 = shared.io_to_markdown()
+    assert "first@example.com" in markdown1
+    assert "second@example.com" not in markdown1
+
+    # Update state
+    with shared.create_cyvest() as cy:
+        cy.observable(ObservableType.EMAIL_ADDR, "second@example.com")
+
+    markdown2 = shared.io_to_markdown()
+    assert "first@example.com" in markdown2
+    assert "second@example.com" in markdown2
+
+    # Save to files and verify
+    path1 = tmp_path / "state1.md"
+
+    # Simulate time passing
+    shared.io_save_markdown(path1)
+
+    content1 = path1.read_text()
+    assert "second@example.com" in content1
+
+
+def test_export_with_enrichments(tmp_path):
+    """Test that export methods include enrichments."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    with shared.create_cyvest() as cy:
+        cy.enrichment_create("whois", {"registrar": "Test Registrar", "created": "2020-01-01"})
+        cy.enrichment_create("dns", {"A": ["1.2.3.4"], "MX": ["mail.example.com"]})
+
+    # Test markdown export
+    markdown = shared.io_to_markdown()
+    assert "whois" in markdown
+    assert "Test Registrar" in markdown
+    assert "dns" in markdown
+
+    # Test dict export
+    data = shared.io_to_dict()
+    assert "enrichments" in data
+    assert len(data["enrichments"]) == 2
+    assert "enr:whois" in data["enrichments"]
+    assert "enr:dns" in data["enrichments"]
+
+    # Test JSON export
+    json_path = tmp_path / "with_enrichments.json"
+    shared.io_save_json(json_path)
+
+    import json
+
+    with open(json_path) as f:
+        loaded = json.load(f)
+    assert "enrichments" in loaded
+    assert len(loaded["enrichments"]) == 2
+
+
+def test_export_with_whitelists(tmp_path):
+    """Test that export methods include whitelist information."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    inv.add_whitelist("wl-001", "Known safe domain", "Verified by security team")
+    shared = SharedInvestigationContext(inv)
+
+    with shared.create_cyvest() as cy:
+        cy.observable(ObservableType.DOMAIN_NAME, "safe.com")
+
+    # Test markdown export
+    markdown = shared.io_to_markdown()
+    assert "Whitelisted Investigation: Yes" in markdown or "Whitelist" in markdown
+
+    # Test dict export
+    data = shared.io_to_dict()
+    assert data["whitelisted"] is True
+    assert "whitelists" in data
+    assert len(data["whitelists"]) == 1
+    assert data["whitelists"][0]["identifier"] == "wl-001"
+    assert data["whitelists"][0]["name"] == "Known safe domain"
+
+    # Test JSON export
+    json_path = tmp_path / "with_whitelists.json"
+    shared.io_save_json(json_path)
+
+    import json
+
+    with open(json_path) as f:
+        loaded = json.load(f)
+    assert loaded["whitelisted"] is True
+    assert len(loaded["whitelists"]) == 1
+
+
+def test_export_comprehensive_investigation(tmp_path):
+    """Test export of a comprehensive investigation with all features."""
+    inv = Investigation({"email_subject": "Phishing attempt", "sender": "attacker@evil.com"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    # Build comprehensive investigation
+    with shared.create_cyvest() as cy:
+        # Observables
+        email_obs = cy.observable(ObservableType.EMAIL_ADDR, "attacker@evil.com")
+        email_obs.add_ti("EmailRep", Decimal("9.5"))
+
+        domain_obs = cy.observable(ObservableType.DOMAIN_NAME, "evil.com")
+        domain_obs.add_ti("VT", Decimal("8.0"))
+
+        url_obs = cy.observable(ObservableType.URL, "https://evil.com/phishing")
+        url_obs.add_ti("URLhaus", Decimal("10.0"))
+
+        # Relationships
+        email_obs.relate_to(domain_obs, RelationshipType.RELATED_TO)
+        url_obs.relate_to(domain_obs, RelationshipType.RELATED_TO)
+
+        # Checks
+        cy.check("sender_reputation", "header", "High risk sender detected").link_observable(email_obs).with_score(
+            Decimal("8.5")
+        )
+        cy.check("url_analysis", "body", "Malicious URL detected").link_observable(url_obs).with_score(Decimal("9.0"))
+
+        # Enrichments
+        cy.enrichment_create("whois", {"registrar": "Evil Registrar", "created": "2024-01-01"}, context="evil.com")
+        cy.enrichment_create("geo", {"country": "Unknown", "city": "Unknown"})
+
+    # Export to all formats
+    markdown = shared.io_to_markdown()
+    data = shared.io_to_dict()
+
+    md_path = tmp_path / "comprehensive.md"
+    json_path = tmp_path / "comprehensive.json"
+
+    shared.io_save_markdown(md_path)
+    shared.io_save_json(json_path)
+
+    # Verify markdown content
+    assert "attacker@evil.com" in markdown
+    assert "evil.com" in markdown
+    assert "sender_reputation" in markdown
+    assert "url_analysis" in markdown
+    assert "whois" in markdown
+
+    # Verify dict structure
+    assert len(data["observables"]) >= 4  # 3 created + 1 root
+    assert "header" in data["checks"]  # checks grouped by scope
+    assert "body" in data["checks"]
+    assert len(data["enrichments"]) == 2
+
+    # Verify files exist and are valid
+    assert md_path.exists()
+    assert json_path.exists()
+
+    import json
+
+    with open(json_path) as f:
+        loaded = json.load(f)
+    assert loaded["score"] == data["score"]
+    assert len(loaded["observables"]) == len(data["observables"])
+
+
+def test_export_empty_investigation(tmp_path):
+    """Test exporting an investigation with only root observable."""
+    inv = Investigation({"test": "empty"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    # No tasks run, only root observable exists
+
+    markdown = shared.io_to_markdown()
+    assert "# Cybersecurity Investigation Report" in markdown
+    assert "Global Score: 0" in markdown or "Global Score:** 0" in markdown
+
+    data = shared.io_to_dict()
+    assert data["score"] == 0.0
+    assert len(data["observables"]) == 1  # Just root
+
+    json_path = tmp_path / "empty.json"
+    md_path = tmp_path / "empty.md"
+
+    shared.io_save_json(json_path)
+    shared.io_save_markdown(md_path)
+
+    assert json_path.exists()
+    assert md_path.exists()
+
+
+def test_export_parallel_updates(tmp_path):
+    """Test that exports are consistent even with parallel task execution."""
+    inv = Investigation({"test": "data"}, root_type="artifact")
+    shared = SharedInvestigationContext(inv)
+
+    # Multiple tasks updating investigation in parallel
+    def create_observable(index: int):
+        with shared.create_cyvest() as cy:
+            cy.observable(ObservableType.IPV4_ADDR, f"10.0.0.{index}")
+            cy.check(f"check_{index}", "scope", f"Check {index}")
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        futures = [executor.submit(create_observable, i) for i in range(10)]
+        for f in futures:
+            f.result()
+
+    # Export should capture all observables and checks
+    data = shared.io_to_dict()
+    assert len(data["observables"]) == 11  # 10 created + 1 root
+    assert data["stats"]["checks_by_scope"]["scope"] == 10
+
+    # Save and verify
+    json_path = tmp_path / "parallel.json"
+    shared.io_save_json(json_path)
+
+    import json
+
+    with open(json_path) as f:
+        loaded = json.load(f)
+    assert len(loaded["observables"]) == 11

--- a/uv.lock
+++ b/uv.lock
@@ -272,7 +272,7 @@ toml = [
 
 [[package]]
 name = "cyvest"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -374,7 +374,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -925,15 +925,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.17.1"
+version = "10.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/a987e4d549c6c82353fce5fa5f650229bb60ea4c0d1684a2714a509aef58/pymdown_extensions-10.17.1.tar.gz", hash = "sha256:60d05fe55e7fb5a1e4740fc575facad20dc6ee3a748e8d3d36ba44142e75ce03", size = 845207, upload-time = "2025-11-11T21:44:58.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/6d/af5378dbdb379fddd9a277f8b9888c027db480cde70028669ebd009d642a/pymdown_extensions-10.17.2.tar.gz", hash = "sha256:26bb3d7688e651606260c90fb46409fbda70bf9fdc3623c7868643a1aeee4713", size = 847344, upload-time = "2025-11-26T15:43:57.004Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/40/b2d7b9fdccc63e48ae4dbd363b6b89eb7ac346ea49ed667bb71f92af3021/pymdown_extensions-10.17.1-py3-none-any.whl", hash = "sha256:1f160209c82eecbb5d8a0d8f89a4d9bd6bdcbde9a8537761844cfc57ad5cd8a6", size = 266310, upload-time = "2025-11-11T21:44:56.809Z" },
+    { url = "https://files.pythonhosted.org/packages/93/78/b93cb80bd673bdc9f6ede63d8eb5b4646366953df15667eb3603be57a2b1/pymdown_extensions-10.17.2-py3-none-any.whl", hash = "sha256:bffae79a2e8b9e44aef0d813583a8fea63457b7a23643a43988055b7b79b4992", size = 266556, upload-time = "2025-11-26T15:43:55.162Z" },
 ]
 
 [[package]]
@@ -1102,28 +1102,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.6"
+version = "0.14.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/f0/62b5a1a723fe183650109407fa56abb433b00aa1c0b9ba555f9c4efec2c6/ruff-0.14.6.tar.gz", hash = "sha256:6f0c742ca6a7783a736b867a263b9a7a80a45ce9bee391eeda296895f1b4e1cc", size = 5669501, upload-time = "2025-11-21T14:26:17.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/5b/dd7406afa6c95e3d8fa9d652b6d6dd17dd4a6bf63cb477014e8ccd3dcd46/ruff-0.14.7.tar.gz", hash = "sha256:3417deb75d23bd14a722b57b0a1435561db65f0ad97435b4cf9f85ffcef34ae5", size = 5727324, upload-time = "2025-11-28T20:55:10.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/d2/7dd544116d107fffb24a0064d41a5d2ed1c9d6372d142f9ba108c8e39207/ruff-0.14.6-py3-none-linux_armv6l.whl", hash = "sha256:d724ac2f1c240dbd01a2ae98db5d1d9a5e1d9e96eba999d1c48e30062df578a3", size = 13326119, upload-time = "2025-11-21T14:25:24.2Z" },
-    { url = "https://files.pythonhosted.org/packages/36/6a/ad66d0a3315d6327ed6b01f759d83df3c4d5f86c30462121024361137b6a/ruff-0.14.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9f7539ea257aa4d07b7ce87aed580e485c40143f2473ff2f2b75aee003186004", size = 13526007, upload-time = "2025-11-21T14:25:26.906Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/9d/dae6db96df28e0a15dea8e986ee393af70fc97fd57669808728080529c37/ruff-0.14.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7f6007e55b90a2a7e93083ba48a9f23c3158c433591c33ee2e99a49b889c6332", size = 12676572, upload-time = "2025-11-21T14:25:29.826Z" },
-    { url = "https://files.pythonhosted.org/packages/76/a4/f319e87759949062cfee1b26245048e92e2acce900ad3a909285f9db1859/ruff-0.14.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a8e7b9d73d8728b68f632aa8e824ef041d068d231d8dbc7808532d3629a6bef", size = 13140745, upload-time = "2025-11-21T14:25:32.788Z" },
-    { url = "https://files.pythonhosted.org/packages/95/d3/248c1efc71a0a8ed4e8e10b4b2266845d7dfc7a0ab64354afe049eaa1310/ruff-0.14.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d50d45d4553a3ebcbd33e7c5e0fe6ca4aafd9a9122492de357205c2c48f00775", size = 13076486, upload-time = "2025-11-21T14:25:35.601Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/19/b68d4563fe50eba4b8c92aa842149bb56dd24d198389c0ed12e7faff4f7d/ruff-0.14.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:118548dd121f8a21bfa8ab2c5b80e5b4aed67ead4b7567790962554f38e598ce", size = 13727563, upload-time = "2025-11-21T14:25:38.514Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ac/943169436832d4b0e867235abbdb57ce3a82367b47e0280fa7b4eabb7593/ruff-0.14.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:57256efafbfefcb8748df9d1d766062f62b20150691021f8ab79e2d919f7c11f", size = 15199755, upload-time = "2025-11-21T14:25:41.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b9/288bb2399860a36d4bb0541cb66cce3c0f4156aaff009dc8499be0c24bf2/ruff-0.14.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ff18134841e5c68f8e5df1999a64429a02d5549036b394fafbe410f886e1989d", size = 14850608, upload-time = "2025-11-21T14:25:44.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/b1/a0d549dd4364e240f37e7d2907e97ee80587480d98c7799d2d8dc7a2f605/ruff-0.14.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:29c4b7ec1e66a105d5c27bd57fa93203637d66a26d10ca9809dc7fc18ec58440", size = 14118754, upload-time = "2025-11-21T14:25:47.214Z" },
-    { url = "https://files.pythonhosted.org/packages/13/ac/9b9fe63716af8bdfddfacd0882bc1586f29985d3b988b3c62ddce2e202c3/ruff-0.14.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:167843a6f78680746d7e226f255d920aeed5e4ad9c03258094a2d49d3028b105", size = 13949214, upload-time = "2025-11-21T14:25:50.002Z" },
-    { url = "https://files.pythonhosted.org/packages/12/27/4dad6c6a77fede9560b7df6802b1b697e97e49ceabe1f12baf3ea20862e9/ruff-0.14.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:16a33af621c9c523b1ae006b1b99b159bf5ac7e4b1f20b85b2572455018e0821", size = 14106112, upload-time = "2025-11-21T14:25:52.841Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/db/23e322d7177873eaedea59a7932ca5084ec5b7e20cb30f341ab594130a71/ruff-0.14.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1432ab6e1ae2dc565a7eea707d3b03a0c234ef401482a6f1621bc1f427c2ff55", size = 13035010, upload-time = "2025-11-21T14:25:55.536Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/9c/20e21d4d69dbb35e6a1df7691e02f363423658a20a2afacf2a2c011800dc/ruff-0.14.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4c55cfbbe7abb61eb914bfd20683d14cdfb38a6d56c6c66efa55ec6570ee4e71", size = 13054082, upload-time = "2025-11-21T14:25:58.625Z" },
-    { url = "https://files.pythonhosted.org/packages/66/25/906ee6a0464c3125c8d673c589771a974965c2be1a1e28b5c3b96cb6ef88/ruff-0.14.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:efea3c0f21901a685fff4befda6d61a1bf4cb43de16da87e8226a281d614350b", size = 13303354, upload-time = "2025-11-21T14:26:01.816Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/58/60577569e198d56922b7ead07b465f559002b7b11d53f40937e95067ca1c/ruff-0.14.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:344d97172576d75dc6afc0e9243376dbe1668559c72de1864439c4fc95f78185", size = 14054487, upload-time = "2025-11-21T14:26:05.058Z" },
-    { url = "https://files.pythonhosted.org/packages/67/0b/8e4e0639e4cc12547f41cb771b0b44ec8225b6b6a93393176d75fe6f7d40/ruff-0.14.6-py3-none-win32.whl", hash = "sha256:00169c0c8b85396516fdd9ce3446c7ca20c2a8f90a77aa945ba6b8f2bfe99e85", size = 13013361, upload-time = "2025-11-21T14:26:08.152Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/02/82240553b77fd1341f80ebb3eaae43ba011c7a91b4224a9f317d8e6591af/ruff-0.14.6-py3-none-win_amd64.whl", hash = "sha256:390e6480c5e3659f8a4c8d6a0373027820419ac14fa0d2713bd8e6c3e125b8b9", size = 14432087, upload-time = "2025-11-21T14:26:10.891Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/1f/93f9b0fad9470e4c829a5bb678da4012f0c710d09331b860ee555216f4ea/ruff-0.14.6-py3-none-win_arm64.whl", hash = "sha256:d43c81fbeae52cfa8728d8766bbf46ee4298c888072105815b392da70ca836b2", size = 13520930, upload-time = "2025-11-21T14:26:13.951Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b1/7ea5647aaf90106f6d102230e5df874613da43d1089864da1553b899ba5e/ruff-0.14.7-py3-none-linux_armv6l.whl", hash = "sha256:b9d5cb5a176c7236892ad7224bc1e63902e4842c460a0b5210701b13e3de4fca", size = 13414475, upload-time = "2025-11-28T20:54:54.569Z" },
+    { url = "https://files.pythonhosted.org/packages/af/19/fddb4cd532299db9cdaf0efdc20f5c573ce9952a11cb532d3b859d6d9871/ruff-0.14.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3f64fe375aefaf36ca7d7250292141e39b4cea8250427482ae779a2aa5d90015", size = 13634613, upload-time = "2025-11-28T20:55:17.54Z" },
+    { url = "https://files.pythonhosted.org/packages/40/2b/469a66e821d4f3de0440676ed3e04b8e2a1dc7575cf6fa3ba6d55e3c8557/ruff-0.14.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93e83bd3a9e1a3bda64cb771c0d47cda0e0d148165013ae2d3554d718632d554", size = 12765458, upload-time = "2025-11-28T20:55:26.128Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/05/0b001f734fe550bcfde4ce845948ac620ff908ab7241a39a1b39bb3c5f49/ruff-0.14.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3838948e3facc59a6070795de2ae16e5786861850f78d5914a03f12659e88f94", size = 13236412, upload-time = "2025-11-28T20:55:28.602Z" },
+    { url = "https://files.pythonhosted.org/packages/11/36/8ed15d243f011b4e5da75cd56d6131c6766f55334d14ba31cce5461f28aa/ruff-0.14.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24c8487194d38b6d71cd0fd17a5b6715cda29f59baca1defe1e3a03240f851d1", size = 13182949, upload-time = "2025-11-28T20:55:33.265Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cf/fcb0b5a195455729834f2a6eadfe2e4519d8ca08c74f6d2b564a4f18f553/ruff-0.14.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79c73db6833f058a4be8ffe4a0913b6d4ad41f6324745179bd2aa09275b01d0b", size = 13816470, upload-time = "2025-11-28T20:55:08.203Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5d/34a4748577ff7a5ed2f2471456740f02e86d1568a18c9faccfc73bd9ca3f/ruff-0.14.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:12eb7014fccff10fc62d15c79d8a6be4d0c2d60fe3f8e4d169a0d2def75f5dad", size = 15289621, upload-time = "2025-11-28T20:55:30.837Z" },
+    { url = "https://files.pythonhosted.org/packages/53/53/0a9385f047a858ba133d96f3f8e3c9c66a31cc7c4b445368ef88ebeac209/ruff-0.14.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c623bbdc902de7ff715a93fa3bb377a4e42dd696937bf95669118773dbf0c50", size = 14975817, upload-time = "2025-11-28T20:55:24.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d7/2f1c32af54c3b46e7fadbf8006d8b9bcfbea535c316b0bd8813d6fb25e5d/ruff-0.14.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f53accc02ed2d200fa621593cdb3c1ae06aa9b2c3cae70bc96f72f0000ae97a9", size = 14284549, upload-time = "2025-11-28T20:55:06.08Z" },
+    { url = "https://files.pythonhosted.org/packages/92/05/434ddd86becd64629c25fb6b4ce7637dd52a45cc4a4415a3008fe61c27b9/ruff-0.14.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:281f0e61a23fcdcffca210591f0f53aafaa15f9025b5b3f9706879aaa8683bc4", size = 14071389, upload-time = "2025-11-28T20:55:35.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/50/fdf89d4d80f7f9d4f420d26089a79b3bb1538fe44586b148451bc2ba8d9c/ruff-0.14.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:dbbaa5e14148965b91cb090236931182ee522a5fac9bc5575bafc5c07b9f9682", size = 14202679, upload-time = "2025-11-28T20:55:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/77/54/87b34988984555425ce967f08a36df0ebd339bb5d9d0e92a47e41151eafc/ruff-0.14.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1464b6e54880c0fe2f2d6eaefb6db15373331414eddf89d6b903767ae2458143", size = 13147677, upload-time = "2025-11-28T20:55:19.933Z" },
+    { url = "https://files.pythonhosted.org/packages/67/29/f55e4d44edfe053918a16a3299e758e1c18eef216b7a7092550d7a9ec51c/ruff-0.14.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f217ed871e4621ea6128460df57b19ce0580606c23aeab50f5de425d05226784", size = 13151392, upload-time = "2025-11-28T20:55:21.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/69/47aae6dbd4f1d9b4f7085f4d9dcc84e04561ee7ad067bf52e0f9b02e3209/ruff-0.14.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6be02e849440ed3602d2eb478ff7ff07d53e3758f7948a2a598829660988619e", size = 13412230, upload-time = "2025-11-28T20:55:12.749Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4b/6e96cb6ba297f2ba502a231cd732ed7c3de98b1a896671b932a5eefa3804/ruff-0.14.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:19a0f116ee5e2b468dfe80c41c84e2bbd6b74f7b719bee86c2ecde0a34563bcc", size = 14195397, upload-time = "2025-11-28T20:54:56.896Z" },
+    { url = "https://files.pythonhosted.org/packages/69/82/251d5f1aa4dcad30aed491b4657cecd9fb4274214da6960ffec144c260f7/ruff-0.14.7-py3-none-win32.whl", hash = "sha256:e33052c9199b347c8937937163b9b149ef6ab2e4bb37b042e593da2e6f6cccfa", size = 13126751, upload-time = "2025-11-28T20:55:03.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b5/d0b7d145963136b564806f6584647af45ab98946660d399ec4da79cae036/ruff-0.14.7-py3-none-win_amd64.whl", hash = "sha256:e17a20ad0d3fad47a326d773a042b924d3ac31c6ca6deb6c72e9e6b5f661a7c6", size = 14531726, upload-time = "2025-11-28T20:54:59.121Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d2/1637f4360ada6a368d3265bf39f2cf737a0aaab15ab520fc005903e883f8/ruff-0.14.7-py3-none-win_arm64.whl", hash = "sha256:be4d653d3bea1b19742fcc6502354e32f65cd61ff2fbdb365803ef2c2aec6228", size = 13609215, upload-time = "2025-11-28T20:55:15.375Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Implemented `io_to_markdown` to generate a Markdown report of the investigation.
- Added `io_save_markdown` to save the Markdown report to a specified file path.
- Introduced `io_to_dict` for serializing the investigation to a dictionary format.
- Created `io_save_json` to save the investigation data as a JSON file.
- Enhanced thread safety for all new export methods.
- Added comprehensive tests for the new export functionalities, ensuring correct behavior and data integrity.
- Updated package versions in `uv.lock` for dependencies.