### PR TITLE
refactor: remove stats_checks from CyvestInvestigation and related schemas

### DIFF
--- a/js/packages/cyvest-app/src/investigations/cyvest_email.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_email.json
@@ -1,15 +1,15 @@
 {
-  "investigation_id": "01KD15RP8XFZRYECKFQAD3RWHC",
+  "investigation_id": "01KD53481PYE3ANAEMPC9KEKFE",
   "investigation_name": "Email Investigation",
-  "started_at": "2025-12-21T19:21:47.037205Z",
+  "started_at": "2025-12-23T07:52:37.686372Z",
   "score": 36.1,
   "level": "MALICIOUS",
   "whitelisted": false,
   "whitelists": [],
   "event_log": [
     {
-      "event_id": "01KD15RP8XW256NTS4CP91XM8Z",
-      "timestamp": "2025-12-21T19:21:47.037869Z",
+      "event_id": "01KD53481P5AH5291354WV7A5T",
+      "timestamp": "2025-12-23T07:52:37.686647Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -19,8 +19,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP8ZGN85TQ7EM1T0JH0R",
-      "timestamp": "2025-12-21T19:21:47.039772Z",
+      "event_id": "01KD53481RYZGN3XVYZF9FQDZE",
+      "timestamp": "2025-12-23T07:52:37.688136Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Merged from obs:artifact:root",
@@ -35,8 +35,8 @@
       }
     },
     {
-      "event_id": "01KD15RP8Z69ACWNNSJYN01HSN",
-      "timestamp": "2025-12-21T19:21:47.039821Z",
+      "event_id": "01KD53481RQ508HB3TVVK3MY0K",
+      "timestamp": "2025-12-23T07:52:37.688182Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -46,8 +46,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP8ZEP82HGZNGQWY72WQ",
-      "timestamp": "2025-12-21T19:21:47.039829Z",
+      "event_id": "01KD53481RVRJCV0B4CJ5V9R18",
+      "timestamp": "2025-12-23T07:52:37.688190Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -57,8 +57,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP8ZW9KTMSMXAFXZYX0M",
-      "timestamp": "2025-12-21T19:21:47.039836Z",
+      "event_id": "01KD53481R56HD6GGSQZV7XR2C",
+      "timestamp": "2025-12-23T07:52:37.688197Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -68,8 +68,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP8ZB7Y6YV5YHC8QEYX5",
-      "timestamp": "2025-12-21T19:21:47.039849Z",
+      "event_id": "01KD53481RP32H7MHFPKK1NGE5",
+      "timestamp": "2025-12-23T07:52:37.688211Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -78,12 +78,14 @@
       "object_key": "obs:domain-name:dmalicious.com",
       "details": {
         "threat_intel_key": "ti:vt:obs:domain-name:dmalicious.com",
-        "source": "VT"
+        "source": "VT",
+        "score": "1",
+        "level": "NOTABLE"
       }
     },
     {
-      "event_id": "01KD15RP8ZX699R3RKHFAG9KKX",
-      "timestamp": "2025-12-21T19:21:47.039860Z",
+      "event_id": "01KD53481RHP21E0658PQTMVC0",
+      "timestamp": "2025-12-23T07:52:37.688226Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -92,12 +94,14 @@
       "object_key": "obs:ipv4-addr:8.1.2.3",
       "details": {
         "threat_intel_key": "ti:abuseipdb:obs:ipv4-addr:8.1.2.3",
-        "source": "ABUSEIPDB"
+        "source": "ABUSEIPDB",
+        "score": "2",
+        "level": "NOTABLE"
       }
     },
     {
-      "event_id": "01KD15RP8ZKSVB6QN26QKYNF0X",
-      "timestamp": "2025-12-21T19:21:47.039876Z",
+      "event_id": "01KD53481RSRNPEWPEVF580X6W",
+      "timestamp": "2025-12-23T07:52:37.688242Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -106,12 +110,14 @@
       "object_key": "obs:email-addr:noreply@dmalicious.com",
       "details": {
         "threat_intel_key": "ti:vt:obs:email-addr:noreply@dmalicious.com",
-        "source": "VT"
+        "source": "VT",
+        "score": "0",
+        "level": "INFO"
       }
     },
     {
-      "event_id": "01KD15RP8ZRNDT713DYM7JSEF2",
-      "timestamp": "2025-12-21T19:21:47.039890Z",
+      "event_id": "01KD53481RB6NMF5JTX0J5D29M",
+      "timestamp": "2025-12-23T07:52:37.688257Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -121,8 +127,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP8ZZXS69GNJ8ZDF4CZ7",
-      "timestamp": "2025-12-21T19:21:47.039896Z",
+      "event_id": "01KD53481RG76WR9FB7TDRE87R",
+      "timestamp": "2025-12-23T07:52:37.688264Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -132,17 +138,17 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP8Z51E24FWE96V1TCCH",
-      "timestamp": "2025-12-21T19:21:47.039926Z",
+      "event_id": "01KD53481R7DMWWZYDC6482WBJ",
+      "timestamp": "2025-12-23T07:52:37.688294Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KD15RP8XFZRYECKFQAD3RWHC",
+      "object_key": "01KD53481PYE3ANAEMPC9KEKFE",
       "details": {
-        "from_investigation_id": "01KD15RP8YM9HZ8EH1RGM6NSZ1",
-        "into_investigation_id": "01KD15RP8XFZRYECKFQAD3RWHC",
+        "from_investigation_id": "01KD53481PXJAS55KDHK4B2VBP",
+        "into_investigation_id": "01KD53481PYE3ANAEMPC9KEKFE",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -206,8 +212,8 @@
       }
     },
     {
-      "event_id": "01KD15RP90FD9KTG6X2KJ95Q4J",
-      "timestamp": "2025-12-21T19:21:47.040735Z",
+      "event_id": "01KD53481S8NE6P65QC48WKQPC",
+      "timestamp": "2025-12-23T07:52:37.689837Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Merged from obs:email-addr:noreply@dmalicious.com",
@@ -222,8 +228,8 @@
       }
     },
     {
-      "event_id": "01KD15RP90ZS9RNEVYJTCE3GW3",
-      "timestamp": "2025-12-21T19:21:47.040781Z",
+      "event_id": "01KD53481SVTEZF3CV43P1Y41T",
+      "timestamp": "2025-12-23T07:52:37.689884Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -232,12 +238,14 @@
       "object_key": "obs:email-addr:noreply@dmalicious.com",
       "details": {
         "threat_intel_key": "ti:proofpoint:obs:email-addr:noreply@dmalicious.com",
-        "source": "PROOFPOINT"
+        "source": "PROOFPOINT",
+        "score": "5",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RP909RWFMQK21VRVNFPN",
-      "timestamp": "2025-12-21T19:21:47.040791Z",
+      "event_id": "01KD53481SRZJYV6B06AD8S053",
+      "timestamp": "2025-12-23T07:52:37.689896Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -247,17 +255,17 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP90V9VCK3TK54F434A8",
-      "timestamp": "2025-12-21T19:21:47.040838Z",
+      "event_id": "01KD53481SPVHGTXVR59J45BGK",
+      "timestamp": "2025-12-23T07:52:37.689946Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KD15RP8XFZRYECKFQAD3RWHC",
+      "object_key": "01KD53481PYE3ANAEMPC9KEKFE",
       "details": {
-        "from_investigation_id": "01KD15RP90XJW9DAGWGDW1JHVD",
-        "into_investigation_id": "01KD15RP8XFZRYECKFQAD3RWHC",
+        "from_investigation_id": "01KD53481S8JX842WG1RZ2CG1W",
+        "into_investigation_id": "01KD53481PYE3ANAEMPC9KEKFE",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -303,8 +311,8 @@
       }
     },
     {
-      "event_id": "01KD15RP91WE4N21NNVN6GFXHF",
-      "timestamp": "2025-12-21T19:21:47.041847Z",
+      "event_id": "01KD53481T2BD7SEWWJ9EFMSV8",
+      "timestamp": "2025-12-23T07:52:37.690610Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -314,8 +322,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP91ECTDP44WTSBCQ83J",
-      "timestamp": "2025-12-21T19:21:47.041859Z",
+      "event_id": "01KD53481TMQ83QJSE2YXDR8QQ",
+      "timestamp": "2025-12-23T07:52:37.690621Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -325,8 +333,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP91TX5THE8KE0R06P0V",
-      "timestamp": "2025-12-21T19:21:47.041867Z",
+      "event_id": "01KD53481T76D1P8PND53DEF2H",
+      "timestamp": "2025-12-23T07:52:37.690627Z",
       "event_type": "ENRICHMENT_CREATED",
       "actor": null,
       "reason": null,
@@ -336,17 +344,17 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP91GD89CQ6VX7XZ1Q0C",
-      "timestamp": "2025-12-21T19:21:47.041930Z",
+      "event_id": "01KD53481TST9JHJYJ47VKV14K",
+      "timestamp": "2025-12-23T07:52:37.690687Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KD15RP8XFZRYECKFQAD3RWHC",
+      "object_key": "01KD53481PYE3ANAEMPC9KEKFE",
       "details": {
-        "from_investigation_id": "01KD15RP90RE1XFNN9S7BY5FZY",
-        "into_investigation_id": "01KD15RP8XFZRYECKFQAD3RWHC",
+        "from_investigation_id": "01KD53481TPKNZPZGVBR3NW16W",
+        "into_investigation_id": "01KD53481PYE3ANAEMPC9KEKFE",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -388,8 +396,8 @@
       }
     },
     {
-      "event_id": "01KD15RP93HBGZEY8M06T9KB52",
-      "timestamp": "2025-12-21T19:21:47.043558Z",
+      "event_id": "01KD53481WKFFXSXZBNQW18EM1",
+      "timestamp": "2025-12-23T07:52:37.692972Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -399,8 +407,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP93HJ62SWVQA0CE18YS",
-      "timestamp": "2025-12-21T19:21:47.043567Z",
+      "event_id": "01KD53481WHZGVMSCE4R72J8FM",
+      "timestamp": "2025-12-23T07:52:37.692981Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -410,8 +418,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP93BXMF061R53T6T8C7",
-      "timestamp": "2025-12-21T19:21:47.043574Z",
+      "event_id": "01KD53481WJNAE31X37BW0CMRA",
+      "timestamp": "2025-12-23T07:52:37.692988Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -421,8 +429,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP93DB1XXENMAMHX09QK",
-      "timestamp": "2025-12-21T19:21:47.043581Z",
+      "event_id": "01KD53481W833GN0ZS21W6VMCJ",
+      "timestamp": "2025-12-23T07:52:37.692995Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -432,8 +440,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP933VE9Y9AW4SE0SMRG",
-      "timestamp": "2025-12-21T19:21:47.043588Z",
+      "event_id": "01KD53481W9XNEDWAKXW353R0T",
+      "timestamp": "2025-12-23T07:52:37.693001Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -443,8 +451,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP93VX3P72QYH16FQ04R",
-      "timestamp": "2025-12-21T19:21:47.043659Z",
+      "event_id": "01KD53481XPBWPNDZJCJJ3DZ1G",
+      "timestamp": "2025-12-23T07:52:37.693014Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -453,12 +461,14 @@
       "object_key": "obs:url:https://virus.com/payload.exe",
       "details": {
         "threat_intel_key": "ti:vt:obs:url:https://virus.com/payload.exe",
-        "source": "VT"
+        "source": "VT",
+        "score": "5",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RP93S6HQMPQA7TAE035Y",
-      "timestamp": "2025-12-21T19:21:47.043673Z",
+      "event_id": "01KD53481XQCJF1NBE5CZG83K5",
+      "timestamp": "2025-12-23T07:52:37.693029Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -467,12 +477,14 @@
       "object_key": "obs:url:https://virus.com/about",
       "details": {
         "threat_intel_key": "ti:vt:obs:url:https://virus.com/about",
-        "source": "VT"
+        "source": "VT",
+        "score": "3",
+        "level": "SUSPICIOUS"
       }
     },
     {
-      "event_id": "01KD15RP93N52N0QSGGCQE71HH",
-      "timestamp": "2025-12-21T19:21:47.043686Z",
+      "event_id": "01KD53481X3GMQK3T0HM0QS6PD",
+      "timestamp": "2025-12-23T07:52:37.693042Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -481,12 +493,14 @@
       "object_key": "obs:url:https://domain.com/ok/toto",
       "details": {
         "threat_intel_key": "ti:vt:obs:url:https://domain.com/ok/toto",
-        "source": "VT"
+        "source": "VT",
+        "score": "-1",
+        "level": "TRUSTED"
       }
     },
     {
-      "event_id": "01KD15RP93AP4K59V83H54N3K6",
-      "timestamp": "2025-12-21T19:21:47.043830Z",
+      "event_id": "01KD53481X7REQ872ZWEAYHRY8",
+      "timestamp": "2025-12-23T07:52:37.693053Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -496,8 +510,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP93KBB1H5SYGH2THNBX",
-      "timestamp": "2025-12-21T19:21:47.043839Z",
+      "event_id": "01KD53481X0DS74CZ748P19QHC",
+      "timestamp": "2025-12-23T07:52:37.693059Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -507,8 +521,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP93YXX73DQNQX3096CX",
-      "timestamp": "2025-12-21T19:21:47.043846Z",
+      "event_id": "01KD53481XQ412XK1N714SG7KV",
+      "timestamp": "2025-12-23T07:52:37.693068Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -518,8 +532,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP93V8TVVZKM48NVPXB5",
-      "timestamp": "2025-12-21T19:21:47.043853Z",
+      "event_id": "01KD53481XD73X9BT1V61JYDED",
+      "timestamp": "2025-12-23T07:52:37.693640Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -529,17 +543,17 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP93Z9R1GBVMYNG1JPJB",
-      "timestamp": "2025-12-21T19:21:47.043920Z",
+      "event_id": "01KD53481XWCD6RBSF3M9XEER1",
+      "timestamp": "2025-12-23T07:52:37.693727Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KD15RP8XFZRYECKFQAD3RWHC",
+      "object_key": "01KD53481PYE3ANAEMPC9KEKFE",
       "details": {
-        "from_investigation_id": "01KD15RP92MC6KS2BC3S51XDDE",
-        "into_investigation_id": "01KD15RP8XFZRYECKFQAD3RWHC",
+        "from_investigation_id": "01KD53481TCYEEB7PMSWM5PYXR",
+        "into_investigation_id": "01KD53481PYE3ANAEMPC9KEKFE",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -627,8 +641,8 @@
       }
     },
     {
-      "event_id": "01KD15RP957KK8GNWXC93JAK5T",
-      "timestamp": "2025-12-21T19:21:47.045556Z",
+      "event_id": "01KD53481ZYCNPY1SKN48DE39P",
+      "timestamp": "2025-12-23T07:52:37.695255Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -638,8 +652,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP95VVM78GYV0VPBKT6B",
-      "timestamp": "2025-12-21T19:21:47.045668Z",
+      "event_id": "01KD53481ZJ2CQDKR29JTZT56J",
+      "timestamp": "2025-12-23T07:52:37.695358Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -648,12 +662,14 @@
       "object_key": "obs:domain-name:virus.com",
       "details": {
         "threat_intel_key": "ti:vt:obs:domain-name:virus.com",
-        "source": "VT"
+        "source": "VT",
+        "score": "3",
+        "level": "SUSPICIOUS"
       }
     },
     {
-      "event_id": "01KD15RP95QGP0MAFQC6QQR30W",
-      "timestamp": "2025-12-21T19:21:47.045687Z",
+      "event_id": "01KD53481Z3FDMY0HZXFY9GK60",
+      "timestamp": "2025-12-23T07:52:37.695376Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -662,12 +678,14 @@
       "object_key": "obs:domain-name:domain.com",
       "details": {
         "threat_intel_key": "ti:vt:obs:domain-name:domain.com",
-        "source": "VT"
+        "source": "VT",
+        "score": "0",
+        "level": "INFO"
       }
     },
     {
-      "event_id": "01KD15RP95Q0HHD1VKAMKC2SDQ",
-      "timestamp": "2025-12-21T19:21:47.045700Z",
+      "event_id": "01KD53481Z89598CERJZ8M73KM",
+      "timestamp": "2025-12-23T07:52:37.695387Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -677,8 +695,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP95FHXQTKGPND7EC3E4",
-      "timestamp": "2025-12-21T19:21:47.045711Z",
+      "event_id": "01KD53481ZA7P06M696EZMJRSE",
+      "timestamp": "2025-12-23T07:52:37.695394Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -688,8 +706,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP95AQYW44BBV77ZEPBV",
-      "timestamp": "2025-12-21T19:21:47.045722Z",
+      "event_id": "01KD53481ZS04YTGCSPDWTBKVN",
+      "timestamp": "2025-12-23T07:52:37.695400Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -699,8 +717,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP95GMD7PA7CT8HHSG10",
-      "timestamp": "2025-12-21T19:21:47.045835Z",
+      "event_id": "01KD53481ZFEZ3GV6J29PA3GTS",
+      "timestamp": "2025-12-23T07:52:37.695508Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:domain-name:virus.com updated",
@@ -715,17 +733,17 @@
       }
     },
     {
-      "event_id": "01KD15RP95X7XD9BJ0YGTZN8RN",
-      "timestamp": "2025-12-21T19:21:47.045852Z",
+      "event_id": "01KD53481ZCDV4H1PHK9DE14YD",
+      "timestamp": "2025-12-23T07:52:37.695523Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KD15RP8XFZRYECKFQAD3RWHC",
+      "object_key": "01KD53481PYE3ANAEMPC9KEKFE",
       "details": {
-        "from_investigation_id": "01KD15RP9481RT6HEMRBS4GYHC",
-        "into_investigation_id": "01KD15RP8XFZRYECKFQAD3RWHC",
+        "from_investigation_id": "01KD53481YR5XGKH5M1Q6SGS9Z",
+        "into_investigation_id": "01KD53481PYE3ANAEMPC9KEKFE",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -794,8 +812,8 @@
       }
     },
     {
-      "event_id": "01KD15RP961SNYNA5KJZ8PND2Q",
-      "timestamp": "2025-12-21T19:21:47.046735Z",
+      "event_id": "01KD534821KJZZ7CJ6RB4R9Q2W",
+      "timestamp": "2025-12-23T07:52:37.697239Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Merged from obs:artifact:root",
@@ -810,8 +828,8 @@
       }
     },
     {
-      "event_id": "01KD15RP962PTYFPB6JM2F8FZ6",
-      "timestamp": "2025-12-21T19:21:47.046934Z",
+      "event_id": "01KD534821E25A0BFBSCBW1ZTR",
+      "timestamp": "2025-12-23T07:52:37.697441Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -821,8 +839,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP96TA9HWWX6K11XMP8V",
-      "timestamp": "2025-12-21T19:21:47.046945Z",
+      "event_id": "01KD534821N8ES0ZAPZJRY1EFN",
+      "timestamp": "2025-12-23T07:52:37.697449Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -832,8 +850,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP96B6CVHKEP1CWGKJ2R",
-      "timestamp": "2025-12-21T19:21:47.046960Z",
+      "event_id": "01KD5348215SM2AJM02ZXC1X8K",
+      "timestamp": "2025-12-23T07:52:37.697461Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -842,12 +860,14 @@
       "object_key": "obs:file:md5:d41d8cd98f00b204e9800998ecf8427e",
       "details": {
         "threat_intel_key": "ti:vt:obs:file:md5:d41d8cd98f00b204e9800998ecf8427e",
-        "source": "VT"
+        "source": "VT",
+        "score": "10",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RP96DAPQQXJ5RERY9XHV",
-      "timestamp": "2025-12-21T19:21:47.046974Z",
+      "event_id": "01KD53482174BVDARES20ZKCWF",
+      "timestamp": "2025-12-23T07:52:37.697475Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -856,12 +876,14 @@
       "object_key": "obs:file:invoice.pdf",
       "details": {
         "threat_intel_key": "ti:malwarebazaar:obs:file:invoice.pdf",
-        "source": "MALWAREBAZAAR"
+        "source": "MALWAREBAZAAR",
+        "score": "10",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RP968593T5Z9HDEEARWY",
-      "timestamp": "2025-12-21T19:21:47.046986Z",
+      "event_id": "01KD5348218RAXBN872JVFQN2M",
+      "timestamp": "2025-12-23T07:52:37.697484Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -871,8 +893,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP96NBGK3SZKMQT0951Z",
-      "timestamp": "2025-12-21T19:21:47.046995Z",
+      "event_id": "01KD534821N0WRG73FG4QBKJRP",
+      "timestamp": "2025-12-23T07:52:37.697490Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -882,17 +904,17 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP97SYWG7ZPHRBR0KFJA",
-      "timestamp": "2025-12-21T19:21:47.047123Z",
+      "event_id": "01KD534821WWH3PTNMRSDHZ16B",
+      "timestamp": "2025-12-23T07:52:37.697618Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KD15RP8XFZRYECKFQAD3RWHC",
+      "object_key": "01KD53481PYE3ANAEMPC9KEKFE",
       "details": {
-        "from_investigation_id": "01KD15RP962KCHESMBJN2C7KSF",
-        "into_investigation_id": "01KD15RP8XFZRYECKFQAD3RWHC",
+        "from_investigation_id": "01KD53481Z5QFPSY6RKYE3VPSZ",
+        "into_investigation_id": "01KD53481PYE3ANAEMPC9KEKFE",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -944,8 +966,8 @@
       }
     },
     {
-      "event_id": "01KD15RP98SFT9PEVZP5BK4PNE",
-      "timestamp": "2025-12-21T19:21:47.048008Z",
+      "event_id": "01KD5348224RWRE3RN6WV9BEJ8",
+      "timestamp": "2025-12-23T07:52:37.698508Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -955,8 +977,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP98V1TNMF1MMV2BB0V1",
-      "timestamp": "2025-12-21T19:21:47.048017Z",
+      "event_id": "01KD5348222481R7RE84A2DG5X",
+      "timestamp": "2025-12-23T07:52:37.698517Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -966,17 +988,17 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP98JDME9H6PWWKCNK8A",
-      "timestamp": "2025-12-21T19:21:47.048141Z",
+      "event_id": "01KD534822H2RMG4S5V6P1DJT7",
+      "timestamp": "2025-12-23T07:52:37.698639Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KD15RP8XFZRYECKFQAD3RWHC",
+      "object_key": "01KD53481PYE3ANAEMPC9KEKFE",
       "details": {
-        "from_investigation_id": "01KD15RP97T6T9XVA34X4E7BGN",
-        "into_investigation_id": "01KD15RP8XFZRYECKFQAD3RWHC",
+        "from_investigation_id": "01KD5348212X7GEKNZ2329QFQ4",
+        "into_investigation_id": "01KD53481PYE3ANAEMPC9KEKFE",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -1004,8 +1026,8 @@
       }
     },
     {
-      "event_id": "01KD15RP98FH9DVF12Y42XB5QV",
-      "timestamp": "2025-12-21T19:21:47.048743Z",
+      "event_id": "01KD5348239YF348CW9YDWH5AY",
+      "timestamp": "2025-12-23T07:52:37.699222Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -1015,17 +1037,17 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RP9832QF1W4TATYGQZCQ",
-      "timestamp": "2025-12-21T19:21:47.048871Z",
+      "event_id": "01KD534823A6PYT9WY44MM0XXY",
+      "timestamp": "2025-12-23T07:52:37.699342Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KD15RP8XFZRYECKFQAD3RWHC",
+      "object_key": "01KD53481PYE3ANAEMPC9KEKFE",
       "details": {
-        "from_investigation_id": "01KD15RP98BZW44YHMXCAHS5C8",
-        "into_investigation_id": "01KD15RP8XFZRYECKFQAD3RWHC",
+        "from_investigation_id": "01KD5348223P0S2H5GMED01CBT",
+        "into_investigation_id": "01KD53481PYE3ANAEMPC9KEKFE",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -1405,7 +1427,7 @@
         "extra": {},
         "score": 2.0,
         "level": "NOTABLE",
-        "origin_investigation_id": "01KD15RP8YM9HZ8EH1RGM6NSZ1",
+        "origin_investigation_id": "01KD53481PXJAS55KDHK4B2VBP",
         "observable_links": [
           {
             "observable_key": "obs:email-addr:noreply@dmalicious.com",
@@ -1423,7 +1445,7 @@
         "extra": {},
         "score": 5.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RP90XJW9DAGWGDW1JHVD",
+        "origin_investigation_id": "01KD53481S8JX842WG1RZ2CG1W",
         "observable_links": [
           {
             "observable_key": "obs:email-addr:noreply@dmalicious.com",
@@ -1441,7 +1463,7 @@
         "extra": {},
         "score": 0.1,
         "level": "NOTABLE",
-        "origin_investigation_id": "01KD15RP90RE1XFNN9S7BY5FZY",
+        "origin_investigation_id": "01KD53481TPKNZPZGVBR3NW16W",
         "observable_links": [
           {
             "observable_key": "obs:email-addr:user@company.com",
@@ -1461,7 +1483,7 @@
         "extra": {},
         "score": 5.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RP92MC6KS2BC3S51XDDE",
+        "origin_investigation_id": "01KD53481TCYEEB7PMSWM5PYXR",
         "observable_links": [
           {
             "observable_key": "obs:url:https://virus.com/payload.exe",
@@ -1479,7 +1501,7 @@
         "extra": {},
         "score": 3.0,
         "level": "SUSPICIOUS",
-        "origin_investigation_id": "01KD15RP92MC6KS2BC3S51XDDE",
+        "origin_investigation_id": "01KD53481TCYEEB7PMSWM5PYXR",
         "observable_links": [
           {
             "observable_key": "obs:url:https://virus.com/about",
@@ -1497,7 +1519,7 @@
         "extra": {},
         "score": 0.0,
         "level": "INFO",
-        "origin_investigation_id": "01KD15RP92MC6KS2BC3S51XDDE",
+        "origin_investigation_id": "01KD53481TCYEEB7PMSWM5PYXR",
         "observable_links": [
           {
             "observable_key": "obs:url:https://domain.com/ok/toto",
@@ -1515,7 +1537,7 @@
         "extra": {},
         "score": 5.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RP9481RT6HEMRBS4GYHC",
+        "origin_investigation_id": "01KD53481YR5XGKH5M1Q6SGS9Z",
         "observable_links": [
           {
             "observable_key": "obs:domain-name:virus.com",
@@ -1533,7 +1555,7 @@
         "extra": {},
         "score": 0.0,
         "level": "INFO",
-        "origin_investigation_id": "01KD15RP9481RT6HEMRBS4GYHC",
+        "origin_investigation_id": "01KD53481YR5XGKH5M1Q6SGS9Z",
         "observable_links": [
           {
             "observable_key": "obs:domain-name:domain.com",
@@ -1553,7 +1575,7 @@
         "extra": {},
         "score": 10.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RP962KCHESMBJN2C7KSF",
+        "origin_investigation_id": "01KD53481Z5QFPSY6RKYE3VPSZ",
         "observable_links": [
           {
             "observable_key": "obs:file:invoice.pdf",
@@ -1573,7 +1595,7 @@
         "extra": {},
         "score": 6.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RP97T6T9XVA34X4E7BGN",
+        "origin_investigation_id": "01KD5348212X7GEKNZ2329QFQ4",
         "observable_links": [],
         "key": "chk:email_risk_aggregated:full",
         "score_display": "6.00"
@@ -1586,7 +1608,7 @@
         "extra": {},
         "score": 0.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RP98BZW44YHMXCAHS5C8",
+        "origin_investigation_id": "01KD5348223P0S2H5GMED01CBT",
         "observable_links": [],
         "key": "chk:ai:full",
         "score_display": "0.00"
@@ -1885,10 +1907,6 @@
       "TRUSTED": 1
     },
     "total_containers": 5
-  },
-  "stats_checks": {
-    "checks": 11,
-    "applied": 11
   },
   "data_extraction": {
     "root_type": "artifact",

--- a/js/packages/cyvest-app/src/investigations/cyvest_visual.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_visual.json
@@ -1,15 +1,15 @@
 {
-  "investigation_id": "01KD15RPPKH3YHQNWSYNYYRYF7",
+  "investigation_id": "01KD5348EYT7K79W8NAKTQR7J0",
   "investigation_name": null,
-  "started_at": "2025-12-21T19:21:47.475055Z",
+  "started_at": "2025-12-23T07:52:38.110188Z",
   "score": 39.5,
   "level": "MALICIOUS",
   "whitelisted": false,
   "whitelists": [],
   "event_log": [
     {
-      "event_id": "01KD15RPPKRTAQV5BXCHEAW39Q",
-      "timestamp": "2025-12-21T19:21:47.475394Z",
+      "event_id": "01KD5348EYSFD1XT456TB76BH1",
+      "timestamp": "2025-12-23T07:52:38.110448Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -19,8 +19,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPKDKS4QAKJ550644CB",
-      "timestamp": "2025-12-21T19:21:47.475423Z",
+      "event_id": "01KD5348EYJV3B9ZRAXFS03AH1",
+      "timestamp": "2025-12-23T07:52:38.110477Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -30,8 +30,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPKB0629158TV7PWS0G",
-      "timestamp": "2025-12-21T19:21:47.475465Z",
+      "event_id": "01KD5348EY3HP9HGFP4VAASW8S",
+      "timestamp": "2025-12-23T07:52:38.110516Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from VirusTotal",
@@ -46,8 +46,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPKZ54ESS5EXDF8PP5T",
-      "timestamp": "2025-12-21T19:21:47.475481Z",
+      "event_id": "01KD5348EY6ZJKRAFDGFF3JCTF",
+      "timestamp": "2025-12-23T07:52:38.110533Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -56,12 +56,14 @@
       "object_key": "obs:domain-name:evil-phishing.com",
       "details": {
         "threat_intel_key": "ti:virustotal:obs:domain-name:evil-phishing.com",
-        "source": "VirusTotal"
+        "source": "VirusTotal",
+        "score": "9.0",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPKQNHSWMZREKZ362C4",
-      "timestamp": "2025-12-21T19:21:47.475505Z",
+      "event_id": "01KD5348EY0FP54F6FSZY48MMY",
+      "timestamp": "2025-12-23T07:52:38.110557Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -70,12 +72,14 @@
       "object_key": "obs:domain-name:evil-phishing.com",
       "details": {
         "threat_intel_key": "ti:alienvault otx:obs:domain-name:evil-phishing.com",
-        "source": "AlienVault OTX"
+        "source": "AlienVault OTX",
+        "score": "8.5",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPK10Z3ZWP7N4VWK3SD",
-      "timestamp": "2025-12-21T19:21:47.475523Z",
+      "event_id": "01KD5348EYXY1TC78NS5FE0V0G",
+      "timestamp": "2025-12-23T07:52:38.110577Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -85,8 +89,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPKT83PJNGAPW340CV9",
-      "timestamp": "2025-12-21T19:21:47.475544Z",
+      "event_id": "01KD5348EYFB1GJ9CPSWEC73P5",
+      "timestamp": "2025-12-23T07:52:38.110599Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from AbuseIPDB",
@@ -101,8 +105,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPKM25X59CZEX5V4NWV",
-      "timestamp": "2025-12-21T19:21:47.475555Z",
+      "event_id": "01KD5348EYD3V4FW7E0KHBBM7F",
+      "timestamp": "2025-12-23T07:52:38.110610Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -111,12 +115,14 @@
       "object_key": "obs:ipv4-addr:185.220.101.50",
       "details": {
         "threat_intel_key": "ti:abuseipdb:obs:ipv4-addr:185.220.101.50",
-        "source": "AbuseIPDB"
+        "source": "AbuseIPDB",
+        "score": "9.5",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPKK32ZVGG4A9EWYRMH",
-      "timestamp": "2025-12-21T19:21:47.475569Z",
+      "event_id": "01KD5348EYB1G76V28WE6615AP",
+      "timestamp": "2025-12-23T07:52:38.110626Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -130,8 +136,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPK09R20WC97M3S32G8",
-      "timestamp": "2025-12-21T19:21:47.475595Z",
+      "event_id": "01KD5348EYXY478KM4PPX7A4ZB",
+      "timestamp": "2025-12-23T07:52:38.110652Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -141,8 +147,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPKB3X12373VXB6GM7K",
-      "timestamp": "2025-12-21T19:21:47.475614Z",
+      "event_id": "01KD5348EYZMHM0F6JBEQWT5ZH",
+      "timestamp": "2025-12-23T07:52:38.110672Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from VirusTotal",
@@ -157,8 +163,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPK5BWCKTN425JTZBD8",
-      "timestamp": "2025-12-21T19:21:47.475625Z",
+      "event_id": "01KD5348EY8HS5ZNJK1P8WPSSS",
+      "timestamp": "2025-12-23T07:52:38.110682Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -167,12 +173,14 @@
       "object_key": "obs:domain-name:sketchy-site.net",
       "details": {
         "threat_intel_key": "ti:virustotal:obs:domain-name:sketchy-site.net",
-        "source": "VirusTotal"
+        "source": "VirusTotal",
+        "score": "4.5",
+        "level": "SUSPICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPKM7TS77QYE0B0WSE9",
-      "timestamp": "2025-12-21T19:21:47.475645Z",
+      "event_id": "01KD5348EYV2VQT0QVA8HWWRQD",
+      "timestamp": "2025-12-23T07:52:38.110700Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -182,8 +190,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPK3BQ9ENP42PXV0N1V",
-      "timestamp": "2025-12-21T19:21:47.475662Z",
+      "event_id": "01KD5348EY5DVMSZQQSJRYHYMF",
+      "timestamp": "2025-12-23T07:52:38.110718Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from Shodan",
@@ -198,8 +206,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPKFPTFN45FS0791BBC",
-      "timestamp": "2025-12-21T19:21:47.475671Z",
+      "event_id": "01KD5348EYFNPPAAPZQMKT3EBP",
+      "timestamp": "2025-12-23T07:52:38.110729Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -208,12 +216,14 @@
       "object_key": "obs:ipv4-addr:192.168.100.5",
       "details": {
         "threat_intel_key": "ti:shodan:obs:ipv4-addr:192.168.100.5",
-        "source": "Shodan"
+        "source": "Shodan",
+        "score": "3.0",
+        "level": "SUSPICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPKC1EQY30NAY3EJDQ7",
-      "timestamp": "2025-12-21T19:21:47.475680Z",
+      "event_id": "01KD5348EYHHC5NNRSPZTGZ7WV",
+      "timestamp": "2025-12-23T07:52:38.110739Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -227,8 +237,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPKDJHA62ZQ9YD7R14E",
-      "timestamp": "2025-12-21T19:21:47.475709Z",
+      "event_id": "01KD5348EYJYNTZMNGWCG0TWMJ",
+      "timestamp": "2025-12-23T07:52:38.110768Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -238,8 +248,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPKN5QEH0ZPW067WJZF",
-      "timestamp": "2025-12-21T19:21:47.475726Z",
+      "event_id": "01KD5348EY16S9RHT98QHQWJYS",
+      "timestamp": "2025-12-23T07:52:38.110784Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from EmailRep",
@@ -254,8 +264,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPKJH5CQGN7GVP6MM0R",
-      "timestamp": "2025-12-21T19:21:47.475734Z",
+      "event_id": "01KD5348EYZK1H7QX9XGTABMC0",
+      "timestamp": "2025-12-23T07:52:38.110793Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -264,12 +274,14 @@
       "object_key": "obs:email-addr:attacker@evil-phishing.com",
       "details": {
         "threat_intel_key": "ti:emailrep:obs:email-addr:attacker@evil-phishing.com",
-        "source": "EmailRep"
+        "source": "EmailRep",
+        "score": "8.0",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPKZ86PR7P5ZKWSQGXE",
-      "timestamp": "2025-12-21T19:21:47.475744Z",
+      "event_id": "01KD5348EYVDBT78S28FZWD7P6",
+      "timestamp": "2025-12-23T07:52:38.110804Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -283,8 +295,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPK6K4Q1H2YX54JFXJA",
-      "timestamp": "2025-12-21T19:21:47.475770Z",
+      "event_id": "01KD5348EYPPWHZ9BPEW4FCQSH",
+      "timestamp": "2025-12-23T07:52:38.110830Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -294,8 +306,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPKXP9K1HSMJWM5VPFZ",
-      "timestamp": "2025-12-21T19:21:47.475785Z",
+      "event_id": "01KD5348EYFF7YS2N292SG8R9B",
+      "timestamp": "2025-12-23T07:52:38.110845Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from Internal Whitelist",
@@ -310,8 +322,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPK8RK5BYHX4QPSV6KY",
-      "timestamp": "2025-12-21T19:21:47.475796Z",
+      "event_id": "01KD5348EYH12CRD11K826PQZ6",
+      "timestamp": "2025-12-23T07:52:38.110853Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -320,12 +332,14 @@
       "object_key": "obs:email-addr:victim@company.com",
       "details": {
         "threat_intel_key": "ti:internal whitelist:obs:email-addr:victim@company.com",
-        "source": "Internal Whitelist"
+        "source": "Internal Whitelist",
+        "score": "-1.0",
+        "level": "TRUSTED"
       }
     },
     {
-      "event_id": "01KD15RPPKX3V908SVPBA1XDK2",
-      "timestamp": "2025-12-21T19:21:47.475811Z",
+      "event_id": "01KD5348EYWCHW6MG3DEFSSTYW",
+      "timestamp": "2025-12-23T07:52:38.110869Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -335,8 +349,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPKN5QR0NF6VNE63457",
-      "timestamp": "2025-12-21T19:21:47.475821Z",
+      "event_id": "01KD5348EYHMPMABZBBDWF3QWC",
+      "timestamp": "2025-12-23T07:52:38.110877Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -350,8 +364,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPKJEYW8SNXZF8J52XA",
-      "timestamp": "2025-12-21T19:21:47.475856Z",
+      "event_id": "01KD5348EYXZSPP29RJ6CVVK83",
+      "timestamp": "2025-12-23T07:52:38.110909Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -365,8 +379,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPKMEHZQG4AYZ12EQ84",
-      "timestamp": "2025-12-21T19:21:47.475905Z",
+      "event_id": "01KD5348EY0ASE014DNGYTEHKZ",
+      "timestamp": "2025-12-23T07:52:38.110955Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -375,12 +389,14 @@
       "object_key": "obs:email-message:phishing email - invoice #12345",
       "details": {
         "threat_intel_key": "ti:email gateway:obs:email-message:phishing email - invoice #12345",
-        "source": "Email Gateway"
+        "source": "Email Gateway",
+        "score": "7.0",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPKBK672WF47A4NMQJQ",
-      "timestamp": "2025-12-21T19:21:47.475920Z",
+      "event_id": "01KD5348EYBNCJG3BANREX5BVN",
+      "timestamp": "2025-12-23T07:52:38.110972Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -390,8 +406,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPKWAERM3XJ89PR00AP",
-      "timestamp": "2025-12-21T19:21:47.475939Z",
+      "event_id": "01KD5348EYGHSV9SESRH1FW7ET",
+      "timestamp": "2025-12-23T07:52:38.110992Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from URLhaus",
@@ -406,8 +422,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPK2EMPMMR0SRJFMEWY",
-      "timestamp": "2025-12-21T19:21:47.475949Z",
+      "event_id": "01KD5348EYHRYDV0ZWCM9C0A8A",
+      "timestamp": "2025-12-23T07:52:38.111002Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -416,12 +432,14 @@
       "object_key": "obs:url:https://evil-phishing.com/login",
       "details": {
         "threat_intel_key": "ti:urlhaus:obs:url:https://evil-phishing.com/login",
-        "source": "URLhaus"
+        "source": "URLhaus",
+        "score": "9.0",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPKVGTW2M8QE3QTZFBQ",
-      "timestamp": "2025-12-21T19:21:47.475957Z",
+      "event_id": "01KD5348EZ422N40J8Y8YYBFWN",
+      "timestamp": "2025-12-23T07:52:38.111011Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -435,8 +453,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPK19ZA84VR4A9CEQZB",
-      "timestamp": "2025-12-21T19:21:47.475998Z",
+      "event_id": "01KD5348EZD4K3102EG42DBC1F",
+      "timestamp": "2025-12-23T07:52:38.111052Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -446,8 +464,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPMMVGYV6FFXXMS6YAN",
-      "timestamp": "2025-12-21T19:21:47.476018Z",
+      "event_id": "01KD5348EZJWZ878RNERH0PPJF",
+      "timestamp": "2025-12-23T07:52:38.111070Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from URLhaus",
@@ -462,8 +480,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMMCHJV93KJ33VKB3P",
-      "timestamp": "2025-12-21T19:21:47.476027Z",
+      "event_id": "01KD5348EZSJB8ZCNW4HHE8F2Z",
+      "timestamp": "2025-12-23T07:52:38.111079Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -472,12 +490,14 @@
       "object_key": "obs:url:https://evil-phishing.com/verify",
       "details": {
         "threat_intel_key": "ti:urlhaus:obs:url:https://evil-phishing.com/verify",
-        "source": "URLhaus"
+        "source": "URLhaus",
+        "score": "8.5",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPMJR5220R92ET00HJG",
-      "timestamp": "2025-12-21T19:21:47.476036Z",
+      "event_id": "01KD5348EZK3BCFN7MKP6NPGG2",
+      "timestamp": "2025-12-23T07:52:38.111089Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -491,8 +511,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMRZTW3FCH1W9Y18B4",
-      "timestamp": "2025-12-21T19:21:47.476085Z",
+      "event_id": "01KD5348EZ8HERMY5ECVY9DKKJ",
+      "timestamp": "2025-12-23T07:52:38.111137Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -506,8 +526,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMXFXE8P41TW8SSSMQ",
-      "timestamp": "2025-12-21T19:21:47.476141Z",
+      "event_id": "01KD5348EZHX263GGT90YA4AKG",
+      "timestamp": "2025-12-23T07:52:38.111191Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -521,8 +541,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM0B3T2HQX3MVM1VBM",
-      "timestamp": "2025-12-21T19:21:47.476197Z",
+      "event_id": "01KD5348EZXTH9938RAMA9KYB6",
+      "timestamp": "2025-12-23T07:52:38.111247Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -532,8 +552,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPMK0H7SP4TAZ7E6SZB",
-      "timestamp": "2025-12-21T19:21:47.476216Z",
+      "event_id": "01KD5348EZ959TSJ7Y859XS7WB",
+      "timestamp": "2025-12-23T07:52:38.111265Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from VirusTotal",
@@ -548,8 +568,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMET6M2WEEDAK53DGF",
-      "timestamp": "2025-12-21T19:21:47.476226Z",
+      "event_id": "01KD5348EZVVVE0T5SJ5GM6QQC",
+      "timestamp": "2025-12-23T07:52:38.111276Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -558,12 +578,14 @@
       "object_key": "obs:file:invoice.exe",
       "details": {
         "threat_intel_key": "ti:virustotal:obs:file:invoice.exe",
-        "source": "VirusTotal"
+        "source": "VirusTotal",
+        "score": "10.0",
+        "level": "MALICIOUS"
       }
     },
     {
-      "event_id": "01KD15RPPMD59TY19C1W7WAAYC",
-      "timestamp": "2025-12-21T19:21:47.476234Z",
+      "event_id": "01KD5348EZNJRR1JTS35MATGVF",
+      "timestamp": "2025-12-23T07:52:38.111287Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -577,8 +599,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMRAW2G2SAFRQMNP5Z",
-      "timestamp": "2025-12-21T19:21:47.476300Z",
+      "event_id": "01KD5348EZGJZS5215FM5QQFF1",
+      "timestamp": "2025-12-23T07:52:38.111352Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -592,8 +614,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM3YXZBBV8D61HGJET",
-      "timestamp": "2025-12-21T19:21:47.476368Z",
+      "event_id": "01KD5348EZBPC6A2VYVKXH9ETE",
+      "timestamp": "2025-12-23T07:52:38.111418Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -603,8 +625,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPMEPFZ61X1Y5PAQP7Q",
-      "timestamp": "2025-12-21T19:21:47.476386Z",
+      "event_id": "01KD5348EZQ5A35DPBZVPHH64N",
+      "timestamp": "2025-12-23T07:52:38.111435Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from Internal Whitelist",
@@ -619,8 +641,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMQ793R6YK807SKJ0D",
-      "timestamp": "2025-12-21T19:21:47.476396Z",
+      "event_id": "01KD5348EZSFV117RYCTTFFPWZ",
+      "timestamp": "2025-12-23T07:52:38.111445Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -629,12 +651,14 @@
       "object_key": "obs:domain-name:google.com",
       "details": {
         "threat_intel_key": "ti:internal whitelist:obs:domain-name:google.com",
-        "source": "Internal Whitelist"
+        "source": "Internal Whitelist",
+        "score": "-2.0",
+        "level": "TRUSTED"
       }
     },
     {
-      "event_id": "01KD15RPPMQWX97D6XJF4MFF7S",
-      "timestamp": "2025-12-21T19:21:47.476408Z",
+      "event_id": "01KD5348EZRFDP8PS9EZBCWYC7",
+      "timestamp": "2025-12-23T07:52:38.111458Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -644,8 +668,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPM8Q45GDVH8ZXXXEY1",
-      "timestamp": "2025-12-21T19:21:47.476423Z",
+      "event_id": "01KD5348EZFKN6CGATQ3E59Q6T",
+      "timestamp": "2025-12-23T07:52:38.111475Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from Passive DNS",
@@ -660,8 +684,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMSPKQEM275WR3JYV0",
-      "timestamp": "2025-12-21T19:21:47.476432Z",
+      "event_id": "01KD5348EZ9PM0PEFVYA3BWRAK",
+      "timestamp": "2025-12-23T07:52:38.111485Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -670,12 +694,14 @@
       "object_key": "obs:domain-name:new-service.cloud",
       "details": {
         "threat_intel_key": "ti:passive dns:obs:domain-name:new-service.cloud",
-        "source": "Passive DNS"
+        "source": "Passive DNS",
+        "score": "2.0",
+        "level": "NOTABLE"
       }
     },
     {
-      "event_id": "01KD15RPPM6NVC1A2T5QEQFFHW",
-      "timestamp": "2025-12-21T19:21:47.476449Z",
+      "event_id": "01KD5348EZQDKPSF6GPED8XCD6",
+      "timestamp": "2025-12-23T07:52:38.111503Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -685,8 +711,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPMJCCCF6QFRJRYBTX3",
-      "timestamp": "2025-12-21T19:21:47.476463Z",
+      "event_id": "01KD5348EZ8X740EM5W7B83Y0B",
+      "timestamp": "2025-12-23T07:52:38.111516Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -699,8 +725,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMZ7RH8CNR13TS654X",
-      "timestamp": "2025-12-21T19:21:47.476474Z",
+      "event_id": "01KD5348EZSM0BGJ8NHXD80DZ2",
+      "timestamp": "2025-12-23T07:52:38.111528Z",
       "event_type": "LEVEL_UPDATED",
       "actor": null,
       "reason": "Effective link added",
@@ -714,8 +740,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMPWNJYK1HMQ2BY9TX",
-      "timestamp": "2025-12-21T19:21:47.476555Z",
+      "event_id": "01KD5348EZX7TFGQ20ESQM9BBQ",
+      "timestamp": "2025-12-23T07:52:38.111607Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:email-message:phishing email - invoice #12345 updated",
@@ -730,8 +756,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMZN8ACWJTB32042WC",
-      "timestamp": "2025-12-21T19:21:47.476568Z",
+      "event_id": "01KD5348EZX5N2EY81QGB6Y2NM",
+      "timestamp": "2025-12-23T07:52:38.111622Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -744,8 +770,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMTJ6FNDKGTEQX1WSV",
-      "timestamp": "2025-12-21T19:21:47.476582Z",
+      "event_id": "01KD5348EZSEQJ16XXKEPHZQ8A",
+      "timestamp": "2025-12-23T07:52:38.111635Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -758,8 +784,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMRJNNWYEJ642897MH",
-      "timestamp": "2025-12-21T19:21:47.476596Z",
+      "event_id": "01KD5348EZMTJ0R9GK8JGE4TK0",
+      "timestamp": "2025-12-23T07:52:38.111649Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "",
@@ -774,8 +800,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM917EKPZ7Y1F919FZ",
-      "timestamp": "2025-12-21T19:21:47.476615Z",
+      "event_id": "01KD5348EZVQP5PYTA3XG0QZGT",
+      "timestamp": "2025-12-23T07:52:38.111668Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -785,8 +811,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPM7J3F7F5110W2N2G0",
-      "timestamp": "2025-12-21T19:21:47.476622Z",
+      "event_id": "01KD5348EZW967G8K6NSA3FFCG",
+      "timestamp": "2025-12-23T07:52:38.111675Z",
       "event_type": "CONTAINER_CHECK_ADDED",
       "actor": null,
       "reason": null,
@@ -798,8 +824,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMHPE5D6T9P4KZVGS7",
-      "timestamp": "2025-12-21T19:21:47.476634Z",
+      "event_id": "01KD5348EZ9ZB72HM0F94XGYBJ",
+      "timestamp": "2025-12-23T07:52:38.111687Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -809,8 +835,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPMRFWDKEFNY12BS72H",
-      "timestamp": "2025-12-21T19:21:47.476643Z",
+      "event_id": "01KD5348EZ7EQM5XYFVKT7KCEE",
+      "timestamp": "2025-12-23T07:52:38.111696Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -823,8 +849,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMZ5NQSEZG11P490YZ",
-      "timestamp": "2025-12-21T19:21:47.476651Z",
+      "event_id": "01KD5348EZQH90TJF2K1ZW1N38",
+      "timestamp": "2025-12-23T07:52:38.111704Z",
       "event_type": "LEVEL_UPDATED",
       "actor": null,
       "reason": "Effective link added",
@@ -838,8 +864,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM4P2V3C01WKG149XB",
-      "timestamp": "2025-12-21T19:21:47.476661Z",
+      "event_id": "01KD5348EZ9ASD2C7PXTP17XKS",
+      "timestamp": "2025-12-23T07:52:38.111715Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:url:https://evil-phishing.com/login updated",
@@ -854,8 +880,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMHQRJBXPHTJESGNQE",
-      "timestamp": "2025-12-21T19:21:47.476672Z",
+      "event_id": "01KD5348EZKKYJQVG187JZVT4R",
+      "timestamp": "2025-12-23T07:52:38.111726Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -868,8 +894,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMBQ826HHWPH4S9H12",
-      "timestamp": "2025-12-21T19:21:47.476685Z",
+      "event_id": "01KD5348EZE1NWXYVNZVQBM4ME",
+      "timestamp": "2025-12-23T07:52:38.111738Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "",
@@ -884,8 +910,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMCG294V47SVTPJ9WZ",
-      "timestamp": "2025-12-21T19:21:47.476695Z",
+      "event_id": "01KD5348EZ1MTW04H238KRQB1Q",
+      "timestamp": "2025-12-23T07:52:38.111748Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -895,8 +921,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPM0623P0KNYH627NRE",
-      "timestamp": "2025-12-21T19:21:47.476703Z",
+      "event_id": "01KD5348EZAFYHWH78VSD0NSBD",
+      "timestamp": "2025-12-23T07:52:38.111755Z",
       "event_type": "CONTAINER_CHECK_ADDED",
       "actor": null,
       "reason": null,
@@ -908,8 +934,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMBXXFW81FW8CBZ32E",
-      "timestamp": "2025-12-21T19:21:47.476714Z",
+      "event_id": "01KD5348EZK9MQ79PJ53BBTNJA",
+      "timestamp": "2025-12-23T07:52:38.111765Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -919,8 +945,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPMFEV4XE7QKQ9G9MB4",
-      "timestamp": "2025-12-21T19:21:47.476722Z",
+      "event_id": "01KD5348EZZBQ9AY0ZQX42PK89",
+      "timestamp": "2025-12-23T07:52:38.111774Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -933,8 +959,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMM3KS16AHMRPTZ2CF",
-      "timestamp": "2025-12-21T19:21:47.476730Z",
+      "event_id": "01KD5348EZ170FYP924F0Q9QZ0",
+      "timestamp": "2025-12-23T07:52:38.111782Z",
       "event_type": "LEVEL_UPDATED",
       "actor": null,
       "reason": "Effective link added",
@@ -948,8 +974,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMEMBE6TQJKK6K5KCG",
-      "timestamp": "2025-12-21T19:21:47.476740Z",
+      "event_id": "01KD5348EZDNW90WCD6AJPBAME",
+      "timestamp": "2025-12-23T07:52:38.111793Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:domain-name:evil-phishing.com updated",
@@ -964,8 +990,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM59MSQ3DAF70BE6BF",
-      "timestamp": "2025-12-21T19:21:47.476753Z",
+      "event_id": "01KD5348EZ69FXQGEJKZZR8X8Q",
+      "timestamp": "2025-12-23T07:52:38.111804Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -978,8 +1004,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM7PMER4MHKTV2QG69",
-      "timestamp": "2025-12-21T19:21:47.476764Z",
+      "event_id": "01KD5348EZS2R43VE98RVXBRH1",
+      "timestamp": "2025-12-23T07:52:38.111815Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:ipv4-addr:185.220.101.50 updated",
@@ -994,8 +1020,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM707XA9EFE3FTQ3B3",
-      "timestamp": "2025-12-21T19:21:47.476850Z",
+      "event_id": "01KD5348EZFBS46MRTYXHC6MQ0",
+      "timestamp": "2025-12-23T07:52:38.111901Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:email-addr:attacker@evil-phishing.com updated",
@@ -1010,8 +1036,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMG061FP31QW5XNP29",
-      "timestamp": "2025-12-21T19:21:47.476867Z",
+      "event_id": "01KD5348EZ1NETHMC7G33DAE7X",
+      "timestamp": "2025-12-23T07:52:38.111917Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:url:https://evil-phishing.com/login updated",
@@ -1026,8 +1052,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM9XCM0G6AQYZ2V2BY",
-      "timestamp": "2025-12-21T19:21:47.476879Z",
+      "event_id": "01KD5348EZCR2TBJNA4P2BRP9J",
+      "timestamp": "2025-12-23T07:52:38.111930Z",
       "event_type": "CONTAINER_CHECK_ADDED",
       "actor": null,
       "reason": null,
@@ -1039,8 +1065,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMNB71KW5SD1YADBMX",
-      "timestamp": "2025-12-21T19:21:47.476890Z",
+      "event_id": "01KD5348EZHR5JCDE8J264YWTA",
+      "timestamp": "2025-12-23T07:52:38.111940Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -1050,8 +1076,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPM88XAFJ2NQC1SCWG6",
-      "timestamp": "2025-12-21T19:21:47.476901Z",
+      "event_id": "01KD5348EZVA98VBFJ7X2G9HSC",
+      "timestamp": "2025-12-23T07:52:38.111951Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -1064,8 +1090,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMS9E191M67RWWRV0K",
-      "timestamp": "2025-12-21T19:21:47.476909Z",
+      "event_id": "01KD5348EZRDMVD9VBVB97YBDH",
+      "timestamp": "2025-12-23T07:52:38.111959Z",
       "event_type": "LEVEL_UPDATED",
       "actor": null,
       "reason": "Effective link added",
@@ -1079,8 +1105,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMZCJA5FZ7Q3HS05C3",
-      "timestamp": "2025-12-21T19:21:47.476919Z",
+      "event_id": "01KD5348EZCBGA7CN21EYW9DQY",
+      "timestamp": "2025-12-23T07:52:38.111970Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:file:invoice.exe updated",
@@ -1095,8 +1121,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMVZ8KJKR16A2MGTJ9",
-      "timestamp": "2025-12-21T19:21:47.476932Z",
+      "event_id": "01KD5348EZAGFXYA3G144KQPMS",
+      "timestamp": "2025-12-23T07:52:38.111982Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -1106,8 +1132,8 @@
       "details": {}
     },
     {
-      "event_id": "01KD15RPPMB4B072BQ09H85HQ1",
-      "timestamp": "2025-12-21T19:21:47.476938Z",
+      "event_id": "01KD5348EZDYV1RGCMZN4AYZEE",
+      "timestamp": "2025-12-23T07:52:38.111988Z",
       "event_type": "CONTAINER_CHECK_ADDED",
       "actor": null,
       "reason": null,
@@ -1119,8 +1145,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM852TMKSX904K2XBH",
-      "timestamp": "2025-12-21T19:21:47.476974Z",
+      "event_id": "01KD5348F0D4QPHY6KH2T4AG87",
+      "timestamp": "2025-12-23T07:52:38.112021Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": "Finalize relationships",
@@ -1134,8 +1160,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPMJZX5ZFPQGJGSV4H7",
-      "timestamp": "2025-12-21T19:21:47.476986Z",
+      "event_id": "01KD5348F0M02V8Q1KN260X69H",
+      "timestamp": "2025-12-23T07:52:38.112031Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": "Finalize relationships",
@@ -1149,8 +1175,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPM85QRVPFVF2RQB7NK",
-      "timestamp": "2025-12-21T19:21:47.476995Z",
+      "event_id": "01KD5348F00MBJWF69PVD3S5EB",
+      "timestamp": "2025-12-23T07:52:38.112040Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": "Finalize relationships",
@@ -1164,8 +1190,8 @@
       }
     },
     {
-      "event_id": "01KD15RPPN8PVNFNAM9VN9NWVV",
-      "timestamp": "2025-12-21T19:21:47.477003Z",
+      "event_id": "01KD5348F029TRJYZ35XVKT23Y",
+      "timestamp": "2025-12-23T07:52:38.112050Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": "Finalize relationships",
@@ -1510,7 +1536,7 @@
         "extra": {},
         "score": 10.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RPPKH3YHQNWSYNYYRYF7",
+        "origin_investigation_id": "01KD5348EYT7K79W8NAKTQR7J0",
         "observable_links": [
           {
             "observable_key": "obs:email-message:phishing email - invoice #12345",
@@ -1538,7 +1564,7 @@
         "extra": {},
         "score": 10.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RPPKH3YHQNWSYNYYRYF7",
+        "origin_investigation_id": "01KD5348EYT7K79W8NAKTQR7J0",
         "observable_links": [
           {
             "observable_key": "obs:url:https://evil-phishing.com/login",
@@ -1560,7 +1586,7 @@
         "extra": {},
         "score": 9.5,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RPPKH3YHQNWSYNYYRYF7",
+        "origin_investigation_id": "01KD5348EYT7K79W8NAKTQR7J0",
         "observable_links": [
           {
             "observable_key": "obs:domain-name:evil-phishing.com",
@@ -1584,7 +1610,7 @@
         "extra": {},
         "score": 10.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KD15RPPKH3YHQNWSYNYYRYF7",
+        "origin_investigation_id": "01KD5348EYT7K79W8NAKTQR7J0",
         "observable_links": [
           {
             "observable_key": "obs:file:invoice.exe",
@@ -1861,10 +1887,6 @@
       "NOTABLE": 1
     },
     "total_containers": 3
-  },
-  "stats_checks": {
-    "checks": 4,
-    "applied": 4
   },
   "data_extraction": {
     "root_type": "file",

--- a/js/packages/cyvest-js/src/getters.ts
+++ b/js/packages/cyvest-js/src/getters.ts
@@ -360,16 +360,6 @@ export function getStats(inv: CyvestInvestigation) {
 }
 
 /**
- * Get the investigation check statistics.
- *
- * @param inv - The investigation
- * @returns Check statistics object
- */
-export function getStatsChecks(inv: CyvestInvestigation) {
-  return inv.stats_checks;
-}
-
-/**
  * Get the data extraction configuration.
  *
  * @param inv - The investigation

--- a/js/packages/cyvest-js/src/types.generated.ts
+++ b/js/packages/cyvest-js/src/types.generated.ts
@@ -90,7 +90,6 @@ export interface CyvestInvestigation {
   enrichments: Enrichments;
   containers: Containers;
   stats: StatisticsSchema;
-  stats_checks: StatsChecksSchema;
   data_extraction: DataExtractionSchema;
   /**
    * Global investigation score formatted as fixed-point x.xx.
@@ -323,13 +322,6 @@ export interface ThreatIntelBySource {
 }
 export interface ThreatIntelByLevel {
   [k: string]: number;
-}
-/**
- * Schema for check statistics summary.
- */
-export interface StatsChecksSchema {
-  checks: number;
-  applied: number;
 }
 /**
  * Schema for data extraction metadata.

--- a/js/packages/cyvest-js/tests/getters-finders.test.ts
+++ b/js/packages/cyvest-js/tests/getters-finders.test.ts
@@ -239,10 +239,6 @@ function createTestInvestigation(): CyvestInvestigation {
       threat_intel_by_level: { MALICIOUS: 1 },
       total_containers: 2,
     },
-    stats_checks: {
-      checks: 3,
-      applied: 2,
-    },
     data_extraction: {
       root_type: "email-message",
       score_mode: "max",

--- a/js/packages/cyvest-js/tests/graph.test.ts
+++ b/js/packages/cyvest-js/tests/graph.test.ts
@@ -144,10 +144,6 @@ function createGraphTestInvestigation(): CyvestInvestigation {
       threat_intel_by_level: {},
       total_containers: 0,
     },
-    stats_checks: {
-      checks: 0,
-      applied: 0,
-    },
     data_extraction: {
       root_type: "email-message",
       score_mode: "max",

--- a/schema/cyvest.schema.json
+++ b/schema/cyvest.schema.json
@@ -588,28 +588,6 @@
       "title": "StatisticsSchema",
       "type": "object"
     },
-    "StatsChecksSchema": {
-      "additionalProperties": false,
-      "description": "Schema for check statistics summary.",
-      "properties": {
-        "checks": {
-          "minimum": 0,
-          "title": "Checks",
-          "type": "integer"
-        },
-        "applied": {
-          "minimum": 0,
-          "title": "Applied",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "checks",
-        "applied"
-      ],
-      "title": "StatsChecksSchema",
-      "type": "object"
-    },
     "ThreatIntel": {
       "description": "Represents threat intelligence from an external source.\n\nThreat intelligence provides verdicts about observables from sources\nlike VirusTotal, URLScan.io, etc.",
       "properties": {
@@ -787,10 +765,6 @@
       "$ref": "#/$defs/StatisticsSchema",
       "description": "Investigation statistics summary."
     },
-    "stats_checks": {
-      "$ref": "#/$defs/StatsChecksSchema",
-      "description": "Check statistics summary."
-    },
     "data_extraction": {
       "$ref": "#/$defs/DataExtractionSchema",
       "description": "Data extraction metadata."
@@ -816,7 +790,6 @@
     "enrichments",
     "containers",
     "stats",
-    "stats_checks",
     "data_extraction",
     "score_display"
   ],

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -6,3 +6,4 @@ pnpm -C js/packages/cyvest-js run generate:types
 uv run examples/04_email.py -o ./js/packages/cyvest-app/src/investigations/cyvest_email.json
 uv run examples/05_visualization.py -o ./js/packages/cyvest-app/src/investigations/cyvest_visual.json
 pnpm -C js run build
+pnpm -C js run test:ci

--- a/src/cyvest/io_serialization.py
+++ b/src/cyvest/io_serialization.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from cyvest.levels import Level
 from cyvest.model import AuditEvent, Check, Container, Enrichment, Observable, Relationship, ThreatIntel
-from cyvest.model_schema import InvestigationSchema, StatsChecksSchema
+from cyvest.model_schema import InvestigationSchema
 from cyvest.score import ScoreMode
 
 if TYPE_CHECKING:
@@ -84,10 +84,6 @@ def serialize_investigation(inv: Investigation) -> InvestigationSchema:
         enrichments=enrichments,
         containers=containers,
         stats=inv.get_statistics(),
-        stats_checks=StatsChecksSchema(
-            checks=len(inv.get_all_checks()),
-            applied=sum(1 for c in inv.get_all_checks().values() if c.level != Level.NONE),
-        ),
         data_extraction={
             "root_type": root_type_value,
             "score_mode": inv._score_engine._score_mode.value,

--- a/src/cyvest/model_schema.py
+++ b/src/cyvest/model_schema.py
@@ -58,15 +58,6 @@ class StatisticsSchema(BaseModel):
     total_containers: Annotated[int, Field(ge=0)]
 
 
-class StatsChecksSchema(BaseModel):
-    """Schema for check statistics summary."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    checks: Annotated[int, Field(ge=0)]
-    applied: Annotated[int, Field(ge=0)]
-
-
 class DataExtractionSchema(BaseModel):
     """Schema for data extraction metadata."""
 
@@ -148,7 +139,6 @@ class InvestigationSchema(BaseModel):
         description="Containers keyed by their unique key.",
     )
     stats: StatisticsSchema = Field(description="Investigation statistics summary.")
-    stats_checks: StatsChecksSchema = Field(description="Check statistics summary.")
     data_extraction: DataExtractionSchema = Field(description="Data extraction metadata.")
 
     @field_serializer("score")
@@ -179,21 +169,3 @@ class InvestigationSchema(BaseModel):
 
         return v
 
-
-# Export model references for schema generation
-__all__ = [
-    "InvestigationSchema",
-    "StatisticsSchema",
-    "StatsChecksSchema",
-    "DataExtractionSchema",
-    # Re-export from model.py for convenience
-    "AuditEvent",
-    "Observable",
-    "Check",
-    "ThreatIntel",
-    "Enrichment",
-    "Container",
-    "InvestigationWhitelist",
-    "Level",
-    "ScoreMode",
-]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -123,7 +123,6 @@ def test_investigation_schema_level_required_and_defaults() -> None:
                 "threat_intel_by_level": {},
                 "total_containers": 0,
             },
-            "stats_checks": {"checks": 0, "applied": 0},
             "data_extraction": {"root_type": None, "score_mode": "max"},
         }
     )

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ toml = [
 
 [[package]]
 name = "cyvest"
-version = "3.2.0"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- Removed the stats_checks property from the CyvestInvestigation interface and its corresponding StatsChecksSchema.
- Updated related functions and tests to reflect the removal of stats_checks.
- Adjusted the investigation serialization logic to exclude stats_checks.
- Updated the schema definition to remove references to stats_checks.
- Bumped version to 4.0.0 to reflect breaking changes.