### PR TITLE
refactor(stats): checks structure in CyvestInvestigation and related schemas

### DIFF
--- a/js/packages/cyvest-app/src/investigations/cyvest_email.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_email.json
@@ -1,15 +1,15 @@
 {
-  "investigation_id": "01KDJAVV1EACSENZG5XBHKQFHP",
+  "investigation_id": "01KE2AVKN6720K74SSHFPE4K5M",
   "investigation_name": "Email Investigation",
-  "started_at": "2025-12-28T11:17:58.446743Z",
+  "started_at": "2026-01-03T16:25:41.797994Z",
   "score": 36.1,
   "level": "MALICIOUS",
   "whitelisted": false,
   "whitelists": [],
   "event_log": [
     {
-      "event_id": "01KDJAVV1F46F87WEJSHGY5KC3",
-      "timestamp": "2025-12-28T11:17:58.447073Z",
+      "event_id": "01KE2AVKN76YQD1FH7V1Q3JCV9",
+      "timestamp": "2026-01-03T16:25:41.799095Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -19,8 +19,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1GR7BTQFB6SD9BNFDF",
-      "timestamp": "2025-12-28T11:17:58.448340Z",
+      "event_id": "01KE2AVKN944NQ3D8WRPVR3BFM",
+      "timestamp": "2026-01-03T16:25:41.801435Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Merged from obs:artifact:root",
@@ -35,8 +35,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1G4PFWDZHSSDK1W4W0",
-      "timestamp": "2025-12-28T11:17:58.448389Z",
+      "event_id": "01KE2AVKN98P6P5XBGJB197ZPG",
+      "timestamp": "2026-01-03T16:25:41.801486Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -46,8 +46,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1G7T05AXFAKFGXRJT7",
-      "timestamp": "2025-12-28T11:17:58.448398Z",
+      "event_id": "01KE2AVKN92PVC6EC1QWEG34C2",
+      "timestamp": "2026-01-03T16:25:41.801496Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -57,8 +57,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1G8C12620D45E79PD1",
-      "timestamp": "2025-12-28T11:17:58.448405Z",
+      "event_id": "01KE2AVKN9C9RWY3HE2F7QBCB8",
+      "timestamp": "2026-01-03T16:25:41.801504Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -68,8 +68,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1G8WP16CEA6E9T8XNK",
-      "timestamp": "2025-12-28T11:17:58.448419Z",
+      "event_id": "01KE2AVKN9HP6KE4Q9AEA3YEYA",
+      "timestamp": "2026-01-03T16:25:41.801521Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -84,8 +84,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1GNZ0G9EB2C6SHPQBK",
-      "timestamp": "2025-12-28T11:17:58.448439Z",
+      "event_id": "01KE2AVKN9863VS6FKCT9Q6HZ9",
+      "timestamp": "2026-01-03T16:25:41.801535Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -100,8 +100,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1G6E0H0QBETNCVETZJ",
-      "timestamp": "2025-12-28T11:17:58.448454Z",
+      "event_id": "01KE2AVKN9C3JMWN5YZW3WY8N2",
+      "timestamp": "2026-01-03T16:25:41.801550Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -116,8 +116,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1GJTZRP7EGYPP5RXPH",
-      "timestamp": "2025-12-28T11:17:58.448469Z",
+      "event_id": "01KE2AVKN9FC423HZ6NANY5FNA",
+      "timestamp": "2026-01-03T16:25:41.801568Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -127,8 +127,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1GXMG8G7YK0HMWEWER",
-      "timestamp": "2025-12-28T11:17:58.448476Z",
+      "event_id": "01KE2AVKN9QAXX5FN28JAPDXS5",
+      "timestamp": "2026-01-03T16:25:41.801575Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -138,17 +138,17 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1GQ9D3T8M57NYSQV0C",
-      "timestamp": "2025-12-28T11:17:58.448506Z",
+      "event_id": "01KE2AVKN9E6FVQ6K2KX3ZD1FJ",
+      "timestamp": "2026-01-03T16:25:41.801606Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KDJAVV1EACSENZG5XBHKQFHP",
+      "object_key": "01KE2AVKN6720K74SSHFPE4K5M",
       "details": {
-        "from_investigation_id": "01KDJAVV1F9050JMMRZ1Y4ZTQV",
-        "into_investigation_id": "01KDJAVV1EACSENZG5XBHKQFHP",
+        "from_investigation_id": "01KE2AVKN8NXMJ32EA2QKHHZNP",
+        "into_investigation_id": "01KE2AVKN6720K74SSHFPE4K5M",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -212,8 +212,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1H2385W1AECK6Y78SM",
-      "timestamp": "2025-12-28T11:17:58.449118Z",
+      "event_id": "01KE2AVKNA7YKE5J8KKYG9BCNN",
+      "timestamp": "2026-01-03T16:25:41.802659Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Merged from obs:email:noreply@dmalicious.com",
@@ -228,8 +228,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1H5BAT3VF7NKWGQW90",
-      "timestamp": "2025-12-28T11:17:58.449163Z",
+      "event_id": "01KE2AVKNAG500BTY1RWFEJKQZ",
+      "timestamp": "2026-01-03T16:25:41.802713Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -244,8 +244,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1HGYKSJ3HWX8AXX4XD",
-      "timestamp": "2025-12-28T11:17:58.449176Z",
+      "event_id": "01KE2AVKNARXCTM71T2W1SY5GW",
+      "timestamp": "2026-01-03T16:25:41.802729Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -255,17 +255,17 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1HPWWACY1R6PRQAEE7",
-      "timestamp": "2025-12-28T11:17:58.449224Z",
+      "event_id": "01KE2AVKNACC2W0ESWJSPBAKMK",
+      "timestamp": "2026-01-03T16:25:41.802781Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KDJAVV1EACSENZG5XBHKQFHP",
+      "object_key": "01KE2AVKN6720K74SSHFPE4K5M",
       "details": {
-        "from_investigation_id": "01KDJAVV1G9JGYY6EM8W54Y7GJ",
-        "into_investigation_id": "01KDJAVV1EACSENZG5XBHKQFHP",
+        "from_investigation_id": "01KE2AVKN9PCG52YT95Z460VBG",
+        "into_investigation_id": "01KE2AVKN6720K74SSHFPE4K5M",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -311,8 +311,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1HPN1QVHAFT9YXP4QK",
-      "timestamp": "2025-12-28T11:17:58.449769Z",
+      "event_id": "01KE2AVKNBHG1SS8TG209BXX1V",
+      "timestamp": "2026-01-03T16:25:41.803506Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -322,8 +322,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1H091QGJ3ZPYJW54Q0",
-      "timestamp": "2025-12-28T11:17:58.449780Z",
+      "event_id": "01KE2AVKNBE2R7DB47DTY4EQ4M",
+      "timestamp": "2026-01-03T16:25:41.803520Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -333,8 +333,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1HPNYH248ATHH8884K",
-      "timestamp": "2025-12-28T11:17:58.449787Z",
+      "event_id": "01KE2AVKNBGMTMWNWB8E7K6RCK",
+      "timestamp": "2026-01-03T16:25:41.803745Z",
       "event_type": "ENRICHMENT_CREATED",
       "actor": null,
       "reason": null,
@@ -344,17 +344,17 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1H2S4KJD0SN83X89ZJ",
-      "timestamp": "2025-12-28T11:17:58.449846Z",
+      "event_id": "01KE2AVKNBR4WWA0J1DHPCH4CV",
+      "timestamp": "2026-01-03T16:25:41.803813Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KDJAVV1EACSENZG5XBHKQFHP",
+      "object_key": "01KE2AVKN6720K74SSHFPE4K5M",
       "details": {
-        "from_investigation_id": "01KDJAVV1HGKD5BH23PTAZFZS9",
-        "into_investigation_id": "01KDJAVV1EACSENZG5XBHKQFHP",
+        "from_investigation_id": "01KE2AVKNAVS0AFGHJ9QRVFR8S",
+        "into_investigation_id": "01KE2AVKN6720K74SSHFPE4K5M",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -396,8 +396,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1MJYXSVRX6T1JPPX1A",
-      "timestamp": "2025-12-28T11:17:58.452570Z",
+      "event_id": "01KE2AVKND2V8DGSNXDTXYTA6J",
+      "timestamp": "2026-01-03T16:25:41.805967Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -407,8 +407,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1MW5VTKJ31E5E4J2XF",
-      "timestamp": "2025-12-28T11:17:58.452590Z",
+      "event_id": "01KE2AVKNDFXWD5K0GZ70BT1HZ",
+      "timestamp": "2026-01-03T16:25:41.805977Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -418,8 +418,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1MXP76R4J42BRZ4QQS",
-      "timestamp": "2025-12-28T11:17:58.452599Z",
+      "event_id": "01KE2AVKND5XNB7346CVKA0NB1",
+      "timestamp": "2026-01-03T16:25:41.805983Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -429,8 +429,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1MS9G68MY9MF0P8Y8P",
-      "timestamp": "2025-12-28T11:17:58.452606Z",
+      "event_id": "01KE2AVKNDD2DMA7DVQ94BGZP0",
+      "timestamp": "2026-01-03T16:25:41.805991Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -440,8 +440,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1MC3ABAYZN6MDMKC29",
-      "timestamp": "2025-12-28T11:17:58.452612Z",
+      "event_id": "01KE2AVKNDTR5ZENYKQ1SQJQDJ",
+      "timestamp": "2026-01-03T16:25:41.806000Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -451,8 +451,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1MRNC249G4Q89V1TA1",
-      "timestamp": "2025-12-28T11:17:58.452633Z",
+      "event_id": "01KE2AVKNECD81T6P6WZFNWD86",
+      "timestamp": "2026-01-03T16:25:41.806013Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -467,8 +467,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1M3KTG7XCSSG038ZQZ",
-      "timestamp": "2025-12-28T11:17:58.452652Z",
+      "event_id": "01KE2AVKNEEKZ4SRF6QM0GQ6PD",
+      "timestamp": "2026-01-03T16:25:41.806028Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -483,8 +483,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1M2H0981GQZ0S2FGKJ",
-      "timestamp": "2025-12-28T11:17:58.452665Z",
+      "event_id": "01KE2AVKNET2KTD4PND58N25PJ",
+      "timestamp": "2026-01-03T16:25:41.806042Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -499,8 +499,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1MTCYQJ2VHS2VGDZVY",
-      "timestamp": "2025-12-28T11:17:58.452675Z",
+      "event_id": "01KE2AVKNEJ1F5YSJJDF65PCWM",
+      "timestamp": "2026-01-03T16:25:41.806053Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -510,8 +510,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1M1S9MZEZFFPN1VMX9",
-      "timestamp": "2025-12-28T11:17:58.452682Z",
+      "event_id": "01KE2AVKNEYRZR3J5HNM5VADFY",
+      "timestamp": "2026-01-03T16:25:41.806060Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -521,8 +521,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1MQH1Z7G31P63J885H",
-      "timestamp": "2025-12-28T11:17:58.452751Z",
+      "event_id": "01KE2AVKNEW79AVZ99BQ4YEYAN",
+      "timestamp": "2026-01-03T16:25:41.806066Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -532,8 +532,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1MD974HEQ8V2KJ0V2A",
-      "timestamp": "2025-12-28T11:17:58.452758Z",
+      "event_id": "01KE2AVKNEAZ7N2ASZM6727CR8",
+      "timestamp": "2026-01-03T16:25:41.806073Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -543,17 +543,17 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1MX75A4B4W9BEYKKFD",
-      "timestamp": "2025-12-28T11:17:58.452821Z",
+      "event_id": "01KE2AVKNECWBKVDKRVZW0R6RQ",
+      "timestamp": "2026-01-03T16:25:41.806137Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KDJAVV1EACSENZG5XBHKQFHP",
+      "object_key": "01KE2AVKN6720K74SSHFPE4K5M",
       "details": {
-        "from_investigation_id": "01KDJAVV1JV98R5NG3CA5MZ4EC",
-        "into_investigation_id": "01KDJAVV1EACSENZG5XBHKQFHP",
+        "from_investigation_id": "01KE2AVKNCE0N8TWTX5GND8N56",
+        "into_investigation_id": "01KE2AVKN6720K74SSHFPE4K5M",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -641,8 +641,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1PVF989QJ6Q1KSH9AF",
-      "timestamp": "2025-12-28T11:17:58.454148Z",
+      "event_id": "01KE2AVKNG4MH2MG7GPWB2D4YE",
+      "timestamp": "2026-01-03T16:25:41.808491Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -652,8 +652,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1PYMZ4ETAJEBZXG5D0",
-      "timestamp": "2025-12-28T11:17:58.454248Z",
+      "event_id": "01KE2AVKNGE19PE6RP4R90ASES",
+      "timestamp": "2026-01-03T16:25:41.808592Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -668,8 +668,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1PQP6YPTBQJ8KNVCTQ",
-      "timestamp": "2025-12-28T11:17:58.454266Z",
+      "event_id": "01KE2AVKNG5DG5NC6G2DJQQNGY",
+      "timestamp": "2026-01-03T16:25:41.808611Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -684,8 +684,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1PFTAVZREA744BR91K",
-      "timestamp": "2025-12-28T11:17:58.454277Z",
+      "event_id": "01KE2AVKNGP03TM1DMYMBZTHWY",
+      "timestamp": "2026-01-03T16:25:41.808624Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -695,8 +695,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1PDVQTWZJSHK4DSA49",
-      "timestamp": "2025-12-28T11:17:58.454285Z",
+      "event_id": "01KE2AVKNGRZ8NNW4Z4N6XC9PY",
+      "timestamp": "2026-01-03T16:25:41.808634Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -706,8 +706,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1PYS979GTRJT5MNTVH",
-      "timestamp": "2025-12-28T11:17:58.454293Z",
+      "event_id": "01KE2AVKNGT3GDANR5CW7K5EZ1",
+      "timestamp": "2026-01-03T16:25:41.808643Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -717,8 +717,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1PGDDDA048PWNHJZFT",
-      "timestamp": "2025-12-28T11:17:58.454396Z",
+      "event_id": "01KE2AVKNGNHCP8E96E8H7AJRK",
+      "timestamp": "2026-01-03T16:25:41.808751Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:domain:virus.com updated",
@@ -733,17 +733,17 @@
       }
     },
     {
-      "event_id": "01KDJAVV1PTHHA8FKFCM3NP7KV",
-      "timestamp": "2025-12-28T11:17:58.454410Z",
+      "event_id": "01KE2AVKNG9VVD5RVG39PMGGFK",
+      "timestamp": "2026-01-03T16:25:41.808766Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KDJAVV1EACSENZG5XBHKQFHP",
+      "object_key": "01KE2AVKN6720K74SSHFPE4K5M",
       "details": {
-        "from_investigation_id": "01KDJAVV1N7PHXT7MMAYAGCWX3",
-        "into_investigation_id": "01KDJAVV1EACSENZG5XBHKQFHP",
+        "from_investigation_id": "01KE2AVKNEEA17AP034V7DMDY7",
+        "into_investigation_id": "01KE2AVKN6720K74SSHFPE4K5M",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -812,8 +812,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1QG6B3AZQW92H264S7",
-      "timestamp": "2025-12-28T11:17:58.455211Z",
+      "event_id": "01KE2AVKNJCP8JYDMCR0NWJVQD",
+      "timestamp": "2026-01-03T16:25:41.810375Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Merged from obs:artifact:root",
@@ -828,8 +828,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1QDMZG87MDG33SB7HG",
-      "timestamp": "2025-12-28T11:17:58.455333Z",
+      "event_id": "01KE2AVKNJ5RMYCNQXBK26JAPR",
+      "timestamp": "2026-01-03T16:25:41.810523Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -839,8 +839,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1Q503356Z7NXWD9XQH",
-      "timestamp": "2025-12-28T11:17:58.455341Z",
+      "event_id": "01KE2AVKNJFZGFE7ZR50FPMQEM",
+      "timestamp": "2026-01-03T16:25:41.810530Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -850,8 +850,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1Q0PM65QTKPHSH1QZW",
-      "timestamp": "2025-12-28T11:17:58.455352Z",
+      "event_id": "01KE2AVKNJAE2MA8J7MSXWW64A",
+      "timestamp": "2026-01-03T16:25:41.810544Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -866,8 +866,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1QD2Z8H3FA52FM1GE8",
-      "timestamp": "2025-12-28T11:17:58.455366Z",
+      "event_id": "01KE2AVKNJX92HPGFJW1S08ECP",
+      "timestamp": "2026-01-03T16:25:41.810560Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -882,8 +882,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1QV2BRWB1K7Q30WG07",
-      "timestamp": "2025-12-28T11:17:58.455377Z",
+      "event_id": "01KE2AVKNJ0C04ZFS59BGPTWK2",
+      "timestamp": "2026-01-03T16:25:41.810571Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -893,8 +893,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1QTQSFT5614704Q0XJ",
-      "timestamp": "2025-12-28T11:17:58.455383Z",
+      "event_id": "01KE2AVKNJ7823W91ZVN2H9166",
+      "timestamp": "2026-01-03T16:25:41.810578Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -904,17 +904,17 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1QDPNMRXK631SBQ49M",
-      "timestamp": "2025-12-28T11:17:58.455507Z",
+      "event_id": "01KE2AVKNJC1VG0CXHB53YV21K",
+      "timestamp": "2026-01-03T16:25:41.810709Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KDJAVV1EACSENZG5XBHKQFHP",
+      "object_key": "01KE2AVKN6720K74SSHFPE4K5M",
       "details": {
-        "from_investigation_id": "01KDJAVV1PVF8KSDH913WBC9XK",
-        "into_investigation_id": "01KDJAVV1EACSENZG5XBHKQFHP",
+        "from_investigation_id": "01KE2AVKNHMKSQ44E24PJQ2NCJ",
+        "into_investigation_id": "01KE2AVKN6720K74SSHFPE4K5M",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -966,8 +966,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1S546WS2D4ETAWDJAP",
-      "timestamp": "2025-12-28T11:17:58.457718Z",
+      "event_id": "01KE2AVKNMBGRV0F2KZG5N3QF1",
+      "timestamp": "2026-01-03T16:25:41.812577Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -977,8 +977,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1S83P6M278XF161WVN",
-      "timestamp": "2025-12-28T11:17:58.457726Z",
+      "event_id": "01KE2AVKNMPAYGAV6G63BT81GX",
+      "timestamp": "2026-01-03T16:25:41.812585Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -988,17 +988,17 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1SYPETA985JWXCXXWM",
-      "timestamp": "2025-12-28T11:17:58.457855Z",
+      "event_id": "01KE2AVKNMDJSRP95A8CHD3S13",
+      "timestamp": "2026-01-03T16:25:41.812710Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KDJAVV1EACSENZG5XBHKQFHP",
+      "object_key": "01KE2AVKN6720K74SSHFPE4K5M",
       "details": {
-        "from_investigation_id": "01KDJAVV1QMWFF2WZHE18DGE9B",
-        "into_investigation_id": "01KDJAVV1EACSENZG5XBHKQFHP",
+        "from_investigation_id": "01KE2AVKNKC1SDFQR73MVD9AKZ",
+        "into_investigation_id": "01KE2AVKN6720K74SSHFPE4K5M",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -1026,8 +1026,8 @@
       }
     },
     {
-      "event_id": "01KDJAVV1T6KK572HVSHGMB09P",
-      "timestamp": "2025-12-28T11:17:58.458540Z",
+      "event_id": "01KE2AVKNNMN0K5ZX7CX6E4MQ2",
+      "timestamp": "2026-01-03T16:25:41.813416Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -1037,17 +1037,17 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVV1T550DDKSE44H9N93D",
-      "timestamp": "2025-12-28T11:17:58.458676Z",
+      "event_id": "01KE2AVKNNPVRV6S8BP9B3ZPS5",
+      "timestamp": "2026-01-03T16:25:41.813543Z",
       "event_type": "INVESTIGATION_MERGED",
       "actor": null,
       "reason": null,
       "tool": null,
       "object_type": "investigation",
-      "object_key": "01KDJAVV1EACSENZG5XBHKQFHP",
+      "object_key": "01KE2AVKN6720K74SSHFPE4K5M",
       "details": {
-        "from_investigation_id": "01KDJAVV1TN32BTNT7TJMRT7H2",
-        "into_investigation_id": "01KDJAVV1EACSENZG5XBHKQFHP",
+        "from_investigation_id": "01KE2AVKNN2W8DPJQSND55A57X",
+        "into_investigation_id": "01KE2AVKN6720K74SSHFPE4K5M",
         "from_investigation_name": null,
         "into_investigation_name": "Email Investigation",
         "object_changes": [
@@ -1427,7 +1427,7 @@
         "extra": {},
         "score": 2.0,
         "level": "NOTABLE",
-        "origin_investigation_id": "01KDJAVV1F9050JMMRZ1Y4ZTQV",
+        "origin_investigation_id": "01KE2AVKN8NXMJ32EA2QKHHZNP",
         "observable_links": [
           {
             "observable_key": "obs:email:noreply@dmalicious.com",
@@ -1445,7 +1445,7 @@
         "extra": {},
         "score": 5.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVV1G9JGYY6EM8W54Y7GJ",
+        "origin_investigation_id": "01KE2AVKN9PCG52YT95Z460VBG",
         "observable_links": [
           {
             "observable_key": "obs:email:noreply@dmalicious.com",
@@ -1463,7 +1463,7 @@
         "extra": {},
         "score": 0.1,
         "level": "NOTABLE",
-        "origin_investigation_id": "01KDJAVV1HGKD5BH23PTAZFZS9",
+        "origin_investigation_id": "01KE2AVKNAVS0AFGHJ9QRVFR8S",
         "observable_links": [
           {
             "observable_key": "obs:email:user@company.com",
@@ -1483,7 +1483,7 @@
         "extra": {},
         "score": 5.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVV1JV98R5NG3CA5MZ4EC",
+        "origin_investigation_id": "01KE2AVKNCE0N8TWTX5GND8N56",
         "observable_links": [
           {
             "observable_key": "obs:url:https://virus.com/payload.exe",
@@ -1501,7 +1501,7 @@
         "extra": {},
         "score": 3.0,
         "level": "SUSPICIOUS",
-        "origin_investigation_id": "01KDJAVV1JV98R5NG3CA5MZ4EC",
+        "origin_investigation_id": "01KE2AVKNCE0N8TWTX5GND8N56",
         "observable_links": [
           {
             "observable_key": "obs:url:https://virus.com/about",
@@ -1519,7 +1519,7 @@
         "extra": {},
         "score": 0.0,
         "level": "INFO",
-        "origin_investigation_id": "01KDJAVV1JV98R5NG3CA5MZ4EC",
+        "origin_investigation_id": "01KE2AVKNCE0N8TWTX5GND8N56",
         "observable_links": [
           {
             "observable_key": "obs:url:https://domain.com/ok/toto",
@@ -1537,7 +1537,7 @@
         "extra": {},
         "score": 5.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVV1N7PHXT7MMAYAGCWX3",
+        "origin_investigation_id": "01KE2AVKNEEA17AP034V7DMDY7",
         "observable_links": [
           {
             "observable_key": "obs:domain:virus.com",
@@ -1555,7 +1555,7 @@
         "extra": {},
         "score": 0.0,
         "level": "INFO",
-        "origin_investigation_id": "01KDJAVV1N7PHXT7MMAYAGCWX3",
+        "origin_investigation_id": "01KE2AVKNEEA17AP034V7DMDY7",
         "observable_links": [
           {
             "observable_key": "obs:domain:domain.com",
@@ -1575,7 +1575,7 @@
         "extra": {},
         "score": 10.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVV1PVF8KSDH913WBC9XK",
+        "origin_investigation_id": "01KE2AVKNHMKSQ44E24PJQ2NCJ",
         "observable_links": [
           {
             "observable_key": "obs:file:invoice.pdf",
@@ -1595,7 +1595,7 @@
         "extra": {},
         "score": 6.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVV1QMWFF2WZHE18DGE9B",
+        "origin_investigation_id": "01KE2AVKNKC1SDFQR73MVD9AKZ",
         "observable_links": [],
         "key": "chk:email_risk_aggregated:full",
         "score_display": "6.00"
@@ -1608,32 +1608,11 @@
         "extra": {},
         "score": 0.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVV1TN32BTNT7TJMRT7H2",
+        "origin_investigation_id": "01KE2AVKNN2W8DPJQSND55A57X",
         "observable_links": [],
         "key": "chk:ai:full",
         "score_display": "0.00"
       }
-    ]
-  },
-  "checks_by_level": {
-    "NOTABLE": [
-      "chk:from:header",
-      "chk:receiver:header"
-    ],
-    "MALICIOUS": [
-      "chk:from-proofpoint:header",
-      "chk:body-url-https://virus.com/payload.exe:body",
-      "chk:body-domain-virus.com:body",
-      "chk:attachment-invoice.pdf:attachment",
-      "chk:email_risk_aggregated:full",
-      "chk:ai:full"
-    ],
-    "SUSPICIOUS": [
-      "chk:body-url-https://virus.com/about:body"
-    ],
-    "INFO": [
-      "chk:body-url-https://domain.com/ok/toto:body",
-      "chk:body-domain-domain.com:body"
     ]
   },
   "threat_intels": {
@@ -1885,16 +1864,46 @@
     "total_checks": 11,
     "applied_checks": 11,
     "checks_by_scope": {
-      "header": 3,
-      "body": 5,
-      "attachment": 1,
-      "full": 2
+      "header": [
+        "chk:from:header",
+        "chk:from-proofpoint:header",
+        "chk:receiver:header"
+      ],
+      "body": [
+        "chk:body-url-https://virus.com/payload.exe:body",
+        "chk:body-url-https://virus.com/about:body",
+        "chk:body-url-https://domain.com/ok/toto:body",
+        "chk:body-domain-virus.com:body",
+        "chk:body-domain-domain.com:body"
+      ],
+      "attachment": [
+        "chk:attachment-invoice.pdf:attachment"
+      ],
+      "full": [
+        "chk:email_risk_aggregated:full",
+        "chk:ai:full"
+      ]
     },
     "checks_by_level": {
-      "NOTABLE": 2,
-      "MALICIOUS": 6,
-      "SUSPICIOUS": 1,
-      "INFO": 2
+      "NOTABLE": [
+        "chk:from:header",
+        "chk:receiver:header"
+      ],
+      "MALICIOUS": [
+        "chk:from-proofpoint:header",
+        "chk:body-url-https://virus.com/payload.exe:body",
+        "chk:body-domain-virus.com:body",
+        "chk:attachment-invoice.pdf:attachment",
+        "chk:email_risk_aggregated:full",
+        "chk:ai:full"
+      ],
+      "SUSPICIOUS": [
+        "chk:body-url-https://virus.com/about:body"
+      ],
+      "INFO": [
+        "chk:body-url-https://domain.com/ok/toto:body",
+        "chk:body-domain-domain.com:body"
+      ]
     },
     "total_threat_intel": 11,
     "threat_intel_by_source": {

--- a/js/packages/cyvest-app/src/investigations/cyvest_visual.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_visual.json
@@ -1,15 +1,15 @@
 {
-  "investigation_id": "01KDJAVVEC3W61ZKAXFK3TJ6T2",
+  "investigation_id": "01KE2AVM40Y026E103737CZ2G4",
   "investigation_name": null,
-  "started_at": "2025-12-28T11:17:58.859969Z",
+  "started_at": "2026-01-03T16:25:42.271866Z",
   "score": 39.5,
   "level": "MALICIOUS",
   "whitelisted": false,
   "whitelists": [],
   "event_log": [
     {
-      "event_id": "01KDJAVVEC2RYJ7FQ1HDRF24VQ",
-      "timestamp": "2025-12-28T11:17:58.860262Z",
+      "event_id": "01KE2AVM405H95RXY4YN31GH87",
+      "timestamp": "2026-01-03T16:25:42.272367Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -19,8 +19,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVECPF50HZCN0PHNNFFJ",
-      "timestamp": "2025-12-28T11:17:58.860292Z",
+      "event_id": "01KE2AVM40TJQ3E6D4HDVJYHZB",
+      "timestamp": "2026-01-03T16:25:42.272429Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -30,8 +30,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVECHT1YD9AGATNBJ4YJ",
-      "timestamp": "2025-12-28T11:17:58.860333Z",
+      "event_id": "01KE2AVM408K87XNYKF2S634Y0",
+      "timestamp": "2026-01-03T16:25:42.272508Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from VirusTotal",
@@ -46,8 +46,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECVMAZNK373KBCHE8K",
-      "timestamp": "2025-12-28T11:17:58.860350Z",
+      "event_id": "01KE2AVM40NHA8R646MFZCEBR9",
+      "timestamp": "2026-01-03T16:25:42.272540Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -62,8 +62,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEC98CNFZEAA081T9K7",
-      "timestamp": "2025-12-28T11:17:58.860373Z",
+      "event_id": "01KE2AVM40M72SGEWZQK2QCQYF",
+      "timestamp": "2026-01-03T16:25:42.272567Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -78,8 +78,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECZTJ3STFCP7B9AP82",
-      "timestamp": "2025-12-28T11:17:58.860393Z",
+      "event_id": "01KE2AVM40GCQBRH6V7DBJJ89B",
+      "timestamp": "2026-01-03T16:25:42.272682Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -89,8 +89,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVECWN21EM4DXN17N6YG",
-      "timestamp": "2025-12-28T11:17:58.860417Z",
+      "event_id": "01KE2AVM40K3QY710G4EY6PNCR",
+      "timestamp": "2026-01-03T16:25:42.272708Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from AbuseIPDB",
@@ -105,8 +105,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECANYXRA5P8H0BYHDR",
-      "timestamp": "2025-12-28T11:17:58.860429Z",
+      "event_id": "01KE2AVM40WHWKKXDFR6PN1RA6",
+      "timestamp": "2026-01-03T16:25:42.272721Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -121,8 +121,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEC876PYWGJKVY5Q7CZ",
-      "timestamp": "2025-12-28T11:17:58.860445Z",
+      "event_id": "01KE2AVM409HTJK7D207XAC8B3",
+      "timestamp": "2026-01-03T16:25:42.272749Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -136,8 +136,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEC9FV26QFJ26YKFEJN",
-      "timestamp": "2025-12-28T11:17:58.860470Z",
+      "event_id": "01KE2AVM40TB3H5VFEDXWZJVPS",
+      "timestamp": "2026-01-03T16:25:42.272780Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -147,8 +147,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVECY8YQ8C7GVRQVQ8JV",
-      "timestamp": "2025-12-28T11:17:58.860492Z",
+      "event_id": "01KE2AVM40WAZ2B99539783710",
+      "timestamp": "2026-01-03T16:25:42.272805Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from VirusTotal",
@@ -163,8 +163,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECNM58654P6C00M1G3",
-      "timestamp": "2025-12-28T11:17:58.860504Z",
+      "event_id": "01KE2AVM40FDFF6R30B7XRYE5E",
+      "timestamp": "2026-01-03T16:25:42.272817Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -179,8 +179,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECTR3A4G785N5DXBKX",
-      "timestamp": "2025-12-28T11:17:58.860519Z",
+      "event_id": "01KE2AVM400R630JK814Q2SBDC",
+      "timestamp": "2026-01-03T16:25:42.272834Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -190,8 +190,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVECDHRKKFVB891PFYZB",
-      "timestamp": "2025-12-28T11:17:58.860536Z",
+      "event_id": "01KE2AVM40Q0EKHS0NYPWEN13P",
+      "timestamp": "2026-01-03T16:25:42.272853Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from Shodan",
@@ -206,8 +206,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECXWYMNHRY0080MWVM",
-      "timestamp": "2025-12-28T11:17:58.860545Z",
+      "event_id": "01KE2AVM40QDA93KPJCT89TAYF",
+      "timestamp": "2026-01-03T16:25:42.272862Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -222,8 +222,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECY3T4M19DTTS5T03R",
-      "timestamp": "2025-12-28T11:17:58.860556Z",
+      "event_id": "01KE2AVM40JW6QQHFSC8WM46P9",
+      "timestamp": "2026-01-03T16:25:42.272874Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -237,8 +237,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECH4RBNG8GYFVH6VKG",
-      "timestamp": "2025-12-28T11:17:58.860584Z",
+      "event_id": "01KE2AVM40AK2Q7C3D8YK8VK0Y",
+      "timestamp": "2026-01-03T16:25:42.272905Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -248,8 +248,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVECKFR9H7QXXJSK4WYH",
-      "timestamp": "2025-12-28T11:17:58.860606Z",
+      "event_id": "01KE2AVM400J7641X2J94VT0MS",
+      "timestamp": "2026-01-03T16:25:42.272923Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from EmailRep",
@@ -264,8 +264,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEC5PN9WVMJGQSC8PSQ",
-      "timestamp": "2025-12-28T11:17:58.860615Z",
+      "event_id": "01KE2AVM4018DT31PTMM7JQVRS",
+      "timestamp": "2026-01-03T16:25:42.272933Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -280,8 +280,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEC8G8QDW9EHA76MNQM",
-      "timestamp": "2025-12-28T11:17:58.860626Z",
+      "event_id": "01KE2AVM40CDZGH80VDD1ER34W",
+      "timestamp": "2026-01-03T16:25:42.272944Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -295,8 +295,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECSP7PKR8EZCEY1HCM",
-      "timestamp": "2025-12-28T11:17:58.860655Z",
+      "event_id": "01KE2AVM409XMBR12BHES1K08P",
+      "timestamp": "2026-01-03T16:25:42.272973Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -306,8 +306,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVECJT6QAYKP1A4N6T0S",
-      "timestamp": "2025-12-28T11:17:58.860672Z",
+      "event_id": "01KE2AVM40SRRHZ8VZB4FJBP7C",
+      "timestamp": "2026-01-03T16:25:42.272990Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from Internal Whitelist",
@@ -322,8 +322,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECP6K6H5DDTKHD2SF4",
-      "timestamp": "2025-12-28T11:17:58.860683Z",
+      "event_id": "01KE2AVM40141PG8GVX291B0XB",
+      "timestamp": "2026-01-03T16:25:42.272999Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -338,8 +338,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECQBSC6DEQWFAQVAKK",
-      "timestamp": "2025-12-28T11:17:58.860700Z",
+      "event_id": "01KE2AVM417P9QHP5QG5ZA7BQG",
+      "timestamp": "2026-01-03T16:25:42.273021Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -349,8 +349,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVECQCKBHH52CP621R5X",
-      "timestamp": "2025-12-28T11:17:58.860711Z",
+      "event_id": "01KE2AVM41VRMYPTDC939KY64N",
+      "timestamp": "2026-01-03T16:25:42.273031Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -364,8 +364,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECG18G87Z818CDWHAN",
-      "timestamp": "2025-12-28T11:17:58.860744Z",
+      "event_id": "01KE2AVM41BPNT8X971N030J3Q",
+      "timestamp": "2026-01-03T16:25:42.273074Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -379,8 +379,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECQW3D224SJQEFWC4C",
-      "timestamp": "2025-12-28T11:17:58.860794Z",
+      "event_id": "01KE2AVM41QTTW10MZR2V5P77E",
+      "timestamp": "2026-01-03T16:25:42.273126Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -395,8 +395,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECR0XDEYXG4FTDHPV5",
-      "timestamp": "2025-12-28T11:17:58.860813Z",
+      "event_id": "01KE2AVM41BTRQF1JYYNSYW8P6",
+      "timestamp": "2026-01-03T16:25:42.273150Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -406,8 +406,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVECX3P12HKDRN1F62R2",
-      "timestamp": "2025-12-28T11:17:58.860834Z",
+      "event_id": "01KE2AVM41PTTS06R5BZ47KNFV",
+      "timestamp": "2026-01-03T16:25:42.273171Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from URLhaus",
@@ -422,8 +422,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECVBTWWJ7NP88ZD405",
-      "timestamp": "2025-12-28T11:17:58.860844Z",
+      "event_id": "01KE2AVM41RRJM1KD0QNR0PHK8",
+      "timestamp": "2026-01-03T16:25:42.273181Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -438,8 +438,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEC35PYJ2FE1CEV643X",
-      "timestamp": "2025-12-28T11:17:58.860856Z",
+      "event_id": "01KE2AVM41XRBR8NR24X4BKDHA",
+      "timestamp": "2026-01-03T16:25:42.273192Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -453,8 +453,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECXA5W58F5VB527ZVE",
-      "timestamp": "2025-12-28T11:17:58.860898Z",
+      "event_id": "01KE2AVM41JC6WE1S4QXC5TMGF",
+      "timestamp": "2026-01-03T16:25:42.273244Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -464,8 +464,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVEC35477YJN1HR7MJ7C",
-      "timestamp": "2025-12-28T11:17:58.860915Z",
+      "event_id": "01KE2AVM41WB5NBYRMXNT1HYMN",
+      "timestamp": "2026-01-03T16:25:42.273285Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from URLhaus",
@@ -480,8 +480,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECXX2T882ENXAX4FZZ",
-      "timestamp": "2025-12-28T11:17:58.860925Z",
+      "event_id": "01KE2AVM418F6TCE40DSX9VNE8",
+      "timestamp": "2026-01-03T16:25:42.273304Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -496,8 +496,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECKD62GMYAFZPFY9JM",
-      "timestamp": "2025-12-28T11:17:58.860935Z",
+      "event_id": "01KE2AVM41BRYPK3TTBXGWTSEM",
+      "timestamp": "2026-01-03T16:25:42.273320Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -511,8 +511,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVECHBGYP720STMBSTM9",
-      "timestamp": "2025-12-28T11:17:58.860983Z",
+      "event_id": "01KE2AVM41HSY3F90WVPNV6TWN",
+      "timestamp": "2026-01-03T16:25:42.273377Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -526,8 +526,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDJEN8AM5PA1YZXCC1",
-      "timestamp": "2025-12-28T11:17:58.861034Z",
+      "event_id": "01KE2AVM416NT8TT13VTSARP6Z",
+      "timestamp": "2026-01-03T16:25:42.273432Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -541,8 +541,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDSC625HHRT7CNC5A7",
-      "timestamp": "2025-12-28T11:17:58.861090Z",
+      "event_id": "01KE2AVM419HA3D5PA1YG163QZ",
+      "timestamp": "2026-01-03T16:25:42.273496Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -552,8 +552,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVEDR053JC0CSRVZM8SQ",
-      "timestamp": "2025-12-28T11:17:58.861107Z",
+      "event_id": "01KE2AVM412T520TWEK3HJ57QT",
+      "timestamp": "2026-01-03T16:25:42.273519Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from VirusTotal",
@@ -568,8 +568,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED1V0JKHTZNDRKX3KA",
-      "timestamp": "2025-12-28T11:17:58.861117Z",
+      "event_id": "01KE2AVM41NSHYG9TQ0T5XC22R",
+      "timestamp": "2026-01-03T16:25:42.273531Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -584,8 +584,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED9QYF5B94BPW2YTBT",
-      "timestamp": "2025-12-28T11:17:58.861127Z",
+      "event_id": "01KE2AVM41RCXW1643H0PWYC0W",
+      "timestamp": "2026-01-03T16:25:42.273543Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -599,8 +599,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDVEGBEGWC1JEN5JQ5",
-      "timestamp": "2025-12-28T11:17:58.861194Z",
+      "event_id": "01KE2AVM41Q633JKXRRAG5W3ZY",
+      "timestamp": "2026-01-03T16:25:42.273615Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": null,
@@ -614,8 +614,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDSV2524HCSKDG47YQ",
-      "timestamp": "2025-12-28T11:17:58.861262Z",
+      "event_id": "01KE2AVM41FDCCTXKC992D6KMX",
+      "timestamp": "2026-01-03T16:25:42.273685Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -625,8 +625,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVED52SFZ5YPKXW4VSJ2",
-      "timestamp": "2025-12-28T11:17:58.861279Z",
+      "event_id": "01KE2AVM41Y9EKVGBE0NBVR77V",
+      "timestamp": "2026-01-03T16:25:42.273704Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from Internal Whitelist",
@@ -641,8 +641,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDBX8RNPKFJZAWRCA9",
-      "timestamp": "2025-12-28T11:17:58.861289Z",
+      "event_id": "01KE2AVM419ES9S9A560427MZM",
+      "timestamp": "2026-01-03T16:25:42.273714Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -657,8 +657,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED6M5BMGBDCN7THWJY",
-      "timestamp": "2025-12-28T11:17:58.861302Z",
+      "event_id": "01KE2AVM4122ZJBSXBNAX0VTJQ",
+      "timestamp": "2026-01-03T16:25:42.273729Z",
       "event_type": "OBSERVABLE_CREATED",
       "actor": null,
       "reason": null,
@@ -668,8 +668,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVEDX4Y2CRJ0Z0C6HD4M",
-      "timestamp": "2025-12-28T11:17:58.861318Z",
+      "event_id": "01KE2AVM41DCQQ54CCZ8NH7K71",
+      "timestamp": "2026-01-03T16:25:42.273746Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Threat intel update from Passive DNS",
@@ -684,8 +684,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED133FK6QGF85MB4QX",
-      "timestamp": "2025-12-28T11:17:58.861328Z",
+      "event_id": "01KE2AVM41DD3HDK5FWFY520AH",
+      "timestamp": "2026-01-03T16:25:42.273756Z",
       "event_type": "THREAT_INTEL_ATTACHED",
       "actor": null,
       "reason": null,
@@ -700,8 +700,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED65Y2T5X1Z0V94FXJ",
-      "timestamp": "2025-12-28T11:17:58.861351Z",
+      "event_id": "01KE2AVM41JX8ZG8DQC1MK3F1Y",
+      "timestamp": "2026-01-03T16:25:42.273787Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -711,8 +711,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVEDHDRC69FFEK80G7E5",
-      "timestamp": "2025-12-28T11:17:58.861364Z",
+      "event_id": "01KE2AVM41T3MB0FQ1862P255W",
+      "timestamp": "2026-01-03T16:25:42.273808Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -725,8 +725,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDH2H38A0M7BZRSBZ1",
-      "timestamp": "2025-12-28T11:17:58.861441Z",
+      "event_id": "01KE2AVM415JQHS8RTJZVC4XFD",
+      "timestamp": "2026-01-03T16:25:42.273824Z",
       "event_type": "LEVEL_UPDATED",
       "actor": null,
       "reason": "Effective link added",
@@ -740,8 +740,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED25VK8X58EZS1XG0X",
-      "timestamp": "2025-12-28T11:17:58.861458Z",
+      "event_id": "01KE2AVM41EXFT77PSKYCJ2ZZN",
+      "timestamp": "2026-01-03T16:25:42.273842Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:artifact:phishing email - invoice #12345 updated",
@@ -756,8 +756,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED1GXFTDAXT1GQB96G",
-      "timestamp": "2025-12-28T11:17:58.861472Z",
+      "event_id": "01KE2AVM41K3Y1DTWFDFZ37W80",
+      "timestamp": "2026-01-03T16:25:42.273857Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -770,8 +770,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDAQJ788YQV0F1NZ3E",
-      "timestamp": "2025-12-28T11:17:58.861486Z",
+      "event_id": "01KE2AVM417YWV159CTP19K4H3",
+      "timestamp": "2026-01-03T16:25:42.273871Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -784,8 +784,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDY43R0QYMDE3P54SB",
-      "timestamp": "2025-12-28T11:17:58.861500Z",
+      "event_id": "01KE2AVM41S6B5WV2XZ4BG7VKS",
+      "timestamp": "2026-01-03T16:25:42.273888Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "",
@@ -800,8 +800,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDV0A2TZ4NA7AQHEWY",
-      "timestamp": "2025-12-28T11:17:58.861520Z",
+      "event_id": "01KE2AVM41Z2KVPZZEF001K3KQ",
+      "timestamp": "2026-01-03T16:25:42.273920Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -811,8 +811,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVEDH70NT0GGCD5MWGE0",
-      "timestamp": "2025-12-28T11:17:58.861527Z",
+      "event_id": "01KE2AVM418P3FJ8GJNZ73DE5S",
+      "timestamp": "2026-01-03T16:25:42.273930Z",
       "event_type": "CONTAINER_CHECK_ADDED",
       "actor": null,
       "reason": null,
@@ -824,8 +824,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED0ZWS0F0Z32DM84VE",
-      "timestamp": "2025-12-28T11:17:58.861540Z",
+      "event_id": "01KE2AVM418QFWV0CGTKXMD7ZQ",
+      "timestamp": "2026-01-03T16:25:42.273945Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -835,8 +835,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVEDZ863KCSPMBVYYP65",
-      "timestamp": "2025-12-28T11:17:58.861553Z",
+      "event_id": "01KE2AVM41V2RK87RY7CD3HPM1",
+      "timestamp": "2026-01-03T16:25:42.273954Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -849,8 +849,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDWRJNXFN6ZQKY9ECD",
-      "timestamp": "2025-12-28T11:17:58.861562Z",
+      "event_id": "01KE2AVM41XD99XNKVVA7S1716",
+      "timestamp": "2026-01-03T16:25:42.273963Z",
       "event_type": "LEVEL_UPDATED",
       "actor": null,
       "reason": "Effective link added",
@@ -864,8 +864,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDE3ZQ60YRFRCDRFDJ",
-      "timestamp": "2025-12-28T11:17:58.861573Z",
+      "event_id": "01KE2AVM41N7FT7Y0DFV3X3V1N",
+      "timestamp": "2026-01-03T16:25:42.273973Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:url:https://evil-phishing.com/login updated",
@@ -880,8 +880,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED19VWS73JVE0WMFF8",
-      "timestamp": "2025-12-28T11:17:58.861584Z",
+      "event_id": "01KE2AVM41DGEPK66VD7Q9D55K",
+      "timestamp": "2026-01-03T16:25:42.273985Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -894,8 +894,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED4700RGBR8GKE9W1Z",
-      "timestamp": "2025-12-28T11:17:58.861597Z",
+      "event_id": "01KE2AVM411ZCXW0SWEDJ4RNF5",
+      "timestamp": "2026-01-03T16:25:42.274000Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "",
@@ -910,8 +910,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDE9N85S7YN3XY9FRF",
-      "timestamp": "2025-12-28T11:17:58.861607Z",
+      "event_id": "01KE2AVM42XAQ15BGWEE28CWHX",
+      "timestamp": "2026-01-03T16:25:42.274011Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -921,8 +921,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVEDMS24CCGXDVHPFXT0",
-      "timestamp": "2025-12-28T11:17:58.861614Z",
+      "event_id": "01KE2AVM425P18YHBSCAPTATA1",
+      "timestamp": "2026-01-03T16:25:42.274018Z",
       "event_type": "CONTAINER_CHECK_ADDED",
       "actor": null,
       "reason": null,
@@ -934,8 +934,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDSNZ917FPER6J5JFM",
-      "timestamp": "2025-12-28T11:17:58.861624Z",
+      "event_id": "01KE2AVM42R6X28RSRE190VQ19",
+      "timestamp": "2026-01-03T16:25:42.274032Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -945,8 +945,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVED0XQXJZFSC84HR0ZE",
-      "timestamp": "2025-12-28T11:17:58.861633Z",
+      "event_id": "01KE2AVM42EBYTB7ENC8JBXSTE",
+      "timestamp": "2026-01-03T16:25:42.274041Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -959,8 +959,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED9JDZ8S987JJ6HZ1A",
-      "timestamp": "2025-12-28T11:17:58.861641Z",
+      "event_id": "01KE2AVM424XAKYYNCDKDS4R35",
+      "timestamp": "2026-01-03T16:25:42.274049Z",
       "event_type": "LEVEL_UPDATED",
       "actor": null,
       "reason": "Effective link added",
@@ -974,8 +974,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDH09RZYSXVMY19FC3",
-      "timestamp": "2025-12-28T11:17:58.861650Z",
+      "event_id": "01KE2AVM424TSCQQECW7NV9MZ2",
+      "timestamp": "2026-01-03T16:25:42.274059Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:domain:evil-phishing.com updated",
@@ -990,8 +990,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED9ATNX8KJYFXS85VA",
-      "timestamp": "2025-12-28T11:17:58.861661Z",
+      "event_id": "01KE2AVM42PAM1B4XT8DMVSV35",
+      "timestamp": "2026-01-03T16:25:42.274070Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -1004,8 +1004,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDA9Z2CG16XJC0FZZM",
-      "timestamp": "2025-12-28T11:17:58.861671Z",
+      "event_id": "01KE2AVM42A07BWEEQ89PSN78M",
+      "timestamp": "2026-01-03T16:25:42.274081Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:ipv4:185.220.101.50 updated",
@@ -1020,8 +1020,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED0WNZ2ZRDX02DDHK1",
-      "timestamp": "2025-12-28T11:17:58.861757Z",
+      "event_id": "01KE2AVM425CZCS9AM5ZJ5NAC0",
+      "timestamp": "2026-01-03T16:25:42.274171Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:email:attacker@evil-phishing.com updated",
@@ -1036,8 +1036,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED8040W1DHETG1ETZM",
-      "timestamp": "2025-12-28T11:17:58.861774Z",
+      "event_id": "01KE2AVM42DABD40BE5T27TYH0",
+      "timestamp": "2026-01-03T16:25:42.274188Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:url:https://evil-phishing.com/login updated",
@@ -1052,8 +1052,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED0H99GPX0GX7573X8",
-      "timestamp": "2025-12-28T11:17:58.861786Z",
+      "event_id": "01KE2AVM42RWWPKEYRZVHA28TF",
+      "timestamp": "2026-01-03T16:25:42.274201Z",
       "event_type": "CONTAINER_CHECK_ADDED",
       "actor": null,
       "reason": null,
@@ -1065,8 +1065,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED258E91DDFGRVDTDK",
-      "timestamp": "2025-12-28T11:17:58.861798Z",
+      "event_id": "01KE2AVM4204PH1RJE91XW3651",
+      "timestamp": "2026-01-03T16:25:42.274214Z",
       "event_type": "CHECK_CREATED",
       "actor": null,
       "reason": null,
@@ -1076,8 +1076,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVEDR8J3ZC136WNZYASV",
-      "timestamp": "2025-12-28T11:17:58.861809Z",
+      "event_id": "01KE2AVM42WD24P8NDK0YRMMVH",
+      "timestamp": "2026-01-03T16:25:42.274225Z",
       "event_type": "CHECK_LINKED_TO_OBSERVABLE",
       "actor": null,
       "reason": null,
@@ -1090,8 +1090,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDVJKT67SD1PQMQ9MA",
-      "timestamp": "2025-12-28T11:17:58.861817Z",
+      "event_id": "01KE2AVM42770RNHAV0QRTCG10",
+      "timestamp": "2026-01-03T16:25:42.274235Z",
       "event_type": "LEVEL_UPDATED",
       "actor": null,
       "reason": "Effective link added",
@@ -1105,8 +1105,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDQYNT77X3A9BASAKG",
-      "timestamp": "2025-12-28T11:17:58.861832Z",
+      "event_id": "01KE2AVM426XYN0Q2XH8BFX05F",
+      "timestamp": "2026-01-03T16:25:42.274248Z",
       "event_type": "SCORE_CHANGED",
       "actor": null,
       "reason": "Linked observable obs:file:invoice.exe updated",
@@ -1121,8 +1121,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDXJAV5109VZ686HB1",
-      "timestamp": "2025-12-28T11:17:58.861845Z",
+      "event_id": "01KE2AVM42FFWC4Y3RQSZ5PTX1",
+      "timestamp": "2026-01-03T16:25:42.274261Z",
       "event_type": "CONTAINER_CREATED",
       "actor": null,
       "reason": null,
@@ -1132,8 +1132,8 @@
       "details": {}
     },
     {
-      "event_id": "01KDJAVVEDPV3WF0M1PWFGJ411",
-      "timestamp": "2025-12-28T11:17:58.861851Z",
+      "event_id": "01KE2AVM42YEFZ6NCEEEHZFG7H",
+      "timestamp": "2026-01-03T16:25:42.274268Z",
       "event_type": "CONTAINER_CHECK_ADDED",
       "actor": null,
       "reason": null,
@@ -1145,8 +1145,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVED4T0KZ1RD2B9FPZNC",
-      "timestamp": "2025-12-28T11:17:58.861882Z",
+      "event_id": "01KE2AVM42B2EJFGYWCGEE2HTG",
+      "timestamp": "2026-01-03T16:25:42.274306Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": "Finalize relationships",
@@ -1160,8 +1160,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDX5K6MT6GD0ZZ13X5",
-      "timestamp": "2025-12-28T11:17:58.861892Z",
+      "event_id": "01KE2AVM4292RZ9ZYY3015ZJAD",
+      "timestamp": "2026-01-03T16:25:42.274319Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": "Finalize relationships",
@@ -1175,8 +1175,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDCS5FKXX3E5GB0HCG",
-      "timestamp": "2025-12-28T11:17:58.861902Z",
+      "event_id": "01KE2AVM422DYZDN3RT9N02VFD",
+      "timestamp": "2026-01-03T16:25:42.274329Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": "Finalize relationships",
@@ -1190,8 +1190,8 @@
       }
     },
     {
-      "event_id": "01KDJAVVEDM4VJTV84NR1MJ6TY",
-      "timestamp": "2025-12-28T11:17:58.861912Z",
+      "event_id": "01KE2AVM42FNXN2YCBPR3R2WFT",
+      "timestamp": "2026-01-03T16:25:42.274338Z",
       "event_type": "RELATIONSHIP_CREATED",
       "actor": null,
       "reason": "Finalize relationships",
@@ -1536,7 +1536,7 @@
         "extra": {},
         "score": 10.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVVEC3W61ZKAXFK3TJ6T2",
+        "origin_investigation_id": "01KE2AVM40Y026E103737CZ2G4",
         "observable_links": [
           {
             "observable_key": "obs:artifact:phishing email - invoice #12345",
@@ -1564,7 +1564,7 @@
         "extra": {},
         "score": 10.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVVEC3W61ZKAXFK3TJ6T2",
+        "origin_investigation_id": "01KE2AVM40Y026E103737CZ2G4",
         "observable_links": [
           {
             "observable_key": "obs:url:https://evil-phishing.com/login",
@@ -1586,7 +1586,7 @@
         "extra": {},
         "score": 9.5,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVVEC3W61ZKAXFK3TJ6T2",
+        "origin_investigation_id": "01KE2AVM40Y026E103737CZ2G4",
         "observable_links": [
           {
             "observable_key": "obs:domain:evil-phishing.com",
@@ -1610,7 +1610,7 @@
         "extra": {},
         "score": 10.0,
         "level": "MALICIOUS",
-        "origin_investigation_id": "01KDJAVVEC3W61ZKAXFK3TJ6T2",
+        "origin_investigation_id": "01KE2AVM40Y026E103737CZ2G4",
         "observable_links": [
           {
             "observable_key": "obs:file:invoice.exe",
@@ -1620,14 +1620,6 @@
         "key": "chk:malware_detection:file",
         "score_display": "10.00"
       }
-    ]
-  },
-  "checks_by_level": {
-    "MALICIOUS": [
-      "chk:email_analysis:email",
-      "chk:url_analysis:network",
-      "chk:infrastructure:network",
-      "chk:malware_detection:file"
     ]
   },
   "threat_intels": {
@@ -1861,12 +1853,24 @@
     "total_checks": 4,
     "applied_checks": 4,
     "checks_by_scope": {
-      "email": 1,
-      "network": 2,
-      "file": 1
+      "email": [
+        "chk:email_analysis:email"
+      ],
+      "network": [
+        "chk:url_analysis:network",
+        "chk:infrastructure:network"
+      ],
+      "file": [
+        "chk:malware_detection:file"
+      ]
     },
     "checks_by_level": {
-      "MALICIOUS": 4
+      "MALICIOUS": [
+        "chk:email_analysis:email",
+        "chk:url_analysis:network",
+        "chk:infrastructure:network",
+        "chk:malware_detection:file"
+      ]
     },
     "total_threat_intel": 13,
     "threat_intel_by_source": {

--- a/js/packages/cyvest-js/src/types.generated.ts
+++ b/js/packages/cyvest-js/src/types.generated.ts
@@ -83,7 +83,6 @@ export interface CyvestInvestigation {
   event_log?: EventLog;
   observables: Observables;
   checks: Checks;
-  checks_by_level: ChecksByLevel;
   threat_intels: ThreatIntels1;
   enrichments: Enrichments;
   containers: Containers;
@@ -198,12 +197,6 @@ export interface ObservableLink {
   propagation_mode?: PropagationMode;
 }
 /**
- * Check keys organized by level name.
- */
-export interface ChecksByLevel {
-  [k: string]: string[];
-}
-/**
  * Threat intelligence entries keyed by their unique key.
  */
 export interface ThreatIntels1 {
@@ -300,7 +293,7 @@ export interface StatisticsSchema {
   total_checks: number;
   applied_checks: number;
   checks_by_scope?: ChecksByScope;
-  checks_by_level?: ChecksByLevel1;
+  checks_by_level?: ChecksByLevel;
   total_threat_intel: number;
   threat_intel_by_source?: ThreatIntelBySource;
   threat_intel_by_level?: ThreatIntelByLevel;
@@ -318,10 +311,10 @@ export interface ObservablesByTypeAndLevel {
   };
 }
 export interface ChecksByScope {
-  [k: string]: number;
+  [k: string]: string[];
 }
-export interface ChecksByLevel1 {
-  [k: string]: number;
+export interface ChecksByLevel {
+  [k: string]: string[];
 }
 export interface ThreatIntelBySource {
   [k: string]: number;

--- a/js/packages/cyvest-js/tests/getters-finders.test.ts
+++ b/js/packages/cyvest-js/tests/getters-finders.test.ts
@@ -176,10 +176,6 @@ function createTestInvestigation(): CyvestInvestigation {
         },
       ],
     },
-    checks_by_level: {
-      INFO: ["chk:ip_check:network", "chk:dns_lookup:dns"],
-      MALICIOUS: ["chk:domain_check:dns"],
-    },
     threat_intels: {
       "ti:virustotal:obs:domain-name:example.com": {
         key: "ti:virustotal:obs:domain-name:example.com",
@@ -232,8 +228,8 @@ function createTestInvestigation(): CyvestInvestigation {
       observables_by_type_and_level: {},
       total_checks: 3,
       applied_checks: 2,
-      checks_by_scope: { network: 1, dns: 2 },
-      checks_by_level: { INFO: 2, MALICIOUS: 1 },
+      checks_by_scope: { network: ["chk:ip_check:network"], dns: ["chk:domain_check:dns", "chk:dns_lookup:dns"] },
+      checks_by_level: { INFO: ["chk:ip_check:network", "chk:dns_lookup:dns"], MALICIOUS: ["chk:domain_check:dns"] },
       total_threat_intel: 1,
       threat_intel_by_source: { virustotal: 1 },
       threat_intel_by_level: { MALICIOUS: 1 },

--- a/js/packages/cyvest-js/tests/graph.test.ts
+++ b/js/packages/cyvest-js/tests/graph.test.ts
@@ -123,7 +123,6 @@ function createGraphTestInvestigation(): CyvestInvestigation {
       },
     },
     checks: {},
-    checks_by_level: {},
     threat_intels: {},
     enrichments: {},
     containers: {},

--- a/schema/cyvest.schema.json
+++ b/schema/cyvest.schema.json
@@ -538,16 +538,20 @@
         },
         "checks_by_scope": {
           "additionalProperties": {
-            "minimum": 0,
-            "type": "integer"
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "title": "Checks By Scope",
           "type": "object"
         },
         "checks_by_level": {
           "additionalProperties": {
-            "minimum": 0,
-            "type": "integer"
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "title": "Checks By Level",
           "type": "object"
@@ -753,17 +757,6 @@
       "title": "Checks",
       "type": "object"
     },
-    "checks_by_level": {
-      "additionalProperties": {
-        "items": {
-          "type": "string"
-        },
-        "type": "array"
-      },
-      "description": "Check keys organized by level name.",
-      "title": "Checks By Level",
-      "type": "object"
-    },
     "threat_intels": {
       "additionalProperties": {
         "$ref": "#/$defs/ThreatIntel"
@@ -812,7 +805,6 @@
     "whitelists",
     "observables",
     "checks",
-    "checks_by_level",
     "threat_intels",
     "enrichments",
     "containers",

--- a/src/cyvest/io_serialization.py
+++ b/src/cyvest/io_serialization.py
@@ -49,13 +49,6 @@ def serialize_investigation(inv: Investigation) -> InvestigationSchema:
             checks_by_scope[check.scope] = []
         checks_by_scope[check.scope].append(check)
 
-    # Build checks organized by level
-    checks_by_level: dict[str, list[str]] = {}
-    for check in inv.get_all_checks().values():
-        if check.level.name not in checks_by_level:
-            checks_by_level[check.level.name] = []
-        checks_by_level[check.level.name].append(check.key)
-
     # Get root type
     root = inv.get_root()
     root_type_value = root.obs_type.value
@@ -80,7 +73,6 @@ def serialize_investigation(inv: Investigation) -> InvestigationSchema:
         event_log=inv.get_event_log(),
         observables=observables,
         checks=checks_by_scope,
-        checks_by_level=checks_by_level,
         threat_intels=threat_intels,
         enrichments=enrichments,
         containers=containers,

--- a/src/cyvest/model.py
+++ b/src/cyvest/model.py
@@ -160,10 +160,8 @@ class Taxonomy(BaseModel):
 
     @field_validator("level", mode="before")
     @classmethod
-    def require_level_enum(cls, v: Any) -> Level:
-        if isinstance(v, Level):
-            return v
-        raise TypeError("Taxonomy level must be a Level enum value.")
+    def coerce_level(cls, v: Any) -> Level:
+        return normalize_level(v)
 
 
 class ThreatIntel(BaseModel):
@@ -236,8 +234,6 @@ class ThreatIntel(BaseModel):
         if "comment" not in values:
             values["comment"] = ""
         if values.get("taxonomies") is None:
-            values["taxonomies"] = []
-        if "taxonomies" not in values:
             values["taxonomies"] = []
         if "key" not in values:
             values["key"] = ""

--- a/src/cyvest/model_schema.py
+++ b/src/cyvest/model_schema.py
@@ -51,8 +51,8 @@ class StatisticsSchema(BaseModel):
     observables_by_type_and_level: dict[str, dict[str, Annotated[int, Field(ge=0)]]] = Field(default_factory=dict)
     total_checks: Annotated[int, Field(ge=0)]
     applied_checks: Annotated[int, Field(ge=0)]
-    checks_by_scope: dict[str, Annotated[int, Field(ge=0)]] = Field(default_factory=dict)
-    checks_by_level: dict[str, Annotated[int, Field(ge=0)]] = Field(default_factory=dict)
+    checks_by_scope: dict[str, list[str]] = Field(default_factory=dict)
+    checks_by_level: dict[str, list[str]] = Field(default_factory=dict)
     total_threat_intel: Annotated[int, Field(ge=0)]
     threat_intel_by_source: dict[str, Annotated[int, Field(ge=0)]] = Field(default_factory=dict)
     threat_intel_by_level: dict[str, Annotated[int, Field(ge=0)]] = Field(default_factory=dict)
@@ -123,10 +123,6 @@ class InvestigationSchema(BaseModel):
         ...,
         description="Checks organized by scope.",
     )
-    checks_by_level: dict[str, list[str]] = Field(
-        ...,
-        description="Check keys organized by level name.",
-    )
     threat_intels: dict[str, ThreatIntel] = Field(
         ...,
         description="Threat intelligence entries keyed by their unique key.",
@@ -163,7 +159,6 @@ class InvestigationSchema(BaseModel):
         v.setdefault("event_log", [])
         v.setdefault("observables", {})
         v.setdefault("checks", {})
-        v.setdefault("checks_by_level", {})
         v.setdefault("threat_intels", {})
         v.setdefault("enrichments", {})
         v.setdefault("containers", {})

--- a/src/cyvest/stats.py
+++ b/src/cyvest/stats.py
@@ -154,6 +154,18 @@ class InvestigationStats:
             counts[check.scope] += 1
         return dict(counts)
 
+    def get_check_keys_by_scope(self) -> dict[str, list[str]]:
+        """
+        Get check keys grouped by scope.
+
+        Returns:
+            Dictionary mapping scope to list of check keys
+        """
+        keys: dict[str, list[str]] = defaultdict(list)
+        for check in self._checks.values():
+            keys[check.scope].append(check.key)
+        return dict(keys)
+
     def get_check_count_by_level(self) -> dict[Level, int]:
         """
         Get count of checks by level.
@@ -165,6 +177,18 @@ class InvestigationStats:
         for check in self._checks.values():
             counts[check.level] += 1
         return dict(counts)
+
+    def get_check_keys_by_level(self) -> dict[Level, list[str]]:
+        """
+        Get check keys grouped by level.
+
+        Returns:
+            Dictionary mapping level to list of check keys
+        """
+        keys: dict[Level, list[str]] = defaultdict(list)
+        for check in self._checks.values():
+            keys[check.level].append(check.key)
+        return dict(keys)
 
     def get_applied_check_count(self) -> int:
         """
@@ -283,8 +307,8 @@ class InvestigationStats:
             },
             total_checks=self.get_total_check_count(),
             applied_checks=self.get_applied_check_count(),
-            checks_by_scope=self.get_check_count_by_scope(),
-            checks_by_level={str(k): v for k, v in self.get_check_count_by_level().items()},
+            checks_by_scope=self.get_check_keys_by_scope(),
+            checks_by_level={str(k): v for k, v in self.get_check_keys_by_level().items()},
             total_threat_intel=self.get_threat_intel_count(),
             threat_intel_by_source=self.get_threat_intel_count_by_source(),
             threat_intel_by_level={str(k): v for k, v in self.get_threat_intel_count_by_level().items()},

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -94,7 +94,6 @@ def test_investigation_schema_level_required_and_defaults() -> None:
         "whitelists",
         "observables",
         "checks",
-        "checks_by_level",
         "threat_intels",
         "enrichments",
         "containers",
@@ -130,7 +129,6 @@ def test_investigation_schema_level_required_and_defaults() -> None:
     assert inst.whitelists == []
     assert inst.observables == {}
     assert inst.checks == {}
-    assert inst.checks_by_level == {}
     assert inst.threat_intels == {}
     assert inst.enrichments == {}
     assert inst.containers == {}

--- a/tests/test_shared_context.py
+++ b/tests/test_shared_context.py
@@ -1378,7 +1378,7 @@ def test_export_parallel_updates(tmp_path):
     # Export should capture all observables and checks
     schema = shared.io_to_invest()
     assert len(schema.observables) == 11  # 10 created + 1 root
-    assert schema.stats.checks_by_scope["scope"] == 10
+    assert len(schema.stats.checks_by_scope["scope"]) == 10
 
     # Save and verify
     json_path = tmp_path / "parallel.json"


### PR DESCRIPTION
- Removed `checks_by_level` from `CyvestInvestigation` interface and adjusted related tests.
- Updated `checks_by_scope` and `checks_by_level` to use arrays of strings instead of integers in various schemas and models.
- Modified serialization logic to exclude `checks_by_level`.
- Adjusted `InvestigationStats` to provide check keys grouped by scope and level.
- Updated tests to reflect changes in checks structure and ensure proper functionality.