### PR TITLE
refactor(models): removed check_id and scope, added check_name and migrated container to tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ cv.io_save_json("investigation.json")
 ### Model Proxies
 
 Cyvest only exposes immutable model proxies. Helpers like `observable_create`, `check_create`, and the
-fluent `cv.observable()`/`cv.check()` convenience methods return `ObservableProxy`, `CheckProxy`, `ContainerProxy`, etc.
+fluent `cv.observable()`/`cv.check()` convenience methods return `ObservableProxy`, `CheckProxy`, `TagProxy`, etc.
 These proxies reflect the live investigation state but raise `AttributeError` if you try to assign to their attributes.
 All mutations are routed through the Investigation layer, so use the facade helpers (`cv.observable_set_level`,
 `cv.check_update_score`, `cv.observable_add_threat_intel`) or the built-in fluent methods on the proxies themselves
 (`with_ti`, `relate_to`, `link_observable`, `with_score`, …) so the score engine and audit log stay consistent.
 
 Mutation helpers that reference existing objects (for example, `cv.observable_add_relationship`,
-`cv.check_link_observable`, `cv.container_add_check`) raise `KeyError` when a key is missing.
+`cv.check_link_observable`, `cv.tag_add_check`) raise `KeyError` when a key is missing.
 
 Safe metadata fields like `comment`, `extra`, or `internal` can be updated through the proxies without breaking score
 consistency:
@@ -179,15 +179,19 @@ ti.add_taxonomy(level=cv.LVL.SUSPICIOUS, name="confidence", value="medium")
 ti.remove_taxonomy("confidence")
 ```
 
-### Containers
+### Tags
 
-Containers organize checks hierarchically:
+Tags organize checks with automatic hierarchy based on `:` delimiter:
 
 ```python
-with cv.container("network_analysis") as network:
-    with network.sub_container("c2_detection") as c2:
-        check = cv.check("beacon_detection", "network", "Detect C2 beacons")
-        c2.add_check(check)
+# Creating "network:c2:detection" auto-creates "network" and "network:c2" tags
+tag = cv.tag("network:c2:detection", "C2 Detection Checks")
+check = cv.check("beacon_detection", "Detect C2 beacons")
+check.in_tag(tag)
+
+# Query hierarchy
+children = cv.tag_get_children("network")  # ["network:c2"]
+descendants = cv.tag_get_descendants("network")  # ["network:c2", "network:c2:detection"]
 ```
 
 ### Lookup Helpers
@@ -203,9 +207,9 @@ check = cv.check_create("malware_detection", "endpoint", "Verify file hash")
 same_check = cv.check_get("malware_detection", "endpoint")
 same_check_by_key = cv.check_get(check.key)
 
-container = cv.container_create("network_analysis")
-same_container = cv.container_get("network_analysis")
-same_container_by_key = cv.container_get(container.key)
+tag = cv.tag_create("network:analysis")
+same_tag = cv.tag_get("network:analysis")
+same_tag_by_key = cv.tag_get(tag.key)
 
 enrichment = cv.enrichment_create("whois", {"registrar": "Example Inc"})
 same_enrichment = cv.enrichment_get("whois")

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -51,9 +51,9 @@ pytest --cov=cyvest --cov-report=term-missing --cov-report=html
 
 | Layer | Role | Files |
 | --- | --- | --- |
-| **Investigation** | Authoritative state: observables, checks, TI, containers, score engine | `src/cyvest/investigation.py` |
+| **Investigation** | Authoritative state: observables, checks, TI, tags, score engine | `src/cyvest/investigation.py` |
 | **Cyvest facade** | Public API + CLI entry, manages deterministic keys, exposes fluent helpers | `src/cyvest/cyvest.py`, `src/cyvest/cli.py` |
-| **Proxy helpers** | Fluent builders for observables/checks/containers with merge-on-create semantics | `src/cyvest/proxies.py` |
+| **Proxy helpers** | Fluent builders for observables/checks/tags with merge-on-create semantics | `src/cyvest/proxies.py` |
 | **Models** | Dataclasses for Observables, Checks, ThreatIntel, etc. | `src/cyvest/model.py` |
 | **Scoring** | Score modes, propagation, and level determination | `src/cyvest/score.py` |
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -145,13 +145,13 @@ obs.with_ti_draft(draft)
 
 Drafts are plain `ThreatIntel` objects without an `observable_key`; the key is generated on attach.
 
-### Containers
+### Tags
 
-**Containers** organize checks hierarchically:
+**Tags** organize checks with automatic hierarchy based on `:` delimiter:
 - Group related checks together
 - Create logical investigation sections
-- Support nesting for complex structures
-- Provide aggregated scores and levels
+- Auto-create ancestor tags (e.g., `header:auth:dkim` creates `header` and `header:auth`)
+- Provide direct and aggregated scores/levels
 
 ### Enrichments
 
@@ -651,7 +651,7 @@ Every object has a unique, deterministic key:
 - **Check**: `chk:{check_name}`
 - **Threat Intel**: `ti:{source}:{observable_key}`
 - **Enrichment**: `enr:{name}[:{context_hash}]`
-- **Container**: `ctr:{path}`
+- **Tag**: `tag:{name}`
 
 Keys enable:
 - Fast object retrieval
@@ -809,7 +809,7 @@ inv1.merge_investigation(inv2)
 - **Checks**: Higher score/level wins, observables merge by key (not identity)
 - **Threat Intel**: Higher score/level wins, taxonomies merge by name (incoming replaces same name)
 - **Enrichments**: Deep merge of data dictionaries
-- **Containers**: Recursive merge of checks and sub-containers
+- **Tags**: Merge of checks, hierarchy auto-reconstructed from names
 
 ## Next Steps
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -107,8 +107,7 @@ obs = cv.observable(cv.OBS.URL, "https://example.com")
 - Any validation logic
 
 Each check has:
-- **Check ID**: Identifier for the verification
-- **Scope**: Category (email, network, endpoint, etc.)
+- **Check Name**: Identifier for the verification
 - **Description**: What the check does
 - **Score**: Contribution to overall severity
 - **Level**: Result classification
@@ -591,7 +590,7 @@ from cyvest import Cyvest
 cv = Cyvest()
 
 # Create a check
-check = cv.check_create("domain_check", "network", "Analyze domain reputation")
+check = cv.check_create("domain_check", "Analyze domain reputation")
 
 # Link a SAFE observable
 safe_domain = cv.observable_create(cv.OBS.DOMAIN_NAME, "trusted.example.com", level=cv.LVL.SAFE)
@@ -649,7 +648,7 @@ cv.observable_add_relationship(
 Every object has a unique, deterministic key:
 
 - **Observable**: `obs:{type}:{normalized_value}`
-- **Check**: `chk:{check_id}:{scope}`
+- **Check**: `chk:{check_name}`
 - **Threat Intel**: `ti:{source}:{observable_key}`
 - **Enrichment**: `enr:{name}[:{context_hash}]`
 - **Container**: `ctr:{path}`
@@ -665,8 +664,7 @@ The facade getters accept either keys or component parameters:
 obs = cv.observable_get(cv.OBS.URL, "https://malicious.com")
 obs_by_key = cv.observable_get("obs:url:https://malicious.com")
 
-check = cv.check_get("malware_detection", "endpoint")
-check_by_key = cv.check_get("chk:malware_detection:endpoint")
+check = cv.check_get("chk:malware_detection")
 ```
 
 Low-level `Investigation` getters accept keys only; use the facade for component-based lookups.
@@ -717,8 +715,8 @@ cv.observable_add_threat_intel(child.key, "urlscan", score=Decimal("5.0"))
 cv.relationship_add(root.key, child.key, cv.REL.RELATED_TO, direction=cv.DIR.OUTBOUND)
 
 # Create check for root
-check = cv.check_create("root-check", "validation")
-cv.check_link_observable(check.check_id, root.key)
+check = cv.check_create("root-check", "Validation check")
+cv.check_link_observable(check.key, root.key)
 
 # Results (MAX mode):
 # - root.score = max(9.0 TI, 5.0 child) = 9.0
@@ -742,7 +740,7 @@ stats = cv.get_statistics()
 stats['total_observables']
 stats['observables_by_type']
 stats['observables_by_level']
-stats['checks_by_scope']
+stats['checks_by_level']
 stats['total_threat_intel']
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -36,7 +36,7 @@ print(cv.get_global_score(), cv.get_global_level())
 ```
 
 !!! tip "Context-first mindset"
-    Pass incident metadata through `Cyvest(root_data={...})`. Every container, check, and export inherits it so you never lose analyst intent.
+    Pass incident metadata through `Cyvest(root_data={...})`. Every tag, check, and export inherits it so you never lose analyst intent.
 
 !!! tip "Deterministic investigation IDs"
     For reproducible reports that enable diffing between runs, pass a custom `investigation_id`:
@@ -113,25 +113,31 @@ cv.observable_add_relationship(
 
 ---
 
-## 4. Organize workstreams with containers
+## 4. Organize workstreams with tags
 
 ```python
 cv = Cyvest()
-with cv.container("network_analysis", "Network telemetry") as network:
-    (
-        cv.check("c2_detection", "Detect C2 communication")
-        .in_container(network)
-    )
 
-    # Nesting is encouraged for larger stories
-    with network.sub_container("east_dc", "East datacenter") as east:
-        (
-            cv.check("ids_east", "IDS signals from east DC")
-            .in_container(east)
-        )
+# Tags use ":" delimiter for automatic hierarchy
+# Creating "network:east_dc" auto-creates "network" tag
+network_tag = cv.tag("network:analysis", "Network telemetry")
+(
+    cv.check("c2_detection", "Detect C2 communication")
+    .in_tag(network_tag)
+)
+
+# Nested tags for larger stories
+east_tag = cv.tag("network:analysis:east_dc", "East datacenter")
+(
+    cv.check("ids_east", "IDS signals from east DC")
+    .in_tag(east_tag)
+)
+
+# Query hierarchy
+children = cv.tag_get_children("network:analysis")  # Returns east_dc tag
 ```
 
-Containers keep checks, sub-containers, and metrics scoped. They also enable reporting sections inside Markdown exports.
+Tags organize checks with automatic hierarchy. Creating `header:auth:dkim` auto-creates `header` and `header:auth` tags.
 
 ---
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -27,7 +27,6 @@ cv.observable_add_threat_intel(
 
 url_check = cv.check_create(
     "url_analysis",
-    "email_body",
     "Analyze URLs in email",
     score=Decimal("8.5"),
 )
@@ -65,7 +64,7 @@ url = (
 )
 
 (
-    cv.check("url_check", "analysis", "Check suspicious URL")
+    cv.check("url_check", "Check suspicious URL")
     .link_observable(url)
     .with_score(Decimal("8.5"))
 )
@@ -120,14 +119,14 @@ cv.observable_add_relationship(
 cv = Cyvest()
 with cv.container("network_analysis", "Network telemetry") as network:
     (
-        cv.check("c2_detection", "network", "Detect C2 communication")
+        cv.check("c2_detection", "Detect C2 communication")
         .in_container(network)
     )
 
     # Nesting is encouraged for larger stories
     with network.sub_container("east_dc", "East datacenter") as east:
         (
-            cv.check("ids_east", "network", "IDS signals from east DC")
+            cv.check("ids_east", "IDS signals from east DC")
             .in_container(east)
         )
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ phishing_url = (
 )
 
 (
-    cv.check("email:url", "body", "Analyze embedded URL")
+    cv.check("email_url_check", "Analyze embedded URL")
     .link_observable(phishing_url)
     .with_score(Decimal("8.5"))
 )

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Build, score, and narrate cybersecurity investigations with a single fluent Pyth
 
 | Area | Why it matters | What to look at |
 | --- | --- | --- |
-| **Structured objects** | Model observables, checks, TI, containers, and enrichments with typed helpers | `cyvest.model`, [Concepts](getting-started/concepts.md#observables) |
+| **Structured objects** | Model observables, checks, TI, tags, and enrichments with typed helpers | `cyvest.model`, [Concepts](getting-started/concepts.md#observables) |
 | **Deterministic scoring** | MAX/SUM propagation, centralized audit log, and automatic level classification | `cyvest.score`, [Scoring System](getting-started/concepts.md#scoring-system) |
 | **Fluent helpers** | Builder-style methods with deterministic keys and safe merges | `cyvest.cyvest`, [Quick Start](getting-started/quickstart.md#using-the-fluent-api) |
 | **Shared context** | Thread-safe fragments that can reconcile into a single story | `cyvest.shared.SharedInvestigationContext`, [Guide](shared-investigation-context.md) |
@@ -67,7 +67,7 @@ print(cv.get_global_score(), cv.get_global_level())
 Cyvest (facade + fluent proxies)
 └─ Investigation (core state)
    ├─ Observables & relationships
-   ├─ Checks and containers (workflow context)
+   ├─ Checks and tags (workflow context)
    ├─ Threat intelligence (source, score, taxonomies)
    ├─ ScoreEngine (MAX/SUM propagation, history)
    ├─ InvestigationStats (live metrics)

--- a/docs/js-packages.md
+++ b/docs/js-packages.md
@@ -9,7 +9,7 @@ recorded as an `INVESTIGATION_STARTED` event in the `audit_log`.
 
 ## Packages
 
-- **@cyvest/cyvest-js** — Generated types, schema validation, graph builders, and helper functions for Cyvest investigation JSON. Ships ESM/CJS builds and `.d.ts` files.
+- **@cyvest/cyvest-js** — Generated types, schema validation, graph builders, tag hierarchy utilities (including aggregated score/level), and helper functions for Cyvest investigation JSON. Ships ESM/CJS builds and `.d.ts` files.
 - **@cyvest/cyvest-vis** — React 19+ visualization components (powered by React Flow + D3) to visualize investigations with level-aware styling. Depends on `@cyvest/cyvest-js`.
 - **@cyvest/cyvest-app** — Private Vite demo that bundles sample investigations and renders them via `CyvestGraph`. Useful for tweaking visuals and testing UI flows.
 
@@ -20,7 +20,7 @@ Interactive graph visualization for Cyvest investigations.
 ### Features
 
 - **Observables Graph**: Force-directed layout showing all observables and relationships
-- **Investigation Graph**: Hierarchical Dagre layout showing root → containers → checks
+- **Investigation Graph**: Hierarchical Dagre layout showing root → tags → checks
 - **Professional icons**: SVG icons for all observable types (IPs, domains, emails, files, etc.)
 - **Interactive controls**: Drag nodes, adjust force parameters, zoom/pan
 - **Level-aware colors**: Nodes styled by security level (SAFE → MALICIOUS)
@@ -44,7 +44,7 @@ import { CyvestGraph } from "@cyvest/cyvest-vis";
 |-----------|-------------|
 | `CyvestGraph` | Combined view with toggle between Observables and Investigation |
 | `ObservablesGraph` | Force-directed graph of observables and relationships |
-| `InvestigationGraph` | Hierarchical graph of root, checks, and containers |
+| `InvestigationGraph` | Hierarchical graph of root, checks, and tags |
 
 See `js/packages/cyvest-vis/src/components` for advanced hooks and utilities.
 

--- a/docs/shared-investigation-context.md
+++ b/docs/shared-investigation-context.md
@@ -128,19 +128,18 @@ if domain:
     )
 ```
 
-##### `check_get(check_id: str, scope: str) -> Check | None`
-Retrieves a shared check by ID and scope.
+##### `check_get(check_name: str) -> Check | None`
+Retrieves a shared check by name.
 
 **Parameters:**
-- `check_id`: Check identifier
-- `scope`: Check scope
+- `check_name`: Check name
 
 **Returns:** Deep copy of the check, or `None` if not found
 
 **Examples:**
 ```python
-from_check = shared_context.check_get("from", "header")
-malware_check = shared_context.check_get("malware_scan", "attachment")
+from_check = shared_context.check_get("from_verification")
+malware_check = shared_context.check_get("malware_scan")
 ```
 
 ##### Existence checks

--- a/docs/shared-investigation-context.md
+++ b/docs/shared-investigation-context.md
@@ -151,13 +151,13 @@ Returns whether the underlying investigation has whitelist entries.
 ##### `get_global_level() -> Level`
 Returns the global level of the underlying investigation.
 
-##### `io_to_markdown(include_containers: bool = False, include_enrichments: bool = False, include_observables: bool = True) -> str`
+##### `io_to_markdown(include_tags: bool = False, include_enrichments: bool = False, include_observables: bool = True) -> str`
 Generate a Markdown report of the shared investigation with optional sections.
 
 Thread-safe: Uses lock to ensure consistent read of investigation state.
 
 **Parameters:**
-- `include_containers`: Include containers section in the report (default: `False`)
+- `include_tags`: Include tags section in the report (default: `False`)
 - `include_enrichments`: Include enrichments section in the report (default: `False`)
 - `include_observables`: Include observables section in the report (default: `True`)
 
@@ -170,14 +170,14 @@ markdown = shared.io_to_markdown()
 print(markdown)
 ```
 
-##### `io_save_markdown(filepath: str | Path, include_containers: bool = False, include_enrichments: bool = False, include_observables: bool = True) -> str`
+##### `io_save_markdown(filepath: str | Path, include_tags: bool = False, include_enrichments: bool = False, include_observables: bool = True) -> str`
 Save the shared investigation as a Markdown report.
 
 Thread-safe: Uses lock to ensure consistent read. Relative paths are converted to absolute paths.
 
 **Parameters:**
 - `filepath`: Path to save the Markdown file (relative or absolute)
-- `include_containers`: Include containers section in the report (default: `False`)
+- `include_tags`: Include tags section in the report (default: `False`)
 - `include_enrichments`: Include enrichments section in the report (default: `False`)
 - `include_observables`: Include observables section in the report (default: `True`)
 

--- a/examples/01_email_basic.py
+++ b/examples/01_email_basic.py
@@ -60,10 +60,10 @@ def main() -> None:
     cv.check_link_observable(sender_check.key, sender_email.key)
     cv.check_link_observable(url_check.key, phishing_url.key)
 
-    # Create container for organization
-    email_container = cv.container_create("email_analysis", "Analysis of suspicious email")
-    cv.container_add_check(email_container.key, sender_check.key)
-    cv.container_add_check(email_container.key, url_check.key)
+    # Create tag for organization
+    email_tag = cv.tag_create("email:analysis", "Analysis of suspicious email")
+    cv.tag_add_check(email_tag.key, sender_check.key)
+    cv.tag_add_check(email_tag.key, url_check.key)
 
     # Add enrichment
     cv.enrichment_create(

--- a/examples/01_email_basic.py
+++ b/examples/01_email_basic.py
@@ -44,7 +44,6 @@ def main() -> None:
     # Create checks
     sender_check = cv.check_create(
         "sender_verification",
-        "email_headers",
         "Verify sender authenticity",
         comment="Sender domain not in known contacts. SPF check failed.",
         score=Decimal("3.5"),
@@ -52,7 +51,6 @@ def main() -> None:
 
     url_check = cv.check_create(
         "url_analysis",
-        "email_body",
         "Analyze URLs in email body",
         comment="Found phishing URL attempting to steal credentials",
         score=Decimal("8.5"),

--- a/examples/02_urls_and_ips.py
+++ b/examples/02_urls_and_ips.py
@@ -65,14 +65,14 @@ def main() -> None:
 
         # Create checks
         _ = (
-            cv.check("c2_detection", "network", "Detect C2 communication")
+            cv.check("c2_detection", "Detect C2 communication")
             .link_observable(url1)
             .link_observable(ip1)
             .in_container(network_ctr)
         )
 
         _ = (
-            cv.check("malware_download", "network", "Detect malware download")
+            cv.check("malware_download", "Detect malware download")
             .link_observable(url2)
             .link_observable(ip2)
             .in_container(network_ctr)
@@ -81,7 +81,6 @@ def main() -> None:
         _ = (
             cv.check(
                 "compromised_host",
-                "endpoint",
                 "Identify compromised endpoint",
                 comment="Host made connections to known malicious infrastructure",
             )

--- a/examples/02_urls_and_ips.py
+++ b/examples/02_urls_and_ips.py
@@ -20,73 +20,74 @@ def main() -> None:
     """Run a URL and IP investigation example."""
     cv = Cyvest(root_data={"type": "network_traffic"})
 
-    # Create container for network analysis
-    with cv.container("network_analysis", "Analysis of network traffic") as network_ctr:
-        # Suspicious URL 1
-        url1 = (
-            cv.observable(cv.OBS.URL, "http://malicious-c2.com/beacon", internal=False)
-            .with_ti("virustotal", score=Decimal("9.0"), level=cv.LVL.MALICIOUS, comment="C2 server detected")
-            .with_ti("alienvault", score=Decimal("8.5"), level=cv.LVL.MALICIOUS, comment="Known APT infrastructure")
+    # Create tag for network analysis
+    network_tag = cv.tag("network:analysis", "Analysis of network traffic")
+
+    # Suspicious URL 1
+    url1 = (
+        cv.observable(cv.OBS.URL, "http://malicious-c2.com/beacon", internal=False)
+        .with_ti("virustotal", score=Decimal("9.0"), level=cv.LVL.MALICIOUS, comment="C2 server detected")
+        .with_ti("alienvault", score=Decimal("8.5"), level=cv.LVL.MALICIOUS, comment="Known APT infrastructure")
+    )
+
+    # IP address for URL1
+    ip1 = cv.observable(cv.OBS.IPV4, "192.0.2.100", internal=False).with_ti(
+        "abuseipdb", score=Decimal("7.5"), level=cv.LVL.MALICIOUS, comment="High abuse score"
+    )
+
+    # Link URL to IP
+    cv.observable_add_relationship(url1.key, ip1.key, cv.REL.RELATED_TO)
+
+    # Suspicious URL 2
+    url2 = cv.observable(cv.OBS.URL, "http://evil-download.net/payload.exe", internal=False).with_ti(
+        "virustotal", score=Decimal("8.0"), level=cv.LVL.MALICIOUS, comment="Malware distribution"
+    )
+
+    # IP address for URL2
+    ip2 = (
+        cv.observable(cv.OBS.IPV4, "198.51.100.50", internal=False)
+        .with_ti("shodan", score=Decimal("0"), comment="Open ports: 80, 443, 8080")
+        .with_ti("abuseipdb", score=Decimal("6.0"), level=cv.LVL.SUSPICIOUS, comment="Moderate abuse score")
+    )
+
+    # Link URL to IP
+    cv.observable_add_relationship(url2.key, ip2.key, cv.REL.RELATED_TO)
+
+    # Internal host that connected
+    internal_host = cv.observable(
+        cv.OBS.DOMAIN,
+        "workstation-042.company.local",
+        internal=True,
+    ).with_ti("edr", score=Decimal("0"), comment="Detected outbound connection to suspicious IP")
+
+    # Link internal host to external URLs
+    cv.observable_add_relationship(internal_host.key, url1.key, cv.REL.RELATED_TO)
+    cv.observable_add_relationship(internal_host.key, url2.key, cv.REL.RELATED_TO)
+
+    # Create checks
+    _ = (
+        cv.check("c2_detection", "Detect C2 communication")
+        .link_observable(url1)
+        .link_observable(ip1)
+        .in_tag(network_tag)
+    )
+
+    _ = (
+        cv.check("malware_download", "Detect malware download")
+        .link_observable(url2)
+        .link_observable(ip2)
+        .in_tag(network_tag)
+    )
+
+    _ = (
+        cv.check(
+            "compromised_host",
+            "Identify compromised endpoint",
+            comment="Host made connections to known malicious infrastructure",
         )
-
-        # IP address for URL1
-        ip1 = cv.observable(cv.OBS.IPV4, "192.0.2.100", internal=False).with_ti(
-            "abuseipdb", score=Decimal("7.5"), level=cv.LVL.MALICIOUS, comment="High abuse score"
-        )
-
-        # Link URL to IP
-        cv.observable_add_relationship(url1.key, ip1.key, cv.REL.RELATED_TO)
-
-        # Suspicious URL 2
-        url2 = cv.observable(cv.OBS.URL, "http://evil-download.net/payload.exe", internal=False).with_ti(
-            "virustotal", score=Decimal("8.0"), level=cv.LVL.MALICIOUS, comment="Malware distribution"
-        )
-
-        # IP address for URL2
-        ip2 = (
-            cv.observable(cv.OBS.IPV4, "198.51.100.50", internal=False)
-            .with_ti("shodan", score=Decimal("0"), comment="Open ports: 80, 443, 8080")
-            .with_ti("abuseipdb", score=Decimal("6.0"), level=cv.LVL.SUSPICIOUS, comment="Moderate abuse score")
-        )
-
-        # Link URL to IP
-        cv.observable_add_relationship(url2.key, ip2.key, cv.REL.RELATED_TO)
-
-        # Internal host that connected
-        internal_host = cv.observable(
-            cv.OBS.DOMAIN,
-            "workstation-042.company.local",
-            internal=True,
-        ).with_ti("edr", score=Decimal("0"), comment="Detected outbound connection to suspicious IP")
-
-        # Link internal host to external URLs
-        cv.observable_add_relationship(internal_host.key, url1.key, cv.REL.RELATED_TO)
-        cv.observable_add_relationship(internal_host.key, url2.key, cv.REL.RELATED_TO)
-
-        # Create checks
-        _ = (
-            cv.check("c2_detection", "Detect C2 communication")
-            .link_observable(url1)
-            .link_observable(ip1)
-            .in_container(network_ctr)
-        )
-
-        _ = (
-            cv.check("malware_download", "Detect malware download")
-            .link_observable(url2)
-            .link_observable(ip2)
-            .in_container(network_ctr)
-        )
-
-        _ = (
-            cv.check(
-                "compromised_host",
-                "Identify compromised endpoint",
-                comment="Host made connections to known malicious infrastructure",
-            )
-            .link_observable(internal_host)
-            .in_container(network_ctr)
-        )
+        .link_observable(internal_host)
+        .in_tag(network_tag)
+    )
 
     # Finalize
     cv.finalize_relationships()

--- a/examples/03_merge_demo.py
+++ b/examples/03_merge_demo.py
@@ -131,14 +131,12 @@ def main() -> None:
     main_investigation.merge_investigation(endpoint_investigation)
     main_investigation.merge_investigation(email_investigation)
 
-    # Create a container to organize all findings
-    incident_container = main_investigation.container_create(
-        "incident_findings", "Consolidated findings from all data sources"
-    )
+    # Create a tag to organize all findings
+    incident_tag = main_investigation.tag_create("incident:findings", "Consolidated findings from all data sources")
 
-    # Add all checks to the container
+    # Add all checks to the tag
     for check in main_investigation.get_all_checks().values():
-        main_investigation.container_add_check(incident_container.key, check.key)
+        main_investigation.tag_add_check(incident_tag.key, check.key)
 
     # Finalize relationships
     main_investigation.finalize_relationships()

--- a/examples/04_email.py
+++ b/examples/04_email.py
@@ -174,7 +174,7 @@ class EmailFrom(BaseRule):
 
         # Create check for header analysis
         (
-            cy.check("from", "header", "test email vt 10", "> ok boys")
+            cy.check("from", "test email vt 10", "> ok boys")
             .link_observable(obs)
             .in_container(cy.container("emails"))
         )
@@ -204,7 +204,7 @@ class EmailFromBIS(BaseRule):
 
         # Create check for header analysis
         (
-            cy.check("from-proofpoint", "header", "test email vt 10", "> ok boys")
+            cy.check("from-proofpoint", "test email vt 10", "> ok boys")
             .link_observable(obs)
             .in_container(cy.container("emails"))
         )
@@ -227,7 +227,7 @@ class EmailReciever(BaseRule):
         logger.info("Analyzing email receiver")
 
         cy.enrichment_create("receiver", {"receiver": ["ok"]}, context="from splunk")
-        cy.check("receiver", "header", "description", "> receiver").with_score(0.1).link_observable(
+        cy.check("receiver", "description", "> receiver").with_score(0.1).link_observable(
             cy.observable(cy.OBS.EMAIL, "user@company.com").relate_to(
                 cy.root(), cy.REL.RELATED_TO, direction=cy.DIR.INBOUND
             )
@@ -285,7 +285,7 @@ class BodiesUrlTask(BaseRule):
 
             # Create check and link to container
             chk = (
-                cy.check(f"body-url-{url}", "body", f"URL analysis {url}", comment=f"> score: {score}")
+                cy.check(f"body-url-{url}", f"URL analysis {url}", comment=f"> score: {score}")
                 .link_observable(url_obs)
                 .in_container(container)
             )
@@ -340,7 +340,7 @@ class BodiesDomainTask(BaseRule):
 
             # Create check and link to container
             chk = (
-                cy.check(f"body-domain-{domain}", "body", f"Domain analysis {domain}", comment=f"> score: {score}")
+                cy.check(f"body-domain-{domain}", f"Domain analysis {domain}", comment=f"> score: {score}")
                 .link_observable(domain_obs, propagation_mode=cy.PROP.GLOBAL)
                 .in_container(container)
             )
@@ -399,7 +399,6 @@ class AttachmentTask(BaseRule):
             check_desc = f"File: {filename} ({size} bytes)"
             cy.check(
                 f"attachment-{filename}",
-                "attachment",
                 check_desc,
                 comment=f"> MD5: {md5_hash}\n> SHA256: {sha256_hash}\n> Threat score: {score}",
             ).link_observable(file_obs).in_container(container)
@@ -435,8 +434,8 @@ class AggregatedRiskTask(BaseRule):
         logger.info("Starting aggregated risk assessment")
 
         # Access checks from other tasks using parameter-based API
-        from_check = self.shared_context.check_get("from", "header")
-        receiver_check = self.shared_context.check_get("receiver", "header")
+        from_check = self.shared_context.check_get("from")
+        receiver_check = self.shared_context.check_get("receiver")
 
         # Access observables from other tasks using parameter-based API
         sender_email = self.shared_context.observable_get(Cyvest.OBS.EMAIL, "noreply@domainmalicious.com")
@@ -479,7 +478,7 @@ class AggregatedRiskTask(BaseRule):
 
         # Create aggregated check
         aggregated_check = cy.check(
-            "email_risk_aggregated", "full", "Aggregated Email Risk Assessment", comment=comment
+            "email_risk_aggregated", "Aggregated Email Risk Assessment", comment=comment
         ).with_score(risk_score)
 
         # Link all relevant observables to the aggregated check
@@ -501,7 +500,7 @@ class AI(BaseRule):
 
     def run(self, cy: Cyvest) -> None:
         """Calculate aggregated risk score based on all previous checks."""
-        cy.check("ai", "full", "ai", score=0, level=cy.LVL.MALICIOUS)
+        cy.check("ai", "AI Analysis", score=0, level=cy.LVL.MALICIOUS)
 
 
 # ============================================================================
@@ -571,7 +570,7 @@ def main(workers, browser, stats, audit, no_audit_log, output):
     cy.finalize_relationships()
     cy._investigation._score_engine.recalculate_all()
 
-    c = cy.check_get("email_risk_aggregated", "full")
+    c = cy.check_get("chk:email_risk_aggregated")
     if c is not None:
         logger.info(c.comment)
 

--- a/examples/04_email.py
+++ b/examples/04_email.py
@@ -63,7 +63,7 @@ class BaseRule(ABC):
                           (access data via cy.root().extra)
 
         Returns:
-            Cyvest instance containing observables, checks, and containers
+            Cyvest instance containing observables, checks, and tags
         """
         pass
 
@@ -173,11 +173,7 @@ class EmailFrom(BaseRule):
         )
 
         # Create check for header analysis
-        (
-            cy.check("from", "test email vt 10", "> ok boys")
-            .link_observable(obs)
-            .in_container(cy.container("emails"))
-        )
+        (cy.check("from", "test email vt 10", "> ok boys").link_observable(obs).in_tag(cy.tag("emails")))
 
         logger.info(f"Email header analysis complete: {obs.key}")
 
@@ -203,11 +199,7 @@ class EmailFromBIS(BaseRule):
         obs = cy.observable(cy.OBS.EMAIL, from_addr).with_ti("PROOFPOINT", 5, "> test")
 
         # Create check for header analysis
-        (
-            cy.check("from-proofpoint", "test email vt 10", "> ok boys")
-            .link_observable(obs)
-            .in_container(cy.container("emails"))
-        )
+        (cy.check("from-proofpoint", "test email vt 10", "> ok boys").link_observable(obs).in_tag(cy.tag("emails")))
 
         logger.info(f"Email header analysis complete: {obs.key}")
 
@@ -231,7 +223,7 @@ class EmailReciever(BaseRule):
             cy.observable(cy.OBS.EMAIL, "user@company.com").relate_to(
                 cy.root(), cy.REL.RELATED_TO, direction=cy.DIR.INBOUND
             )
-        ).in_container(cy.container("emails"))
+        ).in_tag(cy.tag("emails"))
 
         logger.info("Email receiver analysis complete")
 
@@ -259,8 +251,8 @@ class BodiesUrlTask(BaseRule):
 
         logger.info(f"Checking BODIES URLs: {len(urls_with_scores)}")
 
-        # Create container for URL checks
-        container = cy.container("bodies-urls", "Bodies URLs Analysis")
+        # Create tag for URL checks
+        tag = cy.tag("bodies:urls", "Bodies URLs Analysis")
 
         # Analyze each URL
         for url_data in urls_with_scores:
@@ -283,17 +275,17 @@ class BodiesUrlTask(BaseRule):
                     direction=cy.DIR.INBOUND,
                 )
 
-            # Create check and link to container
+            # Create check and link to tag
             chk = (
                 cy.check(f"body-url-{url}", f"URL analysis {url}", comment=f"> score: {score}")
                 .link_observable(url_obs)
-                .in_container(container)
+                .in_tag(tag)
             )
 
             logger.info("[bold red]Check Score: {}[/bold red]", chk.score)
 
         logger.info(f"Bodies URLs analysis complete: {len(urls_with_scores)} URLs processed")
-        logger.info("[bold red]Container Score: {}[/bold red]", container.get_aggregated_score())
+        logger.info("[bold red]Tag Score: {}[/bold red]", tag.get_aggregated_score())
 
 
 class BodiesDomainTask(BaseRule):
@@ -315,8 +307,8 @@ class BodiesDomainTask(BaseRule):
 
         logger.info(f"Checking BODIES DOMAINS: {len(domains_with_scores)}")
 
-        # Create container for domain checks
-        container = cy.container("bodies-domains", "Bodies Domains Analysis")
+        # Create tag for domain checks
+        tag = cy.tag("bodies:domains", "Bodies Domains Analysis")
 
         # Analyze each domain
         for domain_data in domains_with_scores:
@@ -338,17 +330,17 @@ class BodiesDomainTask(BaseRule):
                 )
             )
 
-            # Create check and link to container
+            # Create check and link to tag
             chk = (
                 cy.check(f"body-domain-{domain}", f"Domain analysis {domain}", comment=f"> score: {score}")
                 .link_observable(domain_obs, propagation_mode=cy.PROP.GLOBAL)
-                .in_container(container)
+                .in_tag(tag)
             )
 
             logger.info("[bold red]Check Score: {}[/bold red]", chk.score)
 
         logger.info(f"Bodies DOMAINS analysis complete: {len(domains_with_scores)} DOMAINS processed")
-        logger.info("[bold red]Container Score: {}[/bold red]", container.get_aggregated_score())
+        logger.info("[bold red]Tag Score: {}[/bold red]", tag.get_aggregated_score())
 
 
 class AttachmentTask(BaseRule):
@@ -368,8 +360,8 @@ class AttachmentTask(BaseRule):
 
         logger.info(f"Checking ATTACHMENTS: {len(attachments)}")
 
-        # Create container for attachment checks
-        container = cy.container("attachments", "Email Attachments Analysis")
+        # Create tag for attachment checks
+        tag = cy.tag("attachments", "Email Attachments Analysis")
 
         # Analyze each attachment
         for attachment in attachments:
@@ -395,13 +387,13 @@ class AttachmentTask(BaseRule):
             if score >= 5:
                 file_obs = file_obs.with_ti("MALWAREBAZAAR", score, f"Known malware: {filename}")
 
-            # Create check and link to container
+            # Create check and link to tag
             check_desc = f"File: {filename} ({size} bytes)"
             cy.check(
                 f"attachment-{filename}",
                 check_desc,
                 comment=f"> MD5: {md5_hash}\n> SHA256: {sha256_hash}\n> Threat score: {score}",
-            ).link_observable(file_obs).in_container(container)
+            ).link_observable(file_obs).in_tag(tag)
 
         logger.info(f"Attachments analysis complete: {len(attachments)} files processed")
 
@@ -487,8 +479,8 @@ class AggregatedRiskTask(BaseRule):
         if malicious_domain:
             aggregated_check.link_observable(malicious_domain)
 
-        # Put in a dedicated container
-        aggregated_check.in_container(cy.container("risk_assessment", "Aggregated Risk Analysis"))
+        # Put in a dedicated tag
+        aggregated_check.in_tag(cy.tag("risk_assessment", "Aggregated Risk Analysis"))
 
         logger.info(f"Aggregated risk assessment complete: score={risk_score}")
         logger.info(f"Risk indicators: {len(risk_indicators)}")
@@ -500,7 +492,9 @@ class AI(BaseRule):
 
     def run(self, cy: Cyvest) -> None:
         """Calculate aggregated risk score based on all previous checks."""
-        cy.check("ai", "AI Analysis", score=0, level=cy.LVL.MALICIOUS)
+        cy.check("ai", "AI Analysis", score=0, level=cy.LVL.MALICIOUS).in_tag(
+            cy.tag("risk_assessment:ai", "AI Analysis Tag")
+        )
 
 
 # ============================================================================

--- a/examples/05_visualization.py
+++ b/examples/05_visualization.py
@@ -122,7 +122,7 @@ def main(no_audit_log: bool = False, output: Path | None = None) -> None:
         .link_observable(attacker_email)
         .link_observable(victim_email)
         .with_score(8.0)
-        .in_container(cv.container("phishing_investigation/email"))
+        .in_tag(cv.tag("phishing:investigation:email"))
     )
 
     _ = (
@@ -130,7 +130,7 @@ def main(no_audit_log: bool = False, output: Path | None = None) -> None:
         .link_observable(phishing_url1)
         .link_observable(phishing_url2)
         .with_score(9.0)
-        .in_container(cv.container("phishing_investigation/network"))
+        .in_tag(cv.tag("phishing:investigation:network"))
     )
 
     _ = (
@@ -138,14 +138,14 @@ def main(no_audit_log: bool = False, output: Path | None = None) -> None:
         .link_observable(malicious_domain)
         .link_observable(malicious_ip)
         .with_score(9.5)
-        .in_container(cv.container("phishing_investigation/network"))
+        .in_tag(cv.tag("phishing:investigation:network"))
     )
 
     _ = (
         cv.check("malware_detection", "Malware file analysis")
         .link_observable(malware_file)
         .with_score(10.0)
-        .in_container(cv.container("phishing_investigation/malware"))
+        .in_tag(cv.tag("phishing:investigation:malware"))
     )
 
     # Finalize relationships
@@ -169,9 +169,9 @@ def main(no_audit_log: bool = False, output: Path | None = None) -> None:
 
     # Example: Export to markdown (with optional sections)
     logger.info("[bold cyan]Exporting to Markdown...[/bold cyan]")
-    # Export with containers and enrichments included
+    # Export with tags and enrichments included
     tmp_path = Path(tempfile.gettempdir()) / "investigation_report_full.md"
-    markdown_full_path = cv.io_save_markdown(tmp_path, include_containers=True, include_enrichments=True)
+    markdown_full_path = cv.io_save_markdown(tmp_path, include_tags=True, include_enrichments=True)
     logger.info(f"[green]✓ Full markdown report saved to: {markdown_full_path}[/green]")
 
 

--- a/examples/05_visualization.py
+++ b/examples/05_visualization.py
@@ -117,7 +117,7 @@ def main(no_audit_log: bool = False, output: Path | None = None) -> None:
 
     # Create checks linking observables
     _ = (
-        cv.check("email_analysis", "email", "Phishing email analysis")
+        cv.check("email_analysis", "Phishing email analysis")
         .link_observable(email_message)
         .link_observable(attacker_email)
         .link_observable(victim_email)
@@ -126,7 +126,7 @@ def main(no_audit_log: bool = False, output: Path | None = None) -> None:
     )
 
     _ = (
-        cv.check("url_analysis", "network", "Malicious URLs found in email")
+        cv.check("url_analysis", "Malicious URLs found in email")
         .link_observable(phishing_url1)
         .link_observable(phishing_url2)
         .with_score(9.0)
@@ -134,7 +134,7 @@ def main(no_audit_log: bool = False, output: Path | None = None) -> None:
     )
 
     _ = (
-        cv.check("infrastructure", "network", "Malicious infrastructure identified")
+        cv.check("infrastructure", "Malicious infrastructure identified")
         .link_observable(malicious_domain)
         .link_observable(malicious_ip)
         .with_score(9.5)
@@ -142,7 +142,7 @@ def main(no_audit_log: bool = False, output: Path | None = None) -> None:
     )
 
     _ = (
-        cv.check("malware_detection", "file", "Malware file analysis")
+        cv.check("malware_detection", "Malware file analysis")
         .link_observable(malware_file)
         .with_score(10.0)
         .in_container(cv.container("phishing_investigation/malware"))

--- a/js/packages/cyvest-app/src/investigations/cyvest_email.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_email.json
@@ -92,8 +92,8 @@
       ],
       "key": "obs:email:noreply@dmalicious.com",
       "check_links": [
-        "chk:from-proofpoint:header",
-        "chk:from:header"
+        "chk:from",
+        "chk:from-proofpoint"
       ],
       "score_display": "5.00"
     },
@@ -156,7 +156,7 @@
       ],
       "key": "obs:email:user@company.com",
       "check_links": [
-        "chk:receiver:header"
+        "chk:receiver"
       ],
       "score_display": "0.00"
     },
@@ -181,7 +181,7 @@
       ],
       "key": "obs:url:https://virus.com/payload.exe",
       "check_links": [
-        "chk:body-url-https://virus.com/payload.exe:body"
+        "chk:body-url-https://virus.com/payload.exe"
       ],
       "score_display": "5.00"
     },
@@ -206,7 +206,7 @@
       ],
       "key": "obs:domain:virus.com",
       "check_links": [
-        "chk:body-domain-virus.com:body"
+        "chk:body-domain-virus.com"
       ],
       "score_display": "5.00"
     },
@@ -231,7 +231,7 @@
       ],
       "key": "obs:url:https://virus.com/about",
       "check_links": [
-        "chk:body-url-https://virus.com/about:body"
+        "chk:body-url-https://virus.com/about"
       ],
       "score_display": "3.00"
     },
@@ -256,7 +256,7 @@
       ],
       "key": "obs:url:https://domain.com/ok/toto",
       "check_links": [
-        "chk:body-url-https://domain.com/ok/toto:body"
+        "chk:body-url-https://domain.com/ok/toto"
       ],
       "score_display": "-1.00"
     },
@@ -281,7 +281,7 @@
       ],
       "key": "obs:domain:domain.com",
       "check_links": [
-        "chk:body-domain-domain.com:body"
+        "chk:body-domain-domain.com"
       ],
       "score_display": "0.00"
     },
@@ -332,7 +332,7 @@
       ],
       "key": "obs:file:invoice.pdf",
       "check_links": [
-        "chk:attachment-invoice.pdf:attachment"
+        "chk:attachment-invoice.pdf"
       ],
       "score_display": "10.00"
     },
@@ -355,202 +355,183 @@
     }
   },
   "checks": {
-    "header": [
-      {
-        "check_id": "from",
-        "scope": "header",
-        "description": "test email vt 10",
-        "comment": "> ok boys",
-        "extra": {},
-        "score": 2.0,
-        "level": "NOTABLE",
-        "origin_investigation_id": "fragment-emailfrom",
-        "observable_links": [
-          {
-            "observable_key": "obs:email:noreply@dmalicious.com",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:from:header",
-        "score_display": "2.00"
-      },
-      {
-        "check_id": "from-proofpoint",
-        "scope": "header",
-        "description": "test email vt 10",
-        "comment": "> ok boys",
-        "extra": {},
-        "score": 5.0,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "fragment-emailfrombis",
-        "observable_links": [
-          {
-            "observable_key": "obs:email:noreply@dmalicious.com",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:from-proofpoint:header",
-        "score_display": "5.00"
-      },
-      {
-        "check_id": "receiver",
-        "scope": "header",
-        "description": "description",
-        "comment": "> receiver",
-        "extra": {},
-        "score": 0.1,
-        "level": "NOTABLE",
-        "origin_investigation_id": "fragment-emailreciever",
-        "observable_links": [
-          {
-            "observable_key": "obs:email:user@company.com",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:receiver:header",
-        "score_display": "0.10"
-      }
-    ],
-    "body": [
-      {
-        "check_id": "body-url-https://virus.com/payload.exe",
-        "scope": "body",
-        "description": "URL analysis https://virus.com/payload.exe",
-        "comment": "> score: 5",
-        "extra": {},
-        "score": 5.0,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "fragment-bodiesurltask",
-        "observable_links": [
-          {
-            "observable_key": "obs:url:https://virus.com/payload.exe",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:body-url-https://virus.com/payload.exe:body",
-        "score_display": "5.00"
-      },
-      {
-        "check_id": "body-url-https://virus.com/about",
-        "scope": "body",
-        "description": "URL analysis https://virus.com/about",
-        "comment": "> score: 3",
-        "extra": {},
-        "score": 3.0,
-        "level": "SUSPICIOUS",
-        "origin_investigation_id": "fragment-bodiesurltask",
-        "observable_links": [
-          {
-            "observable_key": "obs:url:https://virus.com/about",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:body-url-https://virus.com/about:body",
-        "score_display": "3.00"
-      },
-      {
-        "check_id": "body-url-https://domain.com/ok/toto",
-        "scope": "body",
-        "description": "URL analysis https://domain.com/ok/toto",
-        "comment": "> score: -1",
-        "extra": {},
-        "score": 0.0,
-        "level": "INFO",
-        "origin_investigation_id": "fragment-bodiesurltask",
-        "observable_links": [
-          {
-            "observable_key": "obs:url:https://domain.com/ok/toto",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:body-url-https://domain.com/ok/toto:body",
-        "score_display": "0.00"
-      },
-      {
-        "check_id": "body-domain-virus.com",
-        "scope": "body",
-        "description": "Domain analysis virus.com",
-        "comment": "> score: 3",
-        "extra": {},
-        "score": 5.0,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "fragment-bodiesdomaintask",
-        "observable_links": [
-          {
-            "observable_key": "obs:domain:virus.com",
-            "propagation_mode": "GLOBAL"
-          }
-        ],
-        "key": "chk:body-domain-virus.com:body",
-        "score_display": "5.00"
-      },
-      {
-        "check_id": "body-domain-domain.com",
-        "scope": "body",
-        "description": "Domain analysis domain.com",
-        "comment": "> score: 0",
-        "extra": {},
-        "score": 0.0,
-        "level": "INFO",
-        "origin_investigation_id": "fragment-bodiesdomaintask",
-        "observable_links": [
-          {
-            "observable_key": "obs:domain:domain.com",
-            "propagation_mode": "GLOBAL"
-          }
-        ],
-        "key": "chk:body-domain-domain.com:body",
-        "score_display": "0.00"
-      }
-    ],
-    "attachment": [
-      {
-        "check_id": "attachment-invoice.pdf",
-        "scope": "attachment",
-        "description": "File: invoice.pdf (1024 bytes)",
-        "comment": "> MD5: d41d8cd98f00b204e9800998ecf8427e\n> SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n> Threat score: 10",
-        "extra": {},
-        "score": 10.0,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "fragment-attachmenttask",
-        "observable_links": [
-          {
-            "observable_key": "obs:file:invoice.pdf",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:attachment-invoice.pdf:attachment",
-        "score_display": "10.00"
-      }
-    ],
-    "full": [
-      {
-        "check_id": "email_risk_aggregated",
-        "scope": "full",
-        "description": "Aggregated Email Risk Assessment",
-        "comment": "> **Aggregated Risk Assessment**\n> Total risk score: 6.0\n> Indicators analyzed: 2\n>\n> **Risk Factors:**\n> - Suspicious URLs detected (max score: 5)\n> - Malicious attachment detected (score: 10)\n>\n> **Component Analysis:**\n> - Header checks: 2\n> - URL checks: 3\n> - Attachment checks: 2\n",
-        "extra": {},
-        "score": 6.0,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "fragment-aggregatedrisktask",
-        "observable_links": [],
-        "key": "chk:email_risk_aggregated:full",
-        "score_display": "6.00"
-      },
-      {
-        "check_id": "ai",
-        "scope": "full",
-        "description": "ai",
-        "comment": "",
-        "extra": {},
-        "score": 0.0,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "fragment-ai",
-        "observable_links": [],
-        "key": "chk:ai:full",
-        "score_display": "0.00"
-      }
-    ]
+    "chk:from": {
+      "check_name": "from",
+      "description": "test email vt 10",
+      "comment": "> ok boys",
+      "extra": {},
+      "score": 2.0,
+      "level": "NOTABLE",
+      "origin_investigation_id": "fragment-emailfrom",
+      "observable_links": [
+        {
+          "observable_key": "obs:email:noreply@dmalicious.com",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:from",
+      "score_display": "2.00"
+    },
+    "chk:from-proofpoint": {
+      "check_name": "from-proofpoint",
+      "description": "test email vt 10",
+      "comment": "> ok boys",
+      "extra": {},
+      "score": 5.0,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "fragment-emailfrombis",
+      "observable_links": [
+        {
+          "observable_key": "obs:email:noreply@dmalicious.com",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:from-proofpoint",
+      "score_display": "5.00"
+    },
+    "chk:receiver": {
+      "check_name": "receiver",
+      "description": "description",
+      "comment": "> receiver",
+      "extra": {},
+      "score": 0.1,
+      "level": "NOTABLE",
+      "origin_investigation_id": "fragment-emailreciever",
+      "observable_links": [
+        {
+          "observable_key": "obs:email:user@company.com",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:receiver",
+      "score_display": "0.10"
+    },
+    "chk:body-url-https://virus.com/payload.exe": {
+      "check_name": "body-url-https://virus.com/payload.exe",
+      "description": "URL analysis https://virus.com/payload.exe",
+      "comment": "> score: 5",
+      "extra": {},
+      "score": 5.0,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "fragment-bodiesurltask",
+      "observable_links": [
+        {
+          "observable_key": "obs:url:https://virus.com/payload.exe",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:body-url-https://virus.com/payload.exe",
+      "score_display": "5.00"
+    },
+    "chk:body-url-https://virus.com/about": {
+      "check_name": "body-url-https://virus.com/about",
+      "description": "URL analysis https://virus.com/about",
+      "comment": "> score: 3",
+      "extra": {},
+      "score": 3.0,
+      "level": "SUSPICIOUS",
+      "origin_investigation_id": "fragment-bodiesurltask",
+      "observable_links": [
+        {
+          "observable_key": "obs:url:https://virus.com/about",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:body-url-https://virus.com/about",
+      "score_display": "3.00"
+    },
+    "chk:body-url-https://domain.com/ok/toto": {
+      "check_name": "body-url-https://domain.com/ok/toto",
+      "description": "URL analysis https://domain.com/ok/toto",
+      "comment": "> score: -1",
+      "extra": {},
+      "score": 0.0,
+      "level": "INFO",
+      "origin_investigation_id": "fragment-bodiesurltask",
+      "observable_links": [
+        {
+          "observable_key": "obs:url:https://domain.com/ok/toto",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:body-url-https://domain.com/ok/toto",
+      "score_display": "0.00"
+    },
+    "chk:body-domain-virus.com": {
+      "check_name": "body-domain-virus.com",
+      "description": "Domain analysis virus.com",
+      "comment": "> score: 3",
+      "extra": {},
+      "score": 5.0,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "fragment-bodiesdomaintask",
+      "observable_links": [
+        {
+          "observable_key": "obs:domain:virus.com",
+          "propagation_mode": "GLOBAL"
+        }
+      ],
+      "key": "chk:body-domain-virus.com",
+      "score_display": "5.00"
+    },
+    "chk:body-domain-domain.com": {
+      "check_name": "body-domain-domain.com",
+      "description": "Domain analysis domain.com",
+      "comment": "> score: 0",
+      "extra": {},
+      "score": 0.0,
+      "level": "INFO",
+      "origin_investigation_id": "fragment-bodiesdomaintask",
+      "observable_links": [
+        {
+          "observable_key": "obs:domain:domain.com",
+          "propagation_mode": "GLOBAL"
+        }
+      ],
+      "key": "chk:body-domain-domain.com",
+      "score_display": "0.00"
+    },
+    "chk:attachment-invoice.pdf": {
+      "check_name": "attachment-invoice.pdf",
+      "description": "File: invoice.pdf (1024 bytes)",
+      "comment": "> MD5: d41d8cd98f00b204e9800998ecf8427e\n> SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n> Threat score: 10",
+      "extra": {},
+      "score": 10.0,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "fragment-attachmenttask",
+      "observable_links": [
+        {
+          "observable_key": "obs:file:invoice.pdf",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:attachment-invoice.pdf",
+      "score_display": "10.00"
+    },
+    "chk:email_risk_aggregated": {
+      "check_name": "email_risk_aggregated",
+      "description": "Aggregated Email Risk Assessment",
+      "comment": "> **Aggregated Risk Assessment**\n> Total risk score: 6.0\n> Indicators analyzed: 2\n>\n> **Risk Factors:**\n> - Suspicious URLs detected (max score: 5)\n> - Malicious attachment detected (score: 10)\n>\n> **Component Analysis:**\n> - Header checks: 2\n> - URL checks: 3\n> - Attachment checks: 2\n",
+      "extra": {},
+      "score": 6.0,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "fragment-aggregatedrisktask",
+      "observable_links": [],
+      "key": "chk:email_risk_aggregated",
+      "score_display": "6.00"
+    },
+    "chk:ai": {
+      "check_name": "ai",
+      "description": "AI Analysis",
+      "comment": "",
+      "extra": {},
+      "score": 0.0,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "fragment-ai",
+      "observable_links": [],
+      "key": "chk:ai",
+      "score_display": "0.00"
+    }
   },
   "threat_intels": {
     "ti:vt:obs:domain:dmalicious.com": {
@@ -692,9 +673,9 @@
       "path": "emails",
       "description": "",
       "checks": [
-        "chk:from:header",
-        "chk:from-proofpoint:header",
-        "chk:receiver:header"
+        "chk:from",
+        "chk:from-proofpoint",
+        "chk:receiver"
       ],
       "sub_containers": {},
       "key": "ctr:emails",
@@ -705,9 +686,9 @@
       "path": "bodies-urls",
       "description": "Bodies URLs Analysis",
       "checks": [
-        "chk:body-url-https://virus.com/payload.exe:body",
-        "chk:body-url-https://virus.com/about:body",
-        "chk:body-url-https://domain.com/ok/toto:body"
+        "chk:body-url-https://virus.com/payload.exe",
+        "chk:body-url-https://virus.com/about",
+        "chk:body-url-https://domain.com/ok/toto"
       ],
       "sub_containers": {},
       "key": "ctr:bodies-urls",
@@ -718,8 +699,8 @@
       "path": "bodies-domains",
       "description": "Bodies Domains Analysis",
       "checks": [
-        "chk:body-domain-virus.com:body",
-        "chk:body-domain-domain.com:body"
+        "chk:body-domain-virus.com",
+        "chk:body-domain-domain.com"
       ],
       "sub_containers": {},
       "key": "ctr:bodies-domains",
@@ -730,7 +711,7 @@
       "path": "attachments",
       "description": "Email Attachments Analysis",
       "checks": [
-        "chk:attachment-invoice.pdf:attachment"
+        "chk:attachment-invoice.pdf"
       ],
       "sub_containers": {},
       "key": "ctr:attachments",
@@ -741,7 +722,7 @@
       "path": "risk_assessment",
       "description": "Aggregated Risk Analysis",
       "checks": [
-        "chk:email_risk_aggregated:full"
+        "chk:email_risk_aggregated"
       ],
       "sub_containers": {},
       "key": "ctr:risk_assessment",
@@ -800,46 +781,25 @@
     },
     "total_checks": 11,
     "applied_checks": 11,
-    "checks_by_scope": {
-      "header": [
-        "chk:from:header",
-        "chk:from-proofpoint:header",
-        "chk:receiver:header"
-      ],
-      "body": [
-        "chk:body-url-https://virus.com/payload.exe:body",
-        "chk:body-url-https://virus.com/about:body",
-        "chk:body-url-https://domain.com/ok/toto:body",
-        "chk:body-domain-virus.com:body",
-        "chk:body-domain-domain.com:body"
-      ],
-      "attachment": [
-        "chk:attachment-invoice.pdf:attachment"
-      ],
-      "full": [
-        "chk:email_risk_aggregated:full",
-        "chk:ai:full"
-      ]
-    },
     "checks_by_level": {
       "NOTABLE": [
-        "chk:from:header",
-        "chk:receiver:header"
+        "chk:from",
+        "chk:receiver"
       ],
       "MALICIOUS": [
-        "chk:from-proofpoint:header",
-        "chk:body-url-https://virus.com/payload.exe:body",
-        "chk:body-domain-virus.com:body",
-        "chk:attachment-invoice.pdf:attachment",
-        "chk:email_risk_aggregated:full",
-        "chk:ai:full"
+        "chk:from-proofpoint",
+        "chk:body-url-https://virus.com/payload.exe",
+        "chk:body-domain-virus.com",
+        "chk:attachment-invoice.pdf",
+        "chk:email_risk_aggregated",
+        "chk:ai"
       ],
       "SUSPICIOUS": [
-        "chk:body-url-https://virus.com/about:body"
+        "chk:body-url-https://virus.com/about"
       ],
       "INFO": [
-        "chk:body-url-https://domain.com/ok/toto:body",
-        "chk:body-domain-domain.com:body"
+        "chk:body-url-https://domain.com/ok/toto",
+        "chk:body-domain-domain.com"
       ]
     },
     "total_threat_intel": 11,

--- a/js/packages/cyvest-app/src/investigations/cyvest_email.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_email.json
@@ -668,66 +668,79 @@
       "key": "enr:receiver:1528478e"
     }
   },
-  "containers": {
-    "ctr:emails": {
-      "path": "emails",
+  "tags": {
+    "tag:emails": {
+      "name": "emails",
       "description": "",
       "checks": [
         "chk:from",
         "chk:from-proofpoint",
         "chk:receiver"
       ],
-      "sub_containers": {},
-      "key": "ctr:emails",
-      "aggregated_score": 7.1,
-      "aggregated_level": "MALICIOUS"
+      "key": "tag:emails",
+      "direct_score": 7.1,
+      "direct_level": "MALICIOUS"
     },
-    "ctr:bodies-urls": {
-      "path": "bodies-urls",
+    "tag:bodies": {
+      "name": "bodies",
+      "description": "",
+      "checks": [],
+      "key": "tag:bodies",
+      "direct_score": 0.0,
+      "direct_level": "INFO"
+    },
+    "tag:bodies:urls": {
+      "name": "bodies:urls",
       "description": "Bodies URLs Analysis",
       "checks": [
         "chk:body-url-https://virus.com/payload.exe",
         "chk:body-url-https://virus.com/about",
         "chk:body-url-https://domain.com/ok/toto"
       ],
-      "sub_containers": {},
-      "key": "ctr:bodies-urls",
-      "aggregated_score": 8.0,
-      "aggregated_level": "MALICIOUS"
+      "key": "tag:bodies:urls",
+      "direct_score": 8.0,
+      "direct_level": "MALICIOUS"
     },
-    "ctr:bodies-domains": {
-      "path": "bodies-domains",
+    "tag:bodies:domains": {
+      "name": "bodies:domains",
       "description": "Bodies Domains Analysis",
       "checks": [
         "chk:body-domain-virus.com",
         "chk:body-domain-domain.com"
       ],
-      "sub_containers": {},
-      "key": "ctr:bodies-domains",
-      "aggregated_score": 5.0,
-      "aggregated_level": "MALICIOUS"
+      "key": "tag:bodies:domains",
+      "direct_score": 5.0,
+      "direct_level": "MALICIOUS"
     },
-    "ctr:attachments": {
-      "path": "attachments",
+    "tag:attachments": {
+      "name": "attachments",
       "description": "Email Attachments Analysis",
       "checks": [
         "chk:attachment-invoice.pdf"
       ],
-      "sub_containers": {},
-      "key": "ctr:attachments",
-      "aggregated_score": 10.0,
-      "aggregated_level": "MALICIOUS"
+      "key": "tag:attachments",
+      "direct_score": 10.0,
+      "direct_level": "MALICIOUS"
     },
-    "ctr:risk_assessment": {
-      "path": "risk_assessment",
+    "tag:risk_assessment": {
+      "name": "risk_assessment",
       "description": "Aggregated Risk Analysis",
       "checks": [
         "chk:email_risk_aggregated"
       ],
-      "sub_containers": {},
-      "key": "ctr:risk_assessment",
-      "aggregated_score": 6.0,
-      "aggregated_level": "MALICIOUS"
+      "key": "tag:risk_assessment",
+      "direct_score": 6.0,
+      "direct_level": "MALICIOUS"
+    },
+    "tag:risk_assessment:ai": {
+      "name": "risk_assessment:ai",
+      "description": "AI Analysis Tag",
+      "checks": [
+        "chk:ai"
+      ],
+      "key": "tag:risk_assessment:ai",
+      "direct_score": 0.0,
+      "direct_level": "INFO"
     }
   },
   "stats": {
@@ -816,7 +829,7 @@
       "SUSPICIOUS": 2,
       "TRUSTED": 1
     },
-    "total_containers": 5
+    "total_tags": 7
   },
   "data_extraction": {
     "root_type": "artifact",

--- a/js/packages/cyvest-app/src/investigations/cyvest_visual.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_visual.json
@@ -559,40 +559,53 @@
     }
   },
   "enrichments": {},
-  "containers": {
-    "ctr:phishing_investigation/email": {
-      "path": "phishing_investigation/email",
+  "tags": {
+    "tag:phishing": {
+      "name": "phishing",
+      "description": "",
+      "checks": [],
+      "key": "tag:phishing",
+      "direct_score": 0.0,
+      "direct_level": "INFO"
+    },
+    "tag:phishing:investigation": {
+      "name": "phishing:investigation",
+      "description": "",
+      "checks": [],
+      "key": "tag:phishing:investigation",
+      "direct_score": 0.0,
+      "direct_level": "INFO"
+    },
+    "tag:phishing:investigation:email": {
+      "name": "phishing:investigation:email",
       "description": "",
       "checks": [
         "chk:email_analysis"
       ],
-      "sub_containers": {},
-      "key": "ctr:phishing_investigation/email",
-      "aggregated_score": 10.0,
-      "aggregated_level": "MALICIOUS"
+      "key": "tag:phishing:investigation:email",
+      "direct_score": 10.0,
+      "direct_level": "MALICIOUS"
     },
-    "ctr:phishing_investigation/network": {
-      "path": "phishing_investigation/network",
+    "tag:phishing:investigation:network": {
+      "name": "phishing:investigation:network",
       "description": "",
       "checks": [
         "chk:url_analysis",
         "chk:infrastructure"
       ],
-      "sub_containers": {},
-      "key": "ctr:phishing_investigation/network",
-      "aggregated_score": 19.5,
-      "aggregated_level": "MALICIOUS"
+      "key": "tag:phishing:investigation:network",
+      "direct_score": 19.5,
+      "direct_level": "MALICIOUS"
     },
-    "ctr:phishing_investigation/malware": {
-      "path": "phishing_investigation/malware",
+    "tag:phishing:investigation:malware": {
+      "name": "phishing:investigation:malware",
       "description": "",
       "checks": [
         "chk:malware_detection"
       ],
-      "sub_containers": {},
-      "key": "ctr:phishing_investigation/malware",
-      "aggregated_score": 10.0,
-      "aggregated_level": "MALICIOUS"
+      "key": "tag:phishing:investigation:malware",
+      "direct_score": 10.0,
+      "direct_level": "MALICIOUS"
     }
   },
   "stats": {
@@ -669,7 +682,7 @@
       "TRUSTED": 2,
       "NOTABLE": 1
     },
-    "total_containers": 3
+    "total_tags": 5
   },
   "data_extraction": {
     "root_type": "file",

--- a/js/packages/cyvest-app/src/investigations/cyvest_visual.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_visual.json
@@ -59,7 +59,7 @@
       "relationships": [],
       "key": "obs:domain:evil-phishing.com",
       "check_links": [
-        "chk:infrastructure:network"
+        "chk:infrastructure"
       ],
       "score_display": "9.00"
     },
@@ -84,7 +84,7 @@
       ],
       "key": "obs:ipv4:185.220.101.50",
       "check_links": [
-        "chk:infrastructure:network"
+        "chk:infrastructure"
       ],
       "score_display": "9.50"
     },
@@ -149,7 +149,7 @@
       ],
       "key": "obs:email:attacker@evil-phishing.com",
       "check_links": [
-        "chk:email_analysis:email"
+        "chk:email_analysis"
       ],
       "score_display": "8.00"
     },
@@ -168,7 +168,7 @@
       "relationships": [],
       "key": "obs:email:victim@company.com",
       "check_links": [
-        "chk:email_analysis:email"
+        "chk:email_analysis"
       ],
       "score_display": "-1.00"
     },
@@ -208,7 +208,7 @@
       ],
       "key": "obs:artifact:phishing email - invoice #12345",
       "check_links": [
-        "chk:email_analysis:email"
+        "chk:email_analysis"
       ],
       "score_display": "10.00"
     },
@@ -233,7 +233,7 @@
       ],
       "key": "obs:url:https://evil-phishing.com/login",
       "check_links": [
-        "chk:url_analysis:network"
+        "chk:url_analysis"
       ],
       "score_display": "10.00"
     },
@@ -258,7 +258,7 @@
       ],
       "key": "obs:url:https://evil-phishing.com/verify",
       "check_links": [
-        "chk:url_analysis:network"
+        "chk:url_analysis"
       ],
       "score_display": "9.00"
     },
@@ -288,7 +288,7 @@
       ],
       "key": "obs:file:invoice.exe",
       "check_links": [
-        "chk:malware_detection:file"
+        "chk:malware_detection"
       ],
       "score_display": "10.00"
     },
@@ -328,100 +328,90 @@
     }
   },
   "checks": {
-    "email": [
-      {
-        "check_id": "email_analysis",
-        "scope": "email",
-        "description": "Phishing email analysis",
-        "comment": "",
-        "extra": {},
-        "score": 10.0,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "cyvest-visual-example",
-        "observable_links": [
-          {
-            "observable_key": "obs:artifact:phishing email - invoice #12345",
-            "propagation_mode": "LOCAL_ONLY"
-          },
-          {
-            "observable_key": "obs:email:attacker@evil-phishing.com",
-            "propagation_mode": "LOCAL_ONLY"
-          },
-          {
-            "observable_key": "obs:email:victim@company.com",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:email_analysis:email",
-        "score_display": "10.00"
-      }
-    ],
-    "network": [
-      {
-        "check_id": "url_analysis",
-        "scope": "network",
-        "description": "Malicious URLs found in email",
-        "comment": "",
-        "extra": {},
-        "score": 10.0,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "cyvest-visual-example",
-        "observable_links": [
-          {
-            "observable_key": "obs:url:https://evil-phishing.com/login",
-            "propagation_mode": "LOCAL_ONLY"
-          },
-          {
-            "observable_key": "obs:url:https://evil-phishing.com/verify",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:url_analysis:network",
-        "score_display": "10.00"
-      },
-      {
-        "check_id": "infrastructure",
-        "scope": "network",
-        "description": "Malicious infrastructure identified",
-        "comment": "",
-        "extra": {},
-        "score": 9.5,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "cyvest-visual-example",
-        "observable_links": [
-          {
-            "observable_key": "obs:domain:evil-phishing.com",
-            "propagation_mode": "LOCAL_ONLY"
-          },
-          {
-            "observable_key": "obs:ipv4:185.220.101.50",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:infrastructure:network",
-        "score_display": "9.50"
-      }
-    ],
-    "file": [
-      {
-        "check_id": "malware_detection",
-        "scope": "file",
-        "description": "Malware file analysis",
-        "comment": "",
-        "extra": {},
-        "score": 10.0,
-        "level": "MALICIOUS",
-        "origin_investigation_id": "cyvest-visual-example",
-        "observable_links": [
-          {
-            "observable_key": "obs:file:invoice.exe",
-            "propagation_mode": "LOCAL_ONLY"
-          }
-        ],
-        "key": "chk:malware_detection:file",
-        "score_display": "10.00"
-      }
-    ]
+    "chk:email_analysis": {
+      "check_name": "email_analysis",
+      "description": "Phishing email analysis",
+      "comment": "",
+      "extra": {},
+      "score": 10.0,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "cyvest-visual-example",
+      "observable_links": [
+        {
+          "observable_key": "obs:artifact:phishing email - invoice #12345",
+          "propagation_mode": "LOCAL_ONLY"
+        },
+        {
+          "observable_key": "obs:email:attacker@evil-phishing.com",
+          "propagation_mode": "LOCAL_ONLY"
+        },
+        {
+          "observable_key": "obs:email:victim@company.com",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:email_analysis",
+      "score_display": "10.00"
+    },
+    "chk:url_analysis": {
+      "check_name": "url_analysis",
+      "description": "Malicious URLs found in email",
+      "comment": "",
+      "extra": {},
+      "score": 10.0,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "cyvest-visual-example",
+      "observable_links": [
+        {
+          "observable_key": "obs:url:https://evil-phishing.com/login",
+          "propagation_mode": "LOCAL_ONLY"
+        },
+        {
+          "observable_key": "obs:url:https://evil-phishing.com/verify",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:url_analysis",
+      "score_display": "10.00"
+    },
+    "chk:infrastructure": {
+      "check_name": "infrastructure",
+      "description": "Malicious infrastructure identified",
+      "comment": "",
+      "extra": {},
+      "score": 9.5,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "cyvest-visual-example",
+      "observable_links": [
+        {
+          "observable_key": "obs:domain:evil-phishing.com",
+          "propagation_mode": "LOCAL_ONLY"
+        },
+        {
+          "observable_key": "obs:ipv4:185.220.101.50",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:infrastructure",
+      "score_display": "9.50"
+    },
+    "chk:malware_detection": {
+      "check_name": "malware_detection",
+      "description": "Malware file analysis",
+      "comment": "",
+      "extra": {},
+      "score": 10.0,
+      "level": "MALICIOUS",
+      "origin_investigation_id": "cyvest-visual-example",
+      "observable_links": [
+        {
+          "observable_key": "obs:file:invoice.exe",
+          "propagation_mode": "LOCAL_ONLY"
+        }
+      ],
+      "key": "chk:malware_detection",
+      "score_display": "10.00"
+    }
   },
   "threat_intels": {
     "ti:virustotal:obs:domain:evil-phishing.com": {
@@ -574,7 +564,7 @@
       "path": "phishing_investigation/email",
       "description": "",
       "checks": [
-        "chk:email_analysis:email"
+        "chk:email_analysis"
       ],
       "sub_containers": {},
       "key": "ctr:phishing_investigation/email",
@@ -585,8 +575,8 @@
       "path": "phishing_investigation/network",
       "description": "",
       "checks": [
-        "chk:url_analysis:network",
-        "chk:infrastructure:network"
+        "chk:url_analysis",
+        "chk:infrastructure"
       ],
       "sub_containers": {},
       "key": "ctr:phishing_investigation/network",
@@ -597,7 +587,7 @@
       "path": "phishing_investigation/malware",
       "description": "",
       "checks": [
-        "chk:malware_detection:file"
+        "chk:malware_detection"
       ],
       "sub_containers": {},
       "key": "ctr:phishing_investigation/malware",
@@ -653,24 +643,12 @@
     },
     "total_checks": 4,
     "applied_checks": 4,
-    "checks_by_scope": {
-      "email": [
-        "chk:email_analysis:email"
-      ],
-      "network": [
-        "chk:url_analysis:network",
-        "chk:infrastructure:network"
-      ],
-      "file": [
-        "chk:malware_detection:file"
-      ]
-    },
     "checks_by_level": {
       "MALICIOUS": [
-        "chk:email_analysis:email",
-        "chk:url_analysis:network",
-        "chk:infrastructure:network",
-        "chk:malware_detection:file"
+        "chk:email_analysis",
+        "chk:url_analysis",
+        "chk:infrastructure",
+        "chk:malware_detection"
       ]
     },
     "total_threat_intel": 13,

--- a/js/packages/cyvest-js/README.md
+++ b/js/packages/cyvest-js/README.md
@@ -5,7 +5,8 @@ TypeScript utilities and generated types for working with serialized Cyvest inve
 ## What it does
 
 - Validates Cyvest JSON payloads against the schema (AJV) and returns typed investigations.
-- Ships generated TypeScript types plus helpers to query observables, checks, threat intel, and relationships.
+- Ships generated TypeScript types plus helpers to query observables, checks, threat intel, tags, and relationships.
+- Provides tag hierarchy utilities including aggregated score/level calculations.
 - Builds lightweight graph representations for use in visualizers or custom tooling.
 
 ## Install & build

--- a/js/packages/cyvest-js/src/finders.ts
+++ b/js/packages/cyvest-js/src/finders.ts
@@ -188,39 +188,6 @@ export function findObservablesWithThreatIntel(
 // ============================================================================
 
 /**
- * Find all checks in a specific scope.
- *
- * @param inv - The investigation to search
- * @param scope - Check scope
- * @returns Array of checks in the scope
- *
- * @example
- * ```ts
- * const emailChecks = findChecksByScope(investigation, "email_headers");
- * ```
- */
-export function findChecksByScope(
-  inv: CyvestInvestigation,
-  scope: string
-): Check[] {
-  const normalizedScope = scope.trim().toLowerCase();
-
-  // Try direct lookup first
-  if (inv.checks[scope]) {
-    return inv.checks[scope];
-  }
-
-  // Fallback to normalized search
-  for (const [key, checks] of Object.entries(inv.checks)) {
-    if (key.toLowerCase() === normalizedScope) {
-      return checks;
-    }
-  }
-
-  return [];
-}
-
-/**
  * Find all checks at a specific level.
  *
  * @param inv - The investigation to search
@@ -231,15 +198,7 @@ export function findChecksByLevel(
   inv: CyvestInvestigation,
   level: Level
 ): Check[] {
-  const result: Check[] = [];
-  for (const checks of Object.values(inv.checks)) {
-    for (const check of checks) {
-      if (check.level === level) {
-        result.push(check);
-      }
-    }
-  }
-  return result;
+  return Object.values(inv.checks).filter((check) => check.level === level);
 }
 
 /**
@@ -253,39 +212,26 @@ export function findChecksAtLeast(
   inv: CyvestInvestigation,
   minLevel: Level
 ): Check[] {
-  const result: Check[] = [];
-  for (const checks of Object.values(inv.checks)) {
-    for (const check of checks) {
-      if (isLevelAtLeast(check.level, minLevel)) {
-        result.push(check);
-      }
-    }
-  }
-  return result;
+  return Object.values(inv.checks).filter((check) =>
+    isLevelAtLeast(check.level, minLevel)
+  );
 }
 
 /**
- * Find checks by check ID (across all scopes).
+ * Find checks by check name.
  *
  * @param inv - The investigation to search
- * @param checkId - Check identifier to search for
- * @returns Array of matching checks
+ * @param checkName - Check name to search for
+ * @returns The matching check or undefined
  */
-export function findChecksByCheckId(
+export function findCheckByName(
   inv: CyvestInvestigation,
-  checkId: string
-): Check[] {
-  const normalizedId = checkId.trim().toLowerCase();
-  const result: Check[] = [];
-
-  for (const checks of Object.values(inv.checks)) {
-    for (const check of checks) {
-      if (check.check_id.toLowerCase() === normalizedId) {
-        result.push(check);
-      }
-    }
-  }
-  return result;
+  checkName: string
+): Check | undefined {
+  const normalizedName = checkName.trim().toLowerCase();
+  return Object.values(inv.checks).find(
+    (check) => check.check_name.toLowerCase() === normalizedName
+  );
 }
 
 // ============================================================================
@@ -417,18 +363,11 @@ export function getChecksForObservable(
 ): Check[] {
   const result: Check[] = [];
   const seen = new Set<string>();
-  const checkLookup = new Map<string, Check>();
-
-  for (const checks of Object.values(inv.checks)) {
-    for (const check of checks) {
-      checkLookup.set(check.key, check);
-    }
-  }
 
   const observable = inv.observables[observableKey];
   if (observable) {
     for (const checkKey of observable.check_links) {
-      const check = checkLookup.get(checkKey);
+      const check = inv.checks[checkKey];
       if (check && !seen.has(check.key)) {
         result.push(check);
         seen.add(check.key);
@@ -436,7 +375,7 @@ export function getChecksForObservable(
     }
   }
 
-  for (const check of checkLookup.values()) {
+  for (const check of Object.values(inv.checks)) {
     if (seen.has(check.key)) {
       continue;
     }
@@ -486,20 +425,16 @@ export function getObservablesForCheck(
   inv: CyvestInvestigation,
   checkKey: string
 ): Observable[] {
-  // Find the check
-  for (const checks of Object.values(inv.checks)) {
-    for (const check of checks) {
-      if (check.key === checkKey) {
-        const keys = new Set<string>();
-        for (const link of check.observable_links) {
-          keys.add(link.observable_key);
-        }
-
-        return Array.from(keys)
-          .map((obsKey) => inv.observables[obsKey])
-          .filter((obs): obs is Observable => obs !== undefined);
-      }
+  const check = inv.checks[checkKey];
+  if (check) {
+    const keys = new Set<string>();
+    for (const link of check.observable_links) {
+      keys.add(link.observable_key);
     }
+
+    return Array.from(keys)
+      .map((obsKey) => inv.observables[obsKey])
+      .filter((obs): obs is Observable => obs !== undefined);
   }
   return [];
 }
@@ -534,12 +469,9 @@ export function getChecksForContainer(
 
   function collectChecks(container: Container): void {
     for (const checkKey of container.checks) {
-      for (const checks of Object.values(inv.checks)) {
-        for (const check of checks) {
-          if (check.key === checkKey) {
-            result.push(check);
-          }
-        }
+      const check = inv.checks[checkKey];
+      if (check) {
+        result.push(check);
       }
     }
 
@@ -635,11 +567,7 @@ export function getHighestScoringChecks(
   inv: CyvestInvestigation,
   n = 10
 ): Check[] {
-  const allChecks: Check[] = [];
-  for (const checks of Object.values(inv.checks)) {
-    allChecks.push(...checks);
-  }
-  return sortChecksByScore(allChecks).slice(0, n);
+  return sortChecksByScore(Object.values(inv.checks)).slice(0, n);
 }
 
 /**
@@ -683,12 +611,12 @@ export function getSuspiciousChecks(inv: CyvestInvestigation): Check[] {
 }
 
 /**
- * Get all scopes that have checks.
+ * Get all check keys in the investigation.
  *
  * @param inv - The investigation
- * @returns Array of scope names
+ * @returns Array of check keys
  */
-export function getAllScopes(inv: CyvestInvestigation): string[] {
+export function getAllCheckKeys(inv: CyvestInvestigation): string[] {
   return Object.keys(inv.checks);
 }
 

--- a/js/packages/cyvest-js/src/finders.ts
+++ b/js/packages/cyvest-js/src/finders.ts
@@ -10,7 +10,7 @@ import type {
   Observable,
   Check,
   ThreatIntel,
-  Container,
+  Tag,
   Level,
 } from "./types.generated";
 import { isLevelAtLeast, isLevelHigherThan, LEVEL_VALUES } from "./levels";
@@ -286,59 +286,51 @@ export function findThreatIntelAtLeast(
 }
 
 // ============================================================================
-// Container Finders
+// Tag Finders
 // ============================================================================
 
 /**
- * Find containers at a specific aggregated level.
+ * Find tags at a specific direct level.
  *
  * @param inv - The investigation to search
- * @param level - Aggregated level to filter by
- * @returns Array of matching containers
+ * @param level - Direct level to filter by
+ * @returns Array of matching tags
  */
-export function findContainersByLevel(
+export function findTagsByLevel(
   inv: CyvestInvestigation,
   level: Level
-): Container[] {
-  const result: Container[] = [];
-
-  function searchContainers(containers: Record<string, Container>): void {
-    for (const container of Object.values(containers)) {
-      if (container.aggregated_level === level) {
-        result.push(container);
-      }
-      searchContainers(container.sub_containers);
-    }
-  }
-
-  searchContainers(inv.containers);
-  return result;
+): Tag[] {
+  return Object.values(inv.tags).filter((tag) => tag.direct_level === level);
 }
 
 /**
- * Find containers at or above a minimum aggregated level.
+ * Find tags at or above a minimum direct level.
  *
  * @param inv - The investigation to search
- * @param minLevel - Minimum aggregated level
- * @returns Array of matching containers
+ * @param minLevel - Minimum direct level
+ * @returns Array of matching tags
  */
-export function findContainersAtLeast(
+export function findTagsAtLeast(
   inv: CyvestInvestigation,
   minLevel: Level
-): Container[] {
-  const result: Container[] = [];
+): Tag[] {
+  return Object.values(inv.tags).filter((tag) =>
+    isLevelAtLeast(tag.direct_level, minLevel)
+  );
+}
 
-  function searchContainers(containers: Record<string, Container>): void {
-    for (const container of Object.values(containers)) {
-      if (isLevelAtLeast(container.aggregated_level, minLevel)) {
-        result.push(container);
-      }
-      searchContainers(container.sub_containers);
-    }
-  }
-
-  searchContainers(inv.containers);
-  return result;
+/**
+ * Find tags by name pattern.
+ *
+ * @param inv - The investigation to search
+ * @param pattern - Pattern to match against tag names
+ * @returns Array of matching tags
+ */
+export function findTagsByNamePattern(
+  inv: CyvestInvestigation,
+  pattern: RegExp
+): Tag[] {
+  return Object.values(inv.tags).filter((tag) => pattern.test(tag.name));
 }
 
 // ============================================================================
@@ -346,7 +338,7 @@ export function findContainersAtLeast(
 // ============================================================================
 
 /**
- * Get all checks that generated or reference a specific observable.
+ * Find all checks that generated or reference a specific observable.
  *
  * @param inv - The investigation to search
  * @param observableKey - Key of the observable
@@ -354,10 +346,10 @@ export function findContainersAtLeast(
  *
  * @example
  * ```ts
- * const checks = getChecksForObservable(investigation, "obs:ipv4-addr:192.168.1.1");
+ * const checks = findChecksForObservable(investigation, "obs:ipv4-addr:192.168.1.1");
  * ```
  */
-export function getChecksForObservable(
+export function findChecksForObservable(
   inv: CyvestInvestigation,
   observableKey: string
 ): Check[] {
@@ -390,13 +382,13 @@ export function getChecksForObservable(
 }
 
 /**
- * Get all threat intel entries for a specific observable.
+ * Find all threat intel entries for a specific observable.
  *
  * @param inv - The investigation to search
  * @param observableKey - Key of the observable
  * @returns Array of threat intel for this observable
  */
-export function getThreatIntelsForObservable(
+export function findThreatIntelsForObservable(
   inv: CyvestInvestigation,
   observableKey: string
 ): ThreatIntel[] {
@@ -415,13 +407,13 @@ export function getThreatIntelsForObservable(
 }
 
 /**
- * Get all observables referenced by a specific check.
+ * Find all observables referenced by a specific check.
  *
  * @param inv - The investigation to search
  * @param checkKey - Key of the check
  * @returns Array of observables referenced by this check
  */
-export function getObservablesForCheck(
+export function findObservablesForCheck(
   inv: CyvestInvestigation,
   checkKey: string
 ): Observable[] {
@@ -440,51 +432,46 @@ export function getObservablesForCheck(
 }
 
 /**
- * Get all checks for a specific container.
+ * Find all checks for a specific tag.
  *
  * @param inv - The investigation to search
- * @param containerKey - Key of the container
- * @param recursive - Include checks from sub-containers (default: false)
- * @returns Array of checks in the container
+ * @param tagKey - Key of the tag
+ * @param recursive - Include checks from descendant tags (default: false)
+ * @returns Array of checks in the tag
  */
-export function getChecksForContainer(
+export function findChecksForTag(
   inv: CyvestInvestigation,
-  containerKey: string,
+  tagKey: string,
   recursive = false
 ): Check[] {
   const result: Check[] = [];
+  const tag = inv.tags[tagKey];
 
-  function findContainer(
-    containers: Record<string, Container>
-  ): Container | undefined {
-    for (const container of Object.values(containers)) {
-      if (container.key === containerKey) {
-        return container;
-      }
-      const found = findContainer(container.sub_containers);
-      if (found) return found;
-    }
-    return undefined;
+  if (!tag) {
+    return result;
   }
 
-  function collectChecks(container: Container): void {
-    for (const checkKey of container.checks) {
-      const check = inv.checks[checkKey];
-      if (check) {
-        result.push(check);
-      }
-    }
-
-    if (recursive) {
-      for (const subContainer of Object.values(container.sub_containers)) {
-        collectChecks(subContainer);
-      }
+  // Get direct checks
+  for (const checkKey of tag.checks) {
+    const check = inv.checks[checkKey];
+    if (check) {
+      result.push(check);
     }
   }
 
-  const container = findContainer(inv.containers);
-  if (container) {
-    collectChecks(container);
+  // If recursive, get checks from descendant tags
+  if (recursive) {
+    const prefix = tag.name + ":";
+    for (const otherTag of Object.values(inv.tags)) {
+      if (otherTag.name.startsWith(prefix)) {
+        for (const checkKey of otherTag.checks) {
+          const check = inv.checks[checkKey];
+          if (check) {
+            result.push(check);
+          }
+        }
+      }
+    }
   }
 
   return result;
@@ -543,13 +530,13 @@ export function sortChecksByLevel(checks: Check[]): Check[] {
 // ============================================================================
 
 /**
- * Get the highest scoring observables.
+ * Find the highest scoring observables.
  *
  * @param inv - The investigation to search
  * @param n - Number of results to return (default: 10)
  * @returns Array of highest scoring observables
  */
-export function getHighestScoringObservables(
+export function findHighestScoringObservables(
   inv: CyvestInvestigation,
   n = 10
 ): Observable[] {
@@ -557,13 +544,13 @@ export function getHighestScoringObservables(
 }
 
 /**
- * Get the highest scoring checks.
+ * Find the highest scoring checks.
  *
  * @param inv - The investigation to search
  * @param n - Number of results to return (default: 10)
  * @returns Array of highest scoring checks
  */
-export function getHighestScoringChecks(
+export function findHighestScoringChecks(
   inv: CyvestInvestigation,
   n = 10
 ): Check[] {
@@ -571,42 +558,42 @@ export function getHighestScoringChecks(
 }
 
 /**
- * Get all malicious observables (convenience function).
+ * Find all malicious observables (convenience function).
  *
  * @param inv - The investigation to search
  * @returns Array of malicious observables
  */
-export function getMaliciousObservables(inv: CyvestInvestigation): Observable[] {
+export function findMaliciousObservables(inv: CyvestInvestigation): Observable[] {
   return findObservablesByLevel(inv, "MALICIOUS");
 }
 
 /**
- * Get all suspicious observables (convenience function).
+ * Find all suspicious observables (convenience function).
  *
  * @param inv - The investigation to search
  * @returns Array of suspicious observables
  */
-export function getSuspiciousObservables(inv: CyvestInvestigation): Observable[] {
+export function findSuspiciousObservables(inv: CyvestInvestigation): Observable[] {
   return findObservablesByLevel(inv, "SUSPICIOUS");
 }
 
 /**
- * Get all malicious checks (convenience function).
+ * Find all malicious checks (convenience function).
  *
  * @param inv - The investigation to search
  * @returns Array of malicious checks
  */
-export function getMaliciousChecks(inv: CyvestInvestigation): Check[] {
+export function findMaliciousChecks(inv: CyvestInvestigation): Check[] {
   return findChecksByLevel(inv, "MALICIOUS");
 }
 
 /**
- * Get all suspicious checks (convenience function).
+ * Find all suspicious checks (convenience function).
  *
  * @param inv - The investigation to search
  * @returns Array of suspicious checks
  */
-export function getSuspiciousChecks(inv: CyvestInvestigation): Check[] {
+export function findSuspiciousChecks(inv: CyvestInvestigation): Check[] {
   return findChecksByLevel(inv, "SUSPICIOUS");
 }
 

--- a/js/packages/cyvest-js/src/getters.ts
+++ b/js/packages/cyvest-js/src/getters.ts
@@ -84,60 +84,32 @@ export function getCheck(
   inv: CyvestInvestigation,
   key: string
 ): Check | undefined {
-  for (const checks of Object.values(inv.checks)) {
-    for (const check of checks) {
-      if (check.key === key) {
-        return check;
-      }
-    }
-  }
-  return undefined;
+  return inv.checks[key];
 }
 
 /**
- * Get a check by its ID and scope.
+ * Get a check by its name.
  *
  * @param inv - The investigation to search
- * @param checkId - Check identifier
- * @param scope - Check scope
+ * @param checkName - Check name
  * @returns The check or undefined if not found
  *
  * @example
  * ```ts
- * const check = getCheckByIdScope(investigation, "sender_verification", "email_headers");
+ * const check = getCheckByName(investigation, "sender_verification");
  * ```
  */
-export function getCheckByIdScope(
+export function getCheckByName(
   inv: CyvestInvestigation,
-  checkId: string,
-  scope: string
+  checkName: string
 ): Check | undefined {
-  const normalizedId = checkId.trim().toLowerCase();
-  const normalizedScope = scope.trim().toLowerCase();
-
-  const scopeChecks = inv.checks[normalizedScope] || inv.checks[scope];
-  if (scopeChecks) {
-    return scopeChecks.find(
-      (c) => c.check_id.toLowerCase() === normalizedId
-    );
-  }
-
-  // Fallback: search all scopes
-  for (const checks of Object.values(inv.checks)) {
-    for (const check of checks) {
-      if (
-        check.check_id.toLowerCase() === normalizedId &&
-        check.scope.toLowerCase() === normalizedScope
-      ) {
-        return check;
-      }
-    }
-  }
-  return undefined;
+  const normalizedName = checkName.trim().toLowerCase();
+  const key = `chk:${normalizedName}`;
+  return inv.checks[key];
 }
 
 /**
- * Get all checks as a flat array (not grouped by scope).
+ * Get all checks as an array.
  *
  * @param inv - The investigation
  * @returns Array of all checks
@@ -149,11 +121,7 @@ export function getCheckByIdScope(
  * ```
  */
 export function getAllChecks(inv: CyvestInvestigation): Check[] {
-  const result: Check[] = [];
-  for (const checks of Object.values(inv.checks)) {
-    result.push(...checks);
-  }
-  return result;
+  return Object.values(inv.checks);
 }
 
 /**

--- a/js/packages/cyvest-js/src/getters.ts
+++ b/js/packages/cyvest-js/src/getters.ts
@@ -2,7 +2,7 @@
  * Getter utilities for retrieving entities from a Cyvest Investigation.
  *
  * These functions provide type-safe access to observables, checks, threat intel,
- * enrichments, and containers by their keys.
+ * enrichments, and tags by their keys.
  */
 
 import type {
@@ -11,8 +11,11 @@ import type {
   Check,
   ThreatIntel,
   Enrichment,
-  Container,
+  Tag,
+  Level,
 } from "./types.generated";
+import { generateObservableKey, isTagChildOf } from "./keys";
+import { getLevelFromScore } from "./levels";
 
 /**
  * Get an observable by its key.
@@ -66,6 +69,32 @@ export function getObservableByTypeValue(
     }
   }
   return undefined;
+}
+
+/**
+ * Get the root observable of the investigation.
+ *
+ * The root observable is identified using the `root_type` from data extraction
+ * metadata combined with value="root".
+ *
+ * @param inv - The investigation
+ * @returns The root observable, or undefined if not found
+ *
+ * @example
+ * ```ts
+ * const root = getRootObservable(investigation);
+ * if (root) {
+ *   console.log(`Root: ${root.type} = ${root.value}`);
+ * }
+ * ```
+ */
+export function getRootObservable(inv: CyvestInvestigation): Observable | undefined {
+  const rootType = inv.data_extraction.root_type;
+  if (!rootType) {
+    return undefined;
+  }
+  const rootKey = generateObservableKey(rootType, "root");
+  return inv.observables[rootKey];
 }
 
 /**
@@ -220,81 +249,62 @@ export function getAllEnrichments(inv: CyvestInvestigation): Enrichment[] {
 }
 
 /**
- * Get a container by its key.
+ * Get a tag by its key.
  *
  * @param inv - The investigation to search
- * @param key - Container key (e.g., "ctr:email/headers")
- * @returns The container or undefined if not found
+ * @param key - Tag key (e.g., "tag:header:auth")
+ * @returns The tag or undefined if not found
+ *
+ * @example
+ * ```ts
+ * const tag = getTag(investigation, "tag:header:auth");
+ * if (tag) {
+ *   console.log(tag.name, tag.direct_level);
+ * }
+ * ```
  */
-export function getContainer(
+export function getTag(
   inv: CyvestInvestigation,
   key: string
-): Container | undefined {
-  // First check top-level containers
-  if (inv.containers[key]) {
-    return inv.containers[key];
-  }
-
-  // Search recursively in sub-containers
-  function searchSubContainers(containers: Record<string, Container>): Container | undefined {
-    for (const container of Object.values(containers)) {
-      if (container.key === key) {
-        return container;
-      }
-      const found = searchSubContainers(container.sub_containers);
-      if (found) return found;
-    }
-    return undefined;
-  }
-
-  return searchSubContainers(inv.containers);
+): Tag | undefined {
+  return inv.tags[key];
 }
 
 /**
- * Get a container by its path.
+ * Get a tag by its name.
  *
  * @param inv - The investigation to search
- * @param path - Container path
- * @returns The container or undefined if not found
+ * @param name - Tag name (e.g., "header:auth:dkim")
+ * @returns The tag or undefined if not found
+ *
+ * @example
+ * ```ts
+ * const tag = getTagByName(investigation, "header:auth:dkim");
+ * ```
  */
-export function getContainerByPath(
+export function getTagByName(
   inv: CyvestInvestigation,
-  path: string
-): Container | undefined {
-  const normalizedPath = path.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "").toLowerCase();
-
-  function searchContainers(containers: Record<string, Container>): Container | undefined {
-    for (const container of Object.values(containers)) {
-      if (container.path.toLowerCase() === normalizedPath) {
-        return container;
-      }
-      const found = searchContainers(container.sub_containers);
-      if (found) return found;
-    }
-    return undefined;
-  }
-
-  return searchContainers(inv.containers);
+  name: string
+): Tag | undefined {
+  const normalizedName = name.trim().toLowerCase();
+  const key = `tag:${normalizedName}`;
+  return inv.tags[key];
 }
 
 /**
- * Get all containers as a flat array (including sub-containers).
+ * Get all tags as an array.
  *
  * @param inv - The investigation
- * @returns Array of all containers
+ * @returns Array of all tags
+ *
+ * @example
+ * ```ts
+ * const allTags = getAllTags(investigation);
+ * console.log(`Total tags: ${allTags.length}`);
+ * ```
  */
-export function getAllContainers(inv: CyvestInvestigation): Container[] {
-  const result: Container[] = [];
-
-  function collectContainers(containers: Record<string, Container>): void {
-    for (const container of Object.values(containers)) {
-      result.push(container);
-      collectContainers(container.sub_containers);
-    }
-  }
-
-  collectContainers(inv.containers);
-  return result;
+export function getAllTags(inv: CyvestInvestigation): Tag[] {
+  return Object.values(inv.tags);
 }
 
 /**
@@ -345,7 +355,7 @@ export interface InvestigationCounts {
   checks: number;
   threatIntels: number;
   enrichments: number;
-  containers: number;
+  tags: number;
   whitelists: number;
 }
 
@@ -361,7 +371,7 @@ export function getCounts(inv: CyvestInvestigation): InvestigationCounts {
     checks: getAllChecks(inv).length,
     threatIntels: Object.keys(inv.threat_intels).length,
     enrichments: Object.keys(inv.enrichments).length,
-    containers: getAllContainers(inv).length,
+    tags: getAllTags(inv).length,
     whitelists: inv.whitelists.length,
   };
 }
@@ -387,4 +397,98 @@ export function getStartedAt(inv: CyvestInvestigation): string | undefined {
     (e) => e.event_type === "INVESTIGATION_STARTED"
   );
   return event?.timestamp;
+}
+
+// ============================================================================
+// Tag Aggregation
+// ============================================================================
+
+/**
+ * Get direct child tags of a given tag.
+ *
+ * @param inv - The investigation
+ * @param tagName - Parent tag name
+ * @returns Array of direct child tags
+ *
+ * @example
+ * ```ts
+ * const children = getTagChildren(investigation, "bodies");
+ * // Returns tags like "bodies:urls", "bodies:domains" (but not "bodies:urls:something")
+ * ```
+ */
+export function getTagChildren(inv: CyvestInvestigation, tagName: string): Tag[] {
+  return Object.values(inv.tags).filter((tag) => isTagChildOf(tag.name, tagName));
+}
+
+/**
+ * Get all descendant tags of a given tag (any depth).
+ *
+ * @param inv - The investigation
+ * @param tagName - Ancestor tag name
+ * @returns Array of all descendant tags
+ *
+ * @example
+ * ```ts
+ * const descendants = getTagDescendants(investigation, "bodies");
+ * // Returns all tags starting with "bodies:"
+ * ```
+ */
+export function getTagDescendants(inv: CyvestInvestigation, tagName: string): Tag[] {
+  const prefix = tagName + ":";
+  return Object.values(inv.tags).filter((tag) => tag.name.startsWith(prefix));
+}
+
+/**
+ * Get the aggregated score for a tag including all descendant tags.
+ *
+ * The aggregated score includes:
+ * - The tag's direct_score (from its direct checks)
+ * - Recursively, the aggregated scores of all child tags
+ *
+ * @param inv - The investigation
+ * @param tagName - Name of the tag
+ * @returns Total aggregated score, or 0 if tag not found
+ *
+ * @example
+ * ```ts
+ * const score = getTagAggregatedScore(investigation, "bodies");
+ * // Includes scores from bodies, bodies:urls, bodies:domains, etc.
+ * ```
+ */
+export function getTagAggregatedScore(inv: CyvestInvestigation, tagName: string): number {
+  const tag = getTagByName(inv, tagName);
+  if (!tag) {
+    return 0;
+  }
+
+  // Start with direct score
+  let total = tag.direct_score;
+
+  // Add scores from direct children (they will recursively add their children)
+  const children = getTagChildren(inv, tagName);
+  for (const child of children) {
+    total += getTagAggregatedScore(inv, child.name);
+  }
+
+  return total;
+}
+
+/**
+ * Get the aggregated level for a tag including all descendant tags.
+ *
+ * The level is calculated from the aggregated score using the standard
+ * score-to-level mapping.
+ *
+ * @param inv - The investigation
+ * @param tagName - Name of the tag
+ * @returns Level based on aggregated score
+ *
+ * @example
+ * ```ts
+ * const level = getTagAggregatedLevel(investigation, "bodies");
+ * // Returns "MALICIOUS" if aggregated score >= 5, etc.
+ * ```
+ */
+export function getTagAggregatedLevel(inv: CyvestInvestigation, tagName: string): Level {
+  return getLevelFromScore(getTagAggregatedScore(inv, tagName));
 }

--- a/js/packages/cyvest-js/src/graph.ts
+++ b/js/packages/cyvest-js/src/graph.ts
@@ -12,7 +12,6 @@ import type {
   Level,
   RelationshipDirection,
 } from "./types.generated";
-import { generateObservableKey } from "./keys";
 
 /**
  * Edge representation for graph operations.
@@ -350,24 +349,6 @@ export function findSourceObservables(inv: CyvestInvestigation): Observable[] {
   return Object.values(inv.observables).filter(
     (obs) => !targetKeys.has(obs.key)
   );
-}
-
-/**
- * Get the root observable of the investigation.
- *
- * The root observable is identified using the `root_type` from data extraction
- * metadata combined with value="root".
- *
- * @param inv - The investigation
- * @returns The root observable, or undefined if not found
- */
-export function getRootObservable(inv: CyvestInvestigation): Observable | undefined {
-  const rootType = inv.data_extraction.root_type;
-  if (!rootType) {
-    return undefined;
-  }
-  const rootKey = generateObservableKey(rootType, "root");
-  return inv.observables[rootKey];
 }
 
 /**

--- a/js/packages/cyvest-js/src/keys.ts
+++ b/js/packages/cyvest-js/src/keys.ts
@@ -58,22 +58,20 @@ export function generateObservableKey(obsType: string, value: string): string {
 /**
  * Generate a unique key for a check.
  *
- * Format: chk:{check_id}:{scope}
+ * Format: chk:{check_name}
  *
- * @param checkId - Identifier of the check
- * @param scope - Scope of the check
+ * @param checkName - Name of the check
  * @returns Unique check key
  *
  * @example
  * ```ts
- * generateCheckKey("sender_verification", "email_headers")
- * // => "chk:sender_verification:email_headers"
+ * generateCheckKey("sender_verification")
+ * // => "chk:sender_verification"
  * ```
  */
-export function generateCheckKey(checkId: string, scope: string): string {
-  const normalizedId = normalizeValue(checkId);
-  const normalizedScope = normalizeValue(scope);
-  return `chk:${normalizedId}:${normalizedScope}`;
+export function generateCheckKey(checkName: string): string {
+  const normalizedName = normalizeValue(checkName);
+  return `chk:${normalizedName}`;
 }
 
 /**
@@ -233,25 +231,24 @@ export function parseObservableKey(
  * Extract components from a check key.
  *
  * @param key - Check key to parse
- * @returns Object with checkId and scope, or null if invalid
+ * @returns Object with checkName, or null if invalid
  *
  * @example
  * ```ts
- * parseCheckKey("chk:sender_verification:email_headers")
- * // => { checkId: "sender_verification", scope: "email_headers" }
+ * parseCheckKey("chk:sender_verification")
+ * // => { checkName: "sender_verification" }
  * ```
  */
 export function parseCheckKey(
   key: string
-): { checkId: string; scope: string } | null {
+): { checkName: string } | null {
   if (!validateKey(key, "chk")) {
     return null;
   }
   const parts = key.split(":");
-  if (parts.length >= 3) {
+  if (parts.length >= 2) {
     return {
-      checkId: parts[1],
-      scope: parts.slice(2).join(":"),
+      checkName: parts.slice(1).join(":"),
     };
   }
   return null;

--- a/js/packages/cyvest-js/src/keys.ts
+++ b/js/packages/cyvest-js/src/keys.ts
@@ -8,7 +8,7 @@
 /**
  * Key type prefixes used in Cyvest.
  */
-export type KeyType = "obs" | "chk" | "ti" | "enr" | "ctr";
+export type KeyType = "obs" | "chk" | "ti" | "enr" | "tag";
 
 /**
  * Normalize a string value for consistent key generation.
@@ -125,31 +125,88 @@ export function generateEnrichmentKey(name: string, context?: string): string {
 }
 
 /**
- * Generate a unique key for a container.
+ * Generate a unique key for a tag.
  *
- * Format: ctr:{normalized_path}
+ * Format: tag:{normalized_name}
  *
- * @param path - Path of the container (can use / or . as separator)
- * @returns Unique container key
+ * @param name - Name of the tag (can use : as hierarchy delimiter)
+ * @returns Unique tag key
  *
  * @example
  * ```ts
- * generateContainerKey("email/headers")
- * // => "ctr:email/headers"
+ * generateTagKey("header:auth:dkim")
+ * // => "tag:header:auth:dkim"
  * ```
  */
-export function generateContainerKey(path: string): string {
-  // Normalize path separators
-  let normalizedPath = path.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
-  normalizedPath = normalizeValue(normalizedPath);
-  return `ctr:${normalizedPath}`;
+export function generateTagKey(name: string): string {
+  const normalizedName = normalizeValue(name);
+  return `tag:${normalizedName}`;
+}
+
+/**
+ * Get all ancestor tag names from a hierarchical tag name.
+ *
+ * @param name - Tag name with : delimiter
+ * @returns Array of ancestor tag names
+ *
+ * @example
+ * ```ts
+ * getTagAncestors("header:auth:dkim")
+ * // => ["header", "header:auth"]
+ * ```
+ */
+export function getTagAncestors(name: string): string[] {
+  const parts = name.split(":");
+  const ancestors: string[] = [];
+  for (let i = 0; i < parts.length - 1; i++) {
+    ancestors.push(parts.slice(0, i + 1).join(":"));
+  }
+  return ancestors;
+}
+
+/**
+ * Check if a tag is a direct child of another tag.
+ *
+ * @param childName - Potential child tag name
+ * @param parentName - Potential parent tag name
+ * @returns True if childName is a direct child of parentName
+ *
+ * @example
+ * ```ts
+ * isTagChildOf("header:auth", "header") // => true
+ * isTagChildOf("header:auth:dkim", "header") // => false (grandchild)
+ * ```
+ */
+export function isTagChildOf(childName: string, parentName: string): boolean {
+  if (!childName.startsWith(parentName + ":")) {
+    return false;
+  }
+  const remaining = childName.slice(parentName.length + 1);
+  return !remaining.includes(":");
+}
+
+/**
+ * Check if a tag is a descendant of another tag (any depth).
+ *
+ * @param descendantName - Potential descendant tag name
+ * @param ancestorName - Potential ancestor tag name
+ * @returns True if descendantName is a descendant of ancestorName
+ *
+ * @example
+ * ```ts
+ * isTagDescendantOf("header:auth:dkim", "header") // => true
+ * isTagDescendantOf("header", "header") // => false (same)
+ * ```
+ */
+export function isTagDescendantOf(descendantName: string, ancestorName: string): boolean {
+  return descendantName.startsWith(ancestorName + ":");
 }
 
 /**
  * Extract the type prefix from a key.
  *
  * @param key - The key to parse
- * @returns Type prefix (obs, chk, ti, enr, ctr) or null if invalid
+ * @returns Type prefix (obs, chk, ti, enr, tag) or null if invalid
  *
  * @example
  * ```ts
@@ -160,7 +217,7 @@ export function generateContainerKey(path: string): string {
 export function parseKeyType(key: string): KeyType | null {
   if (key.includes(":")) {
     const prefix = key.split(":", 1)[0] as KeyType;
-    if (["obs", "chk", "ti", "enr", "ctr"].includes(prefix)) {
+    if (["obs", "chk", "ti", "enr", "tag"].includes(prefix)) {
       return prefix;
     }
   }

--- a/js/packages/cyvest-js/src/levels.ts
+++ b/js/packages/cyvest-js/src/levels.ts
@@ -9,7 +9,7 @@ import type {
   Observable,
   Check,
   ThreatIntel,
-  Container,
+  Tag,
   Level,
 } from "./types.generated";
 
@@ -254,15 +254,15 @@ export function hasLevel(obj: unknown): obj is { level: Level } {
 }
 
 /**
- * Extract level from an entity (Observable, Check, ThreatIntel, Container).
+ * Extract level from an entity (Observable, Check, ThreatIntel, Tag).
  */
 export function getEntityLevel(
-  entity: Observable | Check | ThreatIntel | Container
+  entity: Observable | Check | ThreatIntel | Tag
 ): Level {
-  if ("aggregated_level" in entity) {
-    const aggregatedLevel = entity.aggregated_level;
-    if (typeof aggregatedLevel === "string" && isValidLevel(aggregatedLevel)) {
-      return aggregatedLevel;
+  if ("direct_level" in entity) {
+    const directLevel = entity.direct_level;
+    if (typeof directLevel === "string" && isValidLevel(directLevel)) {
+      return directLevel;
     }
   }
   if ("level" in entity && isValidLevel(entity.level)) {

--- a/js/packages/cyvest-js/src/types.generated.ts
+++ b/js/packages/cyvest-js/src/types.generated.ts
@@ -81,7 +81,7 @@ export interface CyvestInvestigation {
   checks: Checks;
   threat_intels: ThreatIntels1;
   enrichments: Enrichments;
-  containers: Containers;
+  tags: Tags;
   stats: StatisticsSchema;
   data_extraction: DataExtractionSchema;
   /**
@@ -249,28 +249,34 @@ export interface Data {
   [k: string]: unknown;
 }
 /**
- * Containers keyed by their unique key.
+ * Tags keyed by their unique key.
  */
-export interface Containers {
-  [k: string]: Container;
+export interface Tags {
+  [k: string]: Tag;
 }
 /**
- * Groups checks and sub-containers for hierarchical organization.
+ * Groups checks for categorical organization.
  *
- * Containers allow structuring the investigation into logical sections
- * with aggregated scores and levels.
+ * Tags allow structuring the investigation into logical sections
+ * with aggregated scores and levels. Hierarchy is automatic based on
+ * the ":" delimiter in tag names (e.g., "header:auth:dkim").
  */
-export interface Container {
-  path: string;
+export interface Tag {
+  name: string;
   description?: string;
   checks: Checks1;
-  sub_containers: SubContainers;
   key: string;
-  aggregated_score: number;
-  aggregated_level: Level;
-}
-export interface SubContainers {
-  [k: string]: Container;
+  /**
+   * Calculate the score from direct checks only (no hierarchy).
+   *
+   * For hierarchical aggregation (including descendant tags), use
+   * Investigation.get_tag_aggregated_score() or TagProxy.get_aggregated_score().
+   *
+   * Returns:
+   *     Total score from direct checks
+   */
+  direct_score: number;
+  direct_level: Level;
 }
 /**
  * Schema for investigation statistics.
@@ -291,7 +297,7 @@ export interface StatisticsSchema {
   total_threat_intel: number;
   threat_intel_by_source?: ThreatIntelBySource;
   threat_intel_by_level?: ThreatIntelByLevel;
-  total_containers: number;
+  total_tags: number;
 }
 export interface ObservablesByType {
   [k: string]: number;

--- a/js/packages/cyvest-js/src/types.generated.ts
+++ b/js/packages/cyvest-js/src/types.generated.ts
@@ -157,10 +157,10 @@ export interface Relationship {
   [k: string]: unknown;
 }
 /**
- * Checks organized by scope.
+ * Checks keyed by their unique key.
  */
 export interface Checks {
-  [k: string]: Check[];
+  [k: string]: Check;
 }
 /**
  * Represents a verification step in the investigation.
@@ -169,8 +169,7 @@ export interface Checks {
  * and contributes to the overall investigation score.
  */
 export interface Check {
-  check_id: string;
-  scope: string;
+  check_name: string;
   description: string;
   comment: string;
   extra: Extra1;
@@ -288,7 +287,6 @@ export interface StatisticsSchema {
   observables_by_type_and_level?: ObservablesByTypeAndLevel;
   total_checks: number;
   applied_checks: number;
-  checks_by_scope?: ChecksByScope;
   checks_by_level?: ChecksByLevel;
   total_threat_intel: number;
   threat_intel_by_source?: ThreatIntelBySource;
@@ -305,9 +303,6 @@ export interface ObservablesByTypeAndLevel {
   [k: string]: {
     [k: string]: number;
   };
-}
-export interface ChecksByScope {
-  [k: string]: string[];
 }
 export interface ChecksByLevel {
   [k: string]: string[];

--- a/js/packages/cyvest-js/tests/getters-finders.test.ts
+++ b/js/packages/cyvest-js/tests/getters-finders.test.ts
@@ -5,7 +5,7 @@ import {
   getObservable,
   getObservableByTypeValue,
   getCheck,
-  getCheckByIdScope,
+  getCheckByName,
   getAllChecks,
   getThreatIntel,
   getThreatIntelBySourceObservable,
@@ -26,7 +26,6 @@ import {
   findObservablesByValue,
   findInternalObservables,
   findWhitelistedObservables,
-  findChecksByScope,
   findChecksByLevel,
   findChecksAtLeast,
   findThreatIntelBySource,
@@ -35,7 +34,7 @@ import {
   getObservablesForCheck,
   getHighestScoringObservables,
   getMaliciousObservables,
-  getAllScopes,
+  getAllCheckKeys,
   getAllObservableTypes,
 } from "../src";
 
@@ -133,57 +132,50 @@ function createTestInvestigation(): CyvestInvestigation {
       },
     },
     checks: {
-      network: [
-        {
-          key: "chk:ip_check:network",
-          check_id: "ip_check",
-          scope: "network",
-          description: "IP address check",
-          comment: "",
-          extra: {},
-          score: 0,
-          score_display: "0.00",
-          level: "INFO",
-          origin_investigation_id: "01HXYZTESTINVESTIGATION",
-          observable_links: [
-            {
-              observable_key: "obs:ipv4-addr:192.168.1.1",
-            },
-          ],
-        },
-      ],
-      dns: [
-        {
-          key: "chk:domain_check:dns",
-          check_id: "domain_check",
-          scope: "dns",
-          description: "Domain reputation check",
-          comment: "",
-          extra: {},
-          score: 5,
-          score_display: "5.00",
-          level: "MALICIOUS",
-          origin_investigation_id: "01HXYZTESTINVESTIGATION",
-          observable_links: [
-            {
-              observable_key: "obs:domain-name:example.com",
-            },
-          ],
-        },
-        {
-          key: "chk:dns_lookup:dns",
-          check_id: "dns_lookup",
-          scope: "dns",
-          description: "DNS lookup",
-          comment: "",
-          extra: {},
-          score: 0,
-          score_display: "0.00",
-          level: "INFO",
-          origin_investigation_id: "01HXYZTESTINVESTIGATION",
-          observable_links: [],
-        },
-      ],
+      "chk:ip_check": {
+        key: "chk:ip_check",
+        check_name: "ip_check",
+        description: "IP address check",
+        comment: "",
+        extra: {},
+        score: 0,
+        score_display: "0.00",
+        level: "INFO",
+        origin_investigation_id: "01HXYZTESTINVESTIGATION",
+        observable_links: [
+          {
+            observable_key: "obs:ipv4-addr:192.168.1.1",
+          },
+        ],
+      },
+      "chk:domain_check": {
+        key: "chk:domain_check",
+        check_name: "domain_check",
+        description: "Domain reputation check",
+        comment: "",
+        extra: {},
+        score: 5,
+        score_display: "5.00",
+        level: "MALICIOUS",
+        origin_investigation_id: "01HXYZTESTINVESTIGATION",
+        observable_links: [
+          {
+            observable_key: "obs:domain-name:example.com",
+          },
+        ],
+      },
+      "chk:dns_lookup": {
+        key: "chk:dns_lookup",
+        check_name: "dns_lookup",
+        description: "DNS lookup",
+        comment: "",
+        extra: {},
+        score: 0,
+        score_display: "0.00",
+        level: "INFO",
+        origin_investigation_id: "01HXYZTESTINVESTIGATION",
+        observable_links: [],
+      },
     },
     threat_intels: {
       "ti:virustotal:obs:domain-name:example.com": {
@@ -217,7 +209,7 @@ function createTestInvestigation(): CyvestInvestigation {
             key: "ctr:email/headers",
             path: "email/headers",
             description: "Email headers",
-            checks: ["chk:ip_check:network"],
+            checks: ["chk:ip_check"],
             sub_containers: {},
             aggregated_score: 0,
             aggregated_level: "INFO",
@@ -237,8 +229,7 @@ function createTestInvestigation(): CyvestInvestigation {
       observables_by_type_and_level: {},
       total_checks: 3,
       applied_checks: 2,
-      checks_by_scope: { network: ["chk:ip_check:network"], dns: ["chk:domain_check:dns", "chk:dns_lookup:dns"] },
-      checks_by_level: { INFO: ["chk:ip_check:network", "chk:dns_lookup:dns"], MALICIOUS: ["chk:domain_check:dns"] },
+      checks_by_level: { INFO: ["chk:ip_check", "chk:dns_lookup"], MALICIOUS: ["chk:domain_check"] },
       total_threat_intel: 1,
       threat_intel_by_source: { virustotal: 1 },
       threat_intel_by_level: { MALICIOUS: 1 },
@@ -285,17 +276,17 @@ describe("Getters", () => {
 
   describe("getCheck", () => {
     it("returns check by key", () => {
-      const check = getCheck(inv, "chk:domain_check:dns");
+      const check = getCheck(inv, "chk:domain_check");
       expect(check).toBeDefined();
-      expect(check?.check_id).toBe("domain_check");
+      expect(check?.check_name).toBe("domain_check");
     });
   });
 
-  describe("getCheckByIdScope", () => {
-    it("finds check by id and scope", () => {
-      const check = getCheckByIdScope(inv, "domain_check", "dns");
+  describe("getCheckByName", () => {
+    it("finds check by name", () => {
+      const check = getCheckByName(inv, "domain_check");
       expect(check).toBeDefined();
-      expect(check?.key).toBe("chk:domain_check:dns");
+      expect(check?.key).toBe("chk:domain_check");
     });
   });
 
@@ -419,13 +410,6 @@ describe("Finders", () => {
     });
   });
 
-  describe("findChecksByScope", () => {
-    it("finds checks in scope", () => {
-      const dnsChecks = findChecksByScope(inv, "dns");
-      expect(dnsChecks).toHaveLength(2);
-    });
-  });
-
   describe("findChecksByLevel", () => {
     it("finds checks at level", () => {
       const malicious = findChecksByLevel(inv, "MALICIOUS");
@@ -444,7 +428,7 @@ describe("Finders", () => {
     it("finds checks that reference observable", () => {
       const checks = getChecksForObservable(inv, "obs:ipv4-addr:192.168.1.1");
       expect(checks).toHaveLength(1);
-      expect(checks[0].check_id).toBe("ip_check");
+      expect(checks[0].check_name).toBe("ip_check");
     });
   });
 
@@ -461,7 +445,7 @@ describe("Finders", () => {
 
   describe("getObservablesForCheck", () => {
     it("finds observables referenced by check", () => {
-      const obs = getObservablesForCheck(inv, "chk:ip_check:network");
+      const obs = getObservablesForCheck(inv, "chk:ip_check");
       expect(obs).toHaveLength(1);
       expect(obs[0].value).toBe("192.168.1.1");
     });
@@ -482,11 +466,11 @@ describe("Finders", () => {
     });
   });
 
-  describe("getAllScopes", () => {
-    it("returns all scopes", () => {
-      const scopes = getAllScopes(inv);
-      expect(scopes).toContain("network");
-      expect(scopes).toContain("dns");
+  describe("getAllCheckKeys", () => {
+    it("returns all check keys", () => {
+      const keys = getAllCheckKeys(inv);
+      expect(keys).toContain("chk:ip_check");
+      expect(keys).toContain("chk:domain_check");
     });
   });
 

--- a/js/packages/cyvest-js/tests/getters-finders.test.ts
+++ b/js/packages/cyvest-js/tests/getters-finders.test.ts
@@ -13,12 +13,16 @@ import {
   getEnrichment,
   getEnrichmentByName,
   getAllEnrichments,
-  getContainer,
-  getContainerByPath,
-  getAllContainers,
+  getTag,
+  getTagByName,
+  getAllTags,
   getAllObservables,
   getCounts,
   getStartedAt,
+  getTagChildren,
+  getTagDescendants,
+  getTagAggregatedScore,
+  getTagAggregatedLevel,
   // Finders
   findObservablesByType,
   findObservablesByLevel,
@@ -29,11 +33,11 @@ import {
   findChecksByLevel,
   findChecksAtLeast,
   findThreatIntelBySource,
-  getChecksForObservable,
-  getThreatIntelsForObservable,
-  getObservablesForCheck,
-  getHighestScoringObservables,
-  getMaliciousObservables,
+  findChecksForObservable,
+  findThreatIntelsForObservable,
+  findObservablesForCheck,
+  findHighestScoringObservables,
+  findMaliciousObservables,
   getAllCheckKeys,
   getAllObservableTypes,
 } from "../src";
@@ -198,25 +202,38 @@ function createTestInvestigation(): CyvestInvestigation {
         context: "example.com",
       },
     },
-    containers: {
-      "ctr:email": {
-        key: "ctr:email",
-        path: "email",
-        description: "Email container",
+    tags: {
+      "tag:email": {
+        key: "tag:email",
+        name: "email",
+        description: "Email tag",
         checks: [],
-        sub_containers: {
-          "ctr:email/headers": {
-            key: "ctr:email/headers",
-            path: "email/headers",
-            description: "Email headers",
-            checks: ["chk:ip_check"],
-            sub_containers: {},
-            aggregated_score: 0,
-            aggregated_level: "INFO",
-          },
-        },
-        aggregated_score: 0,
-        aggregated_level: "INFO",
+        direct_score: 1.5,
+        direct_level: "NOTABLE",
+      },
+      "tag:email:headers": {
+        key: "tag:email:headers",
+        name: "email:headers",
+        description: "Email headers",
+        checks: ["chk:ip_check"],
+        direct_score: 2.0,
+        direct_level: "NOTABLE",
+      },
+      "tag:email:headers:auth": {
+        key: "tag:email:headers:auth",
+        name: "email:headers:auth",
+        description: "Auth headers",
+        checks: [],
+        direct_score: 3.5,
+        direct_level: "SUSPICIOUS",
+      },
+      "tag:email:body": {
+        key: "tag:email:body",
+        name: "email:body",
+        description: "Email body",
+        checks: [],
+        direct_score: 1.0,
+        direct_level: "NOTABLE",
       },
     },
     stats: {
@@ -233,7 +250,7 @@ function createTestInvestigation(): CyvestInvestigation {
       total_threat_intel: 1,
       threat_intel_by_source: { virustotal: 1 },
       threat_intel_by_level: { MALICIOUS: 1 },
-      total_containers: 2,
+      total_tags: 4,
     },
     data_extraction: {
       root_type: "file",
@@ -308,24 +325,24 @@ describe("Getters", () => {
     });
   });
 
-  describe("getContainer", () => {
-    it("returns top-level container", () => {
-      const container = getContainer(inv, "ctr:email");
-      expect(container).toBeDefined();
-      expect(container?.path).toBe("email");
+  describe("getTag", () => {
+    it("returns tag by key", () => {
+      const tag = getTag(inv, "tag:email");
+      expect(tag).toBeDefined();
+      expect(tag?.name).toBe("email");
     });
 
-    it("returns nested container", () => {
-      const container = getContainer(inv, "ctr:email/headers");
-      expect(container).toBeDefined();
-      expect(container?.path).toBe("email/headers");
+    it("returns nested tag", () => {
+      const tag = getTag(inv, "tag:email:headers");
+      expect(tag).toBeDefined();
+      expect(tag?.name).toBe("email:headers");
     });
   });
 
-  describe("getAllContainers", () => {
-    it("returns all containers including nested", () => {
-      const containers = getAllContainers(inv);
-      expect(containers).toHaveLength(2);
+  describe("getAllTags", () => {
+    it("returns all tags", () => {
+      const tags = getAllTags(inv);
+      expect(tags).toHaveLength(4);
     });
   });
 
@@ -336,7 +353,7 @@ describe("Getters", () => {
       expect(counts.checks).toBe(3);
       expect(counts.threatIntels).toBe(1);
       expect(counts.enrichments).toBe(1);
-      expect(counts.containers).toBe(2);
+      expect(counts.tags).toBe(4);
       expect(counts.whitelists).toBe(1);
     });
   });
@@ -424,17 +441,17 @@ describe("Finders", () => {
     });
   });
 
-  describe("getChecksForObservable", () => {
+  describe("findChecksForObservable", () => {
     it("finds checks that reference observable", () => {
-      const checks = getChecksForObservable(inv, "obs:ipv4-addr:192.168.1.1");
+      const checks = findChecksForObservable(inv, "obs:ipv4-addr:192.168.1.1");
       expect(checks).toHaveLength(1);
       expect(checks[0].check_name).toBe("ip_check");
     });
   });
 
-  describe("getThreatIntelsForObservable", () => {
+  describe("findThreatIntelsForObservable", () => {
     it("finds threat intel for observable", () => {
-      const tis = getThreatIntelsForObservable(
+      const tis = findThreatIntelsForObservable(
         inv,
         "obs:domain-name:example.com"
       );
@@ -443,25 +460,25 @@ describe("Finders", () => {
     });
   });
 
-  describe("getObservablesForCheck", () => {
+  describe("findObservablesForCheck", () => {
     it("finds observables referenced by check", () => {
-      const obs = getObservablesForCheck(inv, "chk:ip_check");
+      const obs = findObservablesForCheck(inv, "chk:ip_check");
       expect(obs).toHaveLength(1);
       expect(obs[0].value).toBe("192.168.1.1");
     });
   });
 
-  describe("getHighestScoringObservables", () => {
+  describe("findHighestScoringObservables", () => {
     it("returns top scoring observables", () => {
-      const top = getHighestScoringObservables(inv, 2);
+      const top = findHighestScoringObservables(inv, 2);
       expect(top).toHaveLength(2);
       expect(top[0].score).toBeGreaterThanOrEqual(top[1].score);
     });
   });
 
-  describe("getMaliciousObservables", () => {
+  describe("findMaliciousObservables", () => {
     it("returns malicious observables", () => {
-      const mal = getMaliciousObservables(inv);
+      const mal = findMaliciousObservables(inv);
       expect(mal).toHaveLength(2);
     });
   });
@@ -480,6 +497,104 @@ describe("Finders", () => {
       expect(types).toContain("ipv4-addr");
       expect(types).toContain("domain-name");
       expect(types).toContain("url");
+    });
+  });
+
+  // Tag Aggregation Tests
+  describe("getTagChildren", () => {
+    it("returns direct children of a tag", () => {
+      const children = getTagChildren(inv, "email");
+      expect(children).toHaveLength(2);
+      const names = children.map((t) => t.name);
+      expect(names).toContain("email:headers");
+      expect(names).toContain("email:body");
+    });
+
+    it("does not return grandchildren", () => {
+      const children = getTagChildren(inv, "email");
+      const names = children.map((t) => t.name);
+      expect(names).not.toContain("email:headers:auth");
+    });
+
+    it("returns empty array for leaf tag", () => {
+      const children = getTagChildren(inv, "email:headers:auth");
+      expect(children).toHaveLength(0);
+    });
+
+    it("returns empty array for non-existent tag", () => {
+      const children = getTagChildren(inv, "nonexistent");
+      expect(children).toHaveLength(0);
+    });
+  });
+
+  describe("getTagDescendants", () => {
+    it("returns all descendants of a tag", () => {
+      const descendants = getTagDescendants(inv, "email");
+      expect(descendants).toHaveLength(3);
+      const names = descendants.map((t) => t.name);
+      expect(names).toContain("email:headers");
+      expect(names).toContain("email:headers:auth");
+      expect(names).toContain("email:body");
+    });
+
+    it("returns children and grandchildren", () => {
+      const descendants = getTagDescendants(inv, "email:headers");
+      expect(descendants).toHaveLength(1);
+      expect(descendants[0].name).toBe("email:headers:auth");
+    });
+
+    it("returns empty array for leaf tag", () => {
+      const descendants = getTagDescendants(inv, "email:headers:auth");
+      expect(descendants).toHaveLength(0);
+    });
+  });
+
+  describe("getTagAggregatedScore", () => {
+    it("returns aggregated score including all descendants", () => {
+      // email (1.5) + email:headers (2.0) + email:headers:auth (3.5) + email:body (1.0) = 8.0
+      const score = getTagAggregatedScore(inv, "email");
+      expect(score).toBe(8.0);
+    });
+
+    it("returns aggregated score for intermediate tag", () => {
+      // email:headers (2.0) + email:headers:auth (3.5) = 5.5
+      const score = getTagAggregatedScore(inv, "email:headers");
+      expect(score).toBe(5.5);
+    });
+
+    it("returns direct score for leaf tag", () => {
+      const score = getTagAggregatedScore(inv, "email:headers:auth");
+      expect(score).toBe(3.5);
+    });
+
+    it("returns 0 for non-existent tag", () => {
+      const score = getTagAggregatedScore(inv, "nonexistent");
+      expect(score).toBe(0);
+    });
+  });
+
+  describe("getTagAggregatedLevel", () => {
+    it("returns level based on aggregated score", () => {
+      // email aggregated score = 8.0 -> MALICIOUS (>= 5)
+      const level = getTagAggregatedLevel(inv, "email");
+      expect(level).toBe("MALICIOUS");
+    });
+
+    it("returns level for intermediate tag", () => {
+      // email:headers aggregated score = 5.5 -> MALICIOUS (>= 5)
+      const level = getTagAggregatedLevel(inv, "email:headers");
+      expect(level).toBe("MALICIOUS");
+    });
+
+    it("returns level for leaf tag", () => {
+      // email:headers:auth direct score = 3.5 -> SUSPICIOUS (3 <= x < 5)
+      const level = getTagAggregatedLevel(inv, "email:headers:auth");
+      expect(level).toBe("SUSPICIOUS");
+    });
+
+    it("returns INFO for non-existent tag (score 0)", () => {
+      const level = getTagAggregatedLevel(inv, "nonexistent");
+      expect(level).toBe("INFO");
     });
   });
 });

--- a/js/packages/cyvest-js/tests/graph.test.ts
+++ b/js/packages/cyvest-js/tests/graph.test.ts
@@ -144,7 +144,6 @@ function createGraphTestInvestigation(): CyvestInvestigation {
       observables_by_type_and_level: {},
       total_checks: 0,
       applied_checks: 0,
-      checks_by_scope: {},
       checks_by_level: {},
       total_threat_intel: 0,
       threat_intel_by_source: {},

--- a/js/packages/cyvest-js/tests/keys-levels.test.ts
+++ b/js/packages/cyvest-js/tests/keys-levels.test.ts
@@ -47,8 +47,8 @@ describe("Key Generation", () => {
 
   describe("generateCheckKey", () => {
     it("generates correct check key", () => {
-      expect(generateCheckKey("sender_verification", "email_headers")).toBe(
-        "chk:sender_verification:email_headers"
+      expect(generateCheckKey("sender_verification")).toBe(
+        "chk:sender_verification"
       );
     });
   });
@@ -153,9 +153,8 @@ describe("Key Generation", () => {
 
   describe("parseCheckKey", () => {
     it("parses check key components", () => {
-      expect(parseCheckKey("chk:sender_verification:email_headers")).toEqual({
-        checkId: "sender_verification",
-        scope: "email_headers",
+      expect(parseCheckKey("chk:sender_verification")).toEqual({
+        checkName: "sender_verification",
       });
     });
   });

--- a/js/packages/cyvest-js/tests/keys-levels.test.ts
+++ b/js/packages/cyvest-js/tests/keys-levels.test.ts
@@ -5,7 +5,7 @@ import {
   generateCheckKey,
   generateThreatIntelKey,
   generateEnrichmentKey,
-  generateContainerKey,
+  generateTagKey,
   parseKeyType,
   validateKey,
   parseObservableKey,
@@ -72,17 +72,17 @@ describe("Key Generation", () => {
     });
   });
 
-  describe("generateContainerKey", () => {
-    it("generates correct container key", () => {
-      expect(generateContainerKey("email/headers")).toBe("ctr:email/headers");
+  describe("generateTagKey", () => {
+    it("generates correct tag key", () => {
+      expect(generateTagKey("header:auth")).toBe("tag:header:auth");
     });
 
-    it("normalizes path separators", () => {
-      expect(generateContainerKey("email\\headers")).toBe("ctr:email/headers");
+    it("normalizes to lowercase", () => {
+      expect(generateTagKey("HEADER:AUTH")).toBe("tag:header:auth");
     });
 
-    it("strips leading/trailing slashes", () => {
-      expect(generateContainerKey("/email/headers/")).toBe("ctr:email/headers");
+    it("trims whitespace", () => {
+      expect(generateTagKey("  header:auth  ")).toBe("tag:header:auth");
     });
   });
 
@@ -103,8 +103,8 @@ describe("Key Generation", () => {
       expect(parseKeyType("enr:whois")).toBe("enr");
     });
 
-    it("parses container key type", () => {
-      expect(parseKeyType("ctr:email/body")).toBe("ctr");
+    it("parses tag key type", () => {
+      expect(parseKeyType("tag:header:auth")).toBe("tag");
     });
 
     it("returns null for invalid key", () => {

--- a/js/packages/cyvest-vis/README.md
+++ b/js/packages/cyvest-vis/README.md
@@ -85,7 +85,7 @@ import { ObservablesGraph } from "@cyvest/cyvest-vis";
 
 #### `InvestigationGraph`
 
-Hierarchical graph showing root → containers → checks structure.
+Hierarchical graph showing root → tags → checks structure.
 
 ```tsx
 import { InvestigationGraph } from "@cyvest/cyvest-vis";
@@ -95,7 +95,7 @@ import { InvestigationGraph } from "@cyvest/cyvest-vis";
   height={600}
   width="100%"
   onNodeClick={(nodeId, nodeType) => {
-    // nodeType: "root" | "check" | "container"
+    // nodeType: "root" | "check" | "tag"
   }}
 />
 ```
@@ -116,7 +116,7 @@ const Icon = getObservableIcon("ipv4-addr"); // Returns GlobeIcon
 <MailIcon size={16} color="#ef4444" />
 ```
 
-Available icons: `GlobeIcon`, `DomainIcon`, `LinkIcon`, `MailIcon`, `EnvelopeIcon`, `FileIcon`, `HashIcon`, `UserIcon`, `IdCardIcon`, `GearIcon`, `AppIcon`, `RegistryIcon`, `ThreatActorIcon`, `BugIcon`, `SwordIcon`, `TargetIcon`, `AlertIcon`, `FlaskIcon`, `CertificateIcon`, `WifiIcon`, `WorldIcon`, `QuestionIcon`, `CheckIcon`, `BoxIcon`, `CrosshairIcon`
+Available icons: `GlobeIcon`, `DomainIcon`, `LinkIcon`, `MailIcon`, `EnvelopeIcon`, `FileIcon`, `HashIcon`, `UserIcon`, `IdCardIcon`, `GearIcon`, `AppIcon`, `RegistryIcon`, `ThreatActorIcon`, `BugIcon`, `SwordIcon`, `TargetIcon`, `AlertIcon`, `FlaskIcon`, `CertificateIcon`, `WifiIcon`, `WorldIcon`, `QuestionIcon`, `CheckIcon`, `TagIcon`, `CrosshairIcon`
 
 ## Types
 

--- a/js/packages/cyvest-vis/src/components/Icons.tsx
+++ b/js/packages/cyvest-vis/src/components/Icons.tsx
@@ -594,9 +594,9 @@ export const CheckIcon: React.FC<IconProps> = ({
 );
 
 /**
- * Box icon for containers
+ * Tag icon for tags
  */
-export const BoxIcon: React.FC<IconProps> = ({
+export const TagIcon: React.FC<IconProps> = ({
   size = defaultSize,
   color = defaultColor,
   className,
@@ -706,7 +706,7 @@ export const INVESTIGATION_ICON_MAP: Record<
 > = {
   root: CrosshairIcon,
   check: CheckIcon,
-  container: BoxIcon,
+  tag: TagIcon,
 };
 
 /**

--- a/js/packages/cyvest-vis/src/components/InvestigationGraph.tsx
+++ b/js/packages/cyvest-vis/src/components/InvestigationGraph.tsx
@@ -1,6 +1,6 @@
 /**
  * InvestigationGraph component - displays investigation structure with Dagre layout.
- * Shows root observable, checks, and containers in a hierarchical view.
+ * Shows root observable, checks, and tags in a hierarchical view.
  */
 
 import React, { useMemo, useCallback } from "react";
@@ -19,7 +19,8 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
-import type { CyvestInvestigation, Check, Container } from "@cyvest/cyvest-js";
+import type { CyvestInvestigation, Check, Tag } from "@cyvest/cyvest-js";
+import { getTagAncestors } from "@cyvest/cyvest-js";
 
 import type {
   InvestigationGraphProps,
@@ -55,21 +56,10 @@ const defaultEdgeOptions = {
 };
 
 /**
- * Flatten containers recursively to get all container keys.
+ * Get all tags as an array.
  */
-function flattenContainers(
-  containers: Record<string, Container>
-): Container[] {
-  const result: Container[] = [];
-
-  for (const container of Object.values(containers)) {
-    result.push(container);
-    if (container.sub_containers) {
-      result.push(...flattenContainers(container.sub_containers));
-    }
-  }
-
-  return result;
+function getAllTags(tags: Record<string, Tag>): Tag[] {
+  return Object.values(tags);
 }
 
 /**
@@ -115,13 +105,13 @@ function createInvestigationGraph(
     draggable: true,
   });
 
-  // Collect all check keys that belong to containers
+  // Collect all check keys that belong to tags
   // These checks should NOT have a direct link to the root node
-  const allContainers = flattenContainers(investigation.containers);
-  const checksInContainers = new Set<string>();
-  for (const container of allContainers) {
-    for (const checkKey of container.checks) {
-      checksInContainers.add(checkKey);
+  const allTags = getAllTags(investigation.tags);
+  const checksInTags = new Set<string>();
+  for (const tag of allTags) {
+    for (const checkKey of tag.checks) {
+      checksInTags.add(checkKey);
     }
   }
 
@@ -151,9 +141,9 @@ function createInvestigationGraph(
       draggable: true,
     });
 
-    // Only create edge from root to check if check is NOT in a container
-    // Checks in containers will be linked through their container instead
-    if (!checksInContainers.has(check.key)) {
+    // Only create edge from root to check if check is NOT in a tag
+    // Checks in tags will be linked through their tag instead
+    if (!checksInTags.has(check.key)) {
       edges.push({
         id: `edge-root-${check.key}`,
         source: rootKey,
@@ -164,43 +154,79 @@ function createInvestigationGraph(
     }
   }
 
-  // Add container nodes
-  for (const container of allContainers) {
-    const containerNodeData: InvestigationNodeData = {
-      label: truncateLabel(
-        container.path.split("/").pop() ?? container.path,
-        20
-      ),
-      nodeType: "container",
-      level: container.aggregated_level,
-      score: container.aggregated_score,
-      path: container.path,
+  // Build hierarchical tag structure
+  // First, collect all tag names and find/create ancestor tags
+  const tagByName = new Map<string, Tag>();
+  for (const tag of allTags) {
+    tagByName.set(tag.name, tag);
+  }
+
+  // Collect all unique tag names including synthetic ancestors
+  const allTagNames = new Set<string>();
+  for (const tag of allTags) {
+    allTagNames.add(tag.name);
+    // Add ancestors (they may not exist as actual tags)
+    for (const ancestor of getTagAncestors(tag.name)) {
+      allTagNames.add(ancestor);
+    }
+  }
+
+  // Create tag nodes (real and synthetic)
+  for (const tagName of allTagNames) {
+    const realTag = tagByName.get(tagName);
+
+    const tagNodeData: InvestigationNodeData = {
+      label: truncateLabel(tagName.split(":").pop() ?? tagName, 20),
+      nodeType: "tag",
+      level: realTag?.direct_level ?? "INFO",
+      score: realTag?.direct_score ?? 0,
+      name: tagName,
     };
 
     nodes.push({
-      id: `container-${container.key}`,
+      id: `tag-${tagName}`,
       type: "investigation",
       position: { x: 0, y: 0 },
-      data: containerNodeData,
+      data: tagNodeData,
       selectable: true,
       draggable: true,
     });
+  }
 
-    // Edge from root to container
-    edges.push({
-      id: `edge-root-container-${container.key}`,
-      source: rootKey,
-      target: `container-${container.key}`,
-      type: "smoothstep",
-      animated: false,
-    });
+  // Create edges based on tag hierarchy
+  for (const tagName of allTagNames) {
+    const nodeId = `tag-${tagName}`;
+    const parts = tagName.split(":");
 
-    // Edges from container to its checks
-    for (const checkKey of container.checks) {
+    if (parts.length === 1) {
+      // Top-level tag, connect to root
+      edges.push({
+        id: `edge-root-tag-${tagName}`,
+        source: rootKey,
+        target: nodeId,
+        type: "smoothstep",
+        animated: false,
+      });
+    } else {
+      // Has a parent tag, connect to parent
+      const parentName = parts.slice(0, -1).join(":");
+      edges.push({
+        id: `edge-tag-${parentName}-${tagName}`,
+        source: `tag-${parentName}`,
+        target: nodeId,
+        type: "smoothstep",
+        animated: false,
+      });
+    }
+  }
+
+  // Create edges from tags to their checks (only for real tags with checks)
+  for (const tag of allTags) {
+    for (const checkKey of tag.checks) {
       if (seenCheckIds.has(checkKey)) {
         edges.push({
-          id: `edge-container-check-${container.key}-${checkKey}`,
-          source: `container-${container.key}`,
+          id: `edge-tag-check-${tag.name}-${checkKey}`,
+          source: `tag-${tag.name}`,
           target: `check-${checkKey}`,
           type: "smoothstep",
           animated: false,

--- a/js/packages/cyvest-vis/src/components/InvestigationGraph.tsx
+++ b/js/packages/cyvest-vis/src/components/InvestigationGraph.tsx
@@ -126,20 +126,16 @@ function createInvestigationGraph(
   }
 
   // Add check nodes
-  // Group checks by scope for better organization
-  const allChecks: Check[] = [];
-  for (const checksForKey of Object.values(investigation.checks)) {
-    allChecks.push(...checksForKey);
-  }
+  const allChecks = Object.values(investigation.checks);
 
-  // Create unique check nodes (by check_id to avoid duplicates)
+  // Create unique check nodes (by key to avoid duplicates)
   const seenCheckIds = new Set<string>();
   for (const check of allChecks) {
     if (seenCheckIds.has(check.key)) continue;
     seenCheckIds.add(check.key);
 
     const checkNodeData: InvestigationNodeData = {
-      label: truncateLabel(check.check_id, 20),
+      label: truncateLabel(check.check_name, 20),
       nodeType: "check",
       level: check.level,
       score: check.score,

--- a/js/packages/cyvest-vis/src/components/InvestigationNode.tsx
+++ b/js/packages/cyvest-vis/src/components/InvestigationNode.tsx
@@ -1,6 +1,6 @@
 /**
  * Custom node component for the Investigation Graph (Dagre layout).
- * Professional design with SVG icons for root, check, and container nodes.
+ * Professional design with SVG icons for root, check, and tag nodes.
  */
 
 import React, { memo, useMemo } from "react";
@@ -33,7 +33,7 @@ const NODE_CONFIG = {
     showIcon: false, // No icon for checks
     alignCenter: false, // Left-aligned
   },
-  container: {
+  tag: {
     minWidth: 120,
     padding: "8px 14px",
     borderRadius: 16,

--- a/js/packages/cyvest-vis/src/types.ts
+++ b/js/packages/cyvest-vis/src/types.ts
@@ -66,7 +66,7 @@ export type ObservableEdge = Edge<ObservableEdgeData>;
 /**
  * Node types for the investigation graph view.
  */
-export type InvestigationNodeType = "root" | "check" | "container";
+export type InvestigationNodeType = "root" | "check" | "tag";
 
 /**
  * Data attached to investigation graph nodes.
@@ -74,7 +74,7 @@ export type InvestigationNodeType = "root" | "check" | "container";
 export interface InvestigationNodeData extends Record<string, unknown> {
   /** Display label */
   label: string;
-  /** Node type (root, check, or container) */
+  /** Node type (root, check, or tag) */
   nodeType: InvestigationNodeType;
   /** Security level */
   level: Level;
@@ -82,8 +82,8 @@ export interface InvestigationNodeData extends Record<string, unknown> {
   score: number;
   /** Description (for checks) */
   description?: string;
-  /** Path (for containers) */
-  path?: string;
+  /** Name (for tags) */
+  name?: string;
 }
 
 /**

--- a/schema/cyvest.schema.json
+++ b/schema/cyvest.schema.json
@@ -154,59 +154,6 @@
       "title": "Check",
       "type": "object"
     },
-    "Container": {
-      "additionalProperties": false,
-      "description": "Groups checks and sub-containers for hierarchical organization.\n\nContainers allow structuring the investigation into logical sections\nwith aggregated scores and levels.",
-      "properties": {
-        "path": {
-          "title": "Path",
-          "type": "string"
-        },
-        "description": {
-          "default": "",
-          "title": "Description",
-          "type": "string"
-        },
-        "checks": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Checks",
-          "type": "array"
-        },
-        "sub_containers": {
-          "additionalProperties": {
-            "$ref": "#/$defs/Container"
-          },
-          "title": "Sub Containers",
-          "type": "object"
-        },
-        "key": {
-          "title": "Key",
-          "type": "string"
-        },
-        "aggregated_score": {
-          "readOnly": true,
-          "title": "Aggregated Score",
-          "type": "number"
-        },
-        "aggregated_level": {
-          "$ref": "#/$defs/Level",
-          "description": "Calculate the aggregated level from the aggregated score.\n\nReturns:\n    Level based on aggregated score",
-          "readOnly": true
-        }
-      },
-      "required": [
-        "path",
-        "checks",
-        "sub_containers",
-        "key",
-        "aggregated_score",
-        "aggregated_level"
-      ],
-      "title": "Container",
-      "type": "object"
-    },
     "DataExtractionSchema": {
       "additionalProperties": false,
       "description": "Schema for data extraction metadata.",
@@ -562,9 +509,9 @@
           "title": "Threat Intel By Level",
           "type": "object"
         },
-        "total_containers": {
+        "total_tags": {
           "minimum": 0,
-          "title": "Total Containers",
+          "title": "Total Tags",
           "type": "integer"
         }
       },
@@ -576,9 +523,55 @@
         "total_checks",
         "applied_checks",
         "total_threat_intel",
-        "total_containers"
+        "total_tags"
       ],
       "title": "StatisticsSchema",
+      "type": "object"
+    },
+    "Tag": {
+      "additionalProperties": false,
+      "description": "Groups checks for categorical organization.\n\nTags allow structuring the investigation into logical sections\nwith aggregated scores and levels. Hierarchy is automatic based on\nthe \":\" delimiter in tag names (e.g., \"header:auth:dkim\").",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "checks": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Checks",
+          "type": "array"
+        },
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "direct_score": {
+          "description": "Calculate the score from direct checks only (no hierarchy).\n\nFor hierarchical aggregation (including descendant tags), use\nInvestigation.get_tag_aggregated_score() or TagProxy.get_aggregated_score().\n\nReturns:\n    Total score from direct checks",
+          "readOnly": true,
+          "title": "Direct Score",
+          "type": "number"
+        },
+        "direct_level": {
+          "$ref": "#/$defs/Level",
+          "description": "Calculate the level from direct checks only (no hierarchy).\n\nFor hierarchical aggregation (including descendant tags), use\nInvestigation.get_tag_aggregated_level() or TagProxy.get_aggregated_level().\n\nReturns:\n    Level based on direct score",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name",
+        "checks",
+        "key",
+        "direct_score",
+        "direct_level"
+      ],
+      "title": "Tag",
       "type": "object"
     },
     "Taxonomy": {
@@ -756,12 +749,12 @@
       "title": "Enrichments",
       "type": "object"
     },
-    "containers": {
+    "tags": {
       "additionalProperties": {
-        "$ref": "#/$defs/Container"
+        "$ref": "#/$defs/Tag"
       },
-      "description": "Containers keyed by their unique key.",
-      "title": "Containers",
+      "description": "Tags keyed by their unique key.",
+      "title": "Tags",
       "type": "object"
     },
     "stats": {
@@ -789,7 +782,7 @@
     "checks",
     "threat_intels",
     "enrichments",
-    "containers",
+    "tags",
     "stats",
     "data_extraction",
     "score_display"

--- a/schema/cyvest.schema.json
+++ b/schema/cyvest.schema.json
@@ -94,12 +94,8 @@
     "Check": {
       "description": "Represents a verification step in the investigation.\n\nA check validates a specific aspect of the data under investigation\nand contributes to the overall investigation score.",
       "properties": {
-        "check_id": {
-          "title": "Check Id",
-          "type": "string"
-        },
-        "scope": {
-          "title": "Scope",
+        "check_name": {
+          "title": "Check Name",
           "type": "string"
         },
         "description": {
@@ -144,8 +140,7 @@
         }
       },
       "required": [
-        "check_id",
-        "scope",
+        "check_name",
         "description",
         "comment",
         "extra",
@@ -536,16 +531,6 @@
           "title": "Applied Checks",
           "type": "integer"
         },
-        "checks_by_scope": {
-          "additionalProperties": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "title": "Checks By Scope",
-          "type": "object"
-        },
         "checks_by_level": {
           "additionalProperties": {
             "items": {
@@ -749,12 +734,9 @@
     },
     "checks": {
       "additionalProperties": {
-        "items": {
-          "$ref": "#/$defs/Check"
-        },
-        "type": "array"
+        "$ref": "#/$defs/Check"
       },
-      "description": "Checks organized by scope.",
+      "description": "Checks keyed by their unique key.",
       "title": "Checks",
       "type": "object"
     },

--- a/src/cyvest/__init__.py
+++ b/src/cyvest/__init__.py
@@ -9,9 +9,9 @@ from logurich import logger
 
 from cyvest.cyvest import Cyvest
 from cyvest.levels import Level
-from cyvest.model import Check, Container, Enrichment, InvestigationWhitelist, Observable, Taxonomy, ThreatIntel
+from cyvest.model import Check, Enrichment, InvestigationWhitelist, Observable, Tag, Taxonomy, ThreatIntel
 from cyvest.model_enums import ObservableType, RelationshipDirection, RelationshipType
-from cyvest.proxies import CheckProxy, ContainerProxy, EnrichmentProxy, ObservableProxy, ThreatIntelProxy
+from cyvest.proxies import CheckProxy, EnrichmentProxy, ObservableProxy, TagProxy, ThreatIntelProxy
 
 __version__ = "4.4.1"
 
@@ -27,8 +27,8 @@ __all__ = [
     "ObservableProxy",
     "ThreatIntelProxy",
     "EnrichmentProxy",
-    "ContainerProxy",
-    "Container",
+    "TagProxy",
+    "Tag",
     "Enrichment",
     "InvestigationWhitelist",
     "Check",

--- a/src/cyvest/cli.py
+++ b/src/cyvest/cli.py
@@ -172,7 +172,7 @@ def merge(inputs: tuple[Path, ...], output: Path, output_format: str, stats: boo
         logger.info(f"  Total Observables: {investigation_stats.total_observables}")
         logger.info(f"  Total Checks: {investigation_stats.total_checks}")
         logger.info(f"  Total Threat Intel: {investigation_stats.total_threat_intel}")
-        logger.info(f"  Total Containers: {investigation_stats.total_containers}")
+        logger.info(f"  Total Tags: {investigation_stats.total_tags}")
         logger.info(f"  Global Score: {main_investigation.get_global_score():.2f}")
         logger.info(f"  Global Level: {main_investigation.get_global_level()}\n")
 

--- a/src/cyvest/cyvest.py
+++ b/src/cyvest/cyvest.py
@@ -581,8 +581,7 @@ class Cyvest:
 
     def check_create(
         self,
-        check_id: str,
-        scope: str,
+        check_name: str,
         description: str,
         comment: str = "",
         extra: dict[str, Any] | None = None,
@@ -593,8 +592,7 @@ class Cyvest:
         Create a new check.
 
         Args:
-            check_id: Check identifier
-            scope: Check scope
+            check_name: Check name
             description: Check description
             comment: Optional comment
             extra: Optional extra data
@@ -605,8 +603,7 @@ class Cyvest:
             The created check
         """
         check_kwargs: dict[str, Any] = {
-            "check_id": check_id,
-            "scope": scope,
+            "check_name": check_name,
             "description": description,
             "comment": comment,
             "extra": extra or {},
@@ -619,55 +616,16 @@ class Cyvest:
         check = Check(**check_kwargs)
         return self._check_proxy(self._investigation.add_check(check))
 
-    @overload
     def check_get(self, key: str) -> CheckProxy | None:
-        """Get a check by full key string."""
-        ...
-
-    @overload
-    def check_get(self, check_id: str, scope: str) -> CheckProxy | None:
-        """Get a check by ID and scope."""
-        ...
-
-    def check_get(self, *args, **kwargs) -> CheckProxy | None:
         """
-        Get a check by key or by check ID and scope.
+        Get a check by key.
 
         Args:
-            key: Check key (single argument)
-            check_id: Check identifier (when using two arguments)
-            scope: Check scope (when using two arguments)
+            key: Check key
 
         Returns:
             Check if found, None otherwise
-
-        Raises:
-            ValueError: If arguments are invalid or key generation fails
         """
-        if kwargs:
-            if not args and set(kwargs) == {"key"}:
-                key = kwargs["key"]
-            elif not args and set(kwargs) == {"check_id", "scope"}:
-                check_id = kwargs["check_id"]
-                scope = kwargs["scope"]
-                try:
-                    key = keys.generate_check_key(check_id, scope)
-                except Exception as e:
-                    raise ValueError(
-                        f"Failed to generate check key for check_id='{check_id}', scope='{scope}': {e}"
-                    ) from e
-            else:
-                raise ValueError("check_get() accepts either (key: str) or (check_id: str, scope: str)")
-        elif len(args) == 1:
-            key = args[0]
-        elif len(args) == 2:
-            check_id, scope = args
-            try:
-                key = keys.generate_check_key(check_id, scope)
-            except Exception as e:
-                raise ValueError(f"Failed to generate check key for check_id='{check_id}', scope='{scope}': {e}") from e
-        else:
-            raise ValueError("check_get() accepts either (key: str) or (check_id: str, scope: str)")
         return self._check_proxy(self._investigation.get_check(key))
 
     def check_get_all(self) -> dict[str, CheckProxy]:
@@ -1213,8 +1171,7 @@ class Cyvest:
 
     def check(
         self,
-        check_id: str,
-        scope: str,
+        check_name: str,
         description: str,
         comment: str = "",
         extra: dict[str, Any] | None = None,
@@ -1225,8 +1182,7 @@ class Cyvest:
         Create a check with fluent helper methods.
 
         Args:
-            check_id: Check identifier
-            scope: Check scope
+            check_name: Check name
             description: Check description
             comment: Optional comment
             extra: Optional extra data
@@ -1236,7 +1192,7 @@ class Cyvest:
         Returns:
             Check proxy exposing mutation helpers for chaining
         """
-        return self.check_create(check_id, scope, description, comment, extra, score, level)
+        return self.check_create(check_name, description, comment, extra, score, level)
 
     def container(self, path: str, description: str = "") -> ContainerProxy:
         """

--- a/src/cyvest/cyvest.py
+++ b/src/cyvest/cyvest.py
@@ -29,10 +29,10 @@ from cyvest.io_serialization import (
     serialize_investigation,
 )
 from cyvest.levels import Level
-from cyvest.model import Check, Container, Enrichment, Observable, Taxonomy, ThreatIntel
+from cyvest.model import Check, Enrichment, Observable, Tag, Taxonomy, ThreatIntel
 from cyvest.model_enums import ObservableType, PropagationMode, RelationshipDirection, RelationshipType
 from cyvest.model_schema import InvestigationSchema, StatisticsSchema
-from cyvest.proxies import CheckProxy, ContainerProxy, EnrichmentProxy, ObservableProxy, ThreatIntelProxy
+from cyvest.proxies import CheckProxy, EnrichmentProxy, ObservableProxy, TagProxy, ThreatIntelProxy
 from cyvest.score import ScoreMode
 
 if TYPE_CHECKING:
@@ -44,7 +44,7 @@ class Cyvest:
     High-level facade for building and managing cybersecurity investigations.
 
     Provides methods for creating observables, checks, threat intel, enrichments,
-    and containers, with automatic score propagation and statistics tracking.
+    and tags, with automatic score propagation and statistics tracking.
     """
 
     OBS: Final[type[ObservableType]] = ObservableType
@@ -130,10 +130,10 @@ class Cyvest:
             return None
         return CheckProxy(self._investigation, check.key)
 
-    def _container_proxy(self, container: Container | None) -> ContainerProxy | None:
-        if container is None:
+    def _tag_proxy(self, tag: Tag | None) -> TagProxy | None:
+        if tag is None:
             return None
-        return ContainerProxy(self._investigation, container.key)
+        return TagProxy(self._investigation, tag.key)
 
     def _threat_intel_proxy(self, ti: ThreatIntel | None) -> ThreatIntelProxy | None:
         if ti is None:
@@ -675,32 +675,37 @@ class Cyvest:
         self._investigation.apply_score_change(check, Decimal(str(score)), reason=reason)
         return self._check_proxy(check)
 
-    # Container methods
+    # Tag methods
 
-    def container_create(self, path: str, description: str = "") -> ContainerProxy:
+    def tag_create(self, name: str, description: str = "") -> TagProxy:
         """
-        Create a new container.
+        Create a new tag, automatically creating ancestor tags.
+
+        When creating a tag with a hierarchical name (using ":" delimiter),
+        ancestor tags are automatically created if they don't exist.
+        For example, creating "header:auth:dkim" will auto-create
+        "header" and "header:auth" tags.
 
         Args:
-            path: Container path
-            description: Container description
+            name: Tag name (use ":" as hierarchy delimiter)
+            description: Tag description
 
         Returns:
-            The created container
+            The created tag
         """
-        container = Container(path=path, description=description)
-        return self._container_proxy(self._investigation.add_container(container))
+        tag = Tag(name=name, description=description)
+        return self._tag_proxy(self._investigation.add_tag(tag))
 
-    def container_get(self, *args, **kwargs) -> ContainerProxy | None:
+    def tag_get(self, *args, **kwargs) -> TagProxy | None:
         """
-        Get a container by key or by path.
+        Get a tag by key or by name.
 
         Args:
-            key: Container key (single argument, prefixed with ctr:)
-            path: Container path (single argument without prefix)
+            key: Tag key (single argument, prefixed with tag:)
+            name: Tag name (single argument without prefix)
 
         Returns:
-            Container if found, None otherwise
+            Tag if found, None otherwise
 
         Raises:
             ValueError: If arguments are invalid or key generation fails
@@ -708,66 +713,62 @@ class Cyvest:
         if kwargs:
             if not args and set(kwargs) == {"key"}:
                 key = kwargs["key"]
-            elif not args and set(kwargs) == {"path"}:
-                path = kwargs["path"]
+            elif not args and set(kwargs) == {"name"}:
+                name = kwargs["name"]
                 try:
-                    key = keys.generate_container_key(path)
+                    key = keys.generate_tag_key(name)
                 except Exception as e:
-                    raise ValueError(f"Failed to generate container key for path='{path}': {e}") from e
+                    raise ValueError(f"Failed to generate tag key for name='{name}': {e}") from e
             else:
-                raise ValueError("container_get() accepts either (key: str) or (path: str)")
+                raise ValueError("tag_get() accepts either (key: str) or (name: str)")
         elif len(args) == 1:
-            key_or_path = args[0]
-            if isinstance(key_or_path, str) and key_or_path.startswith("ctr:"):
-                key = key_or_path
+            key_or_name = args[0]
+            if isinstance(key_or_name, str) and key_or_name.startswith("tag:"):
+                key = key_or_name
             else:
                 try:
-                    key = keys.generate_container_key(key_or_path)
+                    key = keys.generate_tag_key(key_or_name)
                 except Exception as e:
-                    raise ValueError(f"Failed to generate container key for path='{key_or_path}': {e}") from e
+                    raise ValueError(f"Failed to generate tag key for name='{key_or_name}': {e}") from e
         else:
-            raise ValueError("container_get() accepts either (key: str) or (path: str)")
-        return self._container_proxy(self._investigation.get_container(key))
+            raise ValueError("tag_get() accepts either (key: str) or (name: str)")
+        return self._tag_proxy(self._investigation.get_tag(key))
 
-    def container_get_all(self) -> dict[str, ContainerProxy]:
-        """Get read-only proxies for all containers."""
-        return {
-            key: ContainerProxy(self._investigation, key) for key in self._investigation.get_all_containers().keys()
-        }
+    def tag_get_all(self) -> dict[str, TagProxy]:
+        """Get read-only proxies for all tags."""
+        return {key: TagProxy(self._investigation, key) for key in self._investigation.get_all_tags().keys()}
 
-    def container_add_check(self, container_key: str, check_key: str) -> ContainerProxy:
+    def tag_add_check(self, tag_key: str, check_key: str) -> TagProxy:
         """
-        Add a check to a container.
+        Add a check to a tag.
 
         Args:
-            container_key: Key of the container
+            tag_key: Key of the tag
             check_key: Key of the check
 
         Returns:
-            The container
+            The tag
 
         Raises:
-            KeyError: If the container or check does not exist
+            KeyError: If the tag or check does not exist
         """
-        container = self._investigation.add_check_to_container(container_key, check_key)
-        return self._container_proxy(container)
+        tag = self._investigation.add_check_to_tag(tag_key, check_key)
+        return self._tag_proxy(tag)
 
-    def container_add_sub_container(self, parent_key: str, child_key: str) -> ContainerProxy:
-        """
-        Add a sub-container to a container.
+    def tag_get_children(self, tag_name: str) -> list[TagProxy]:
+        """Get direct child tags of a tag."""
+        tags = self._investigation.get_tag_children(tag_name)
+        return [TagProxy(self._investigation, t.key) for t in tags]
 
-        Args:
-            parent_key: Key of the parent container
-            child_key: Key of the child container
+    def tag_get_descendants(self, tag_name: str) -> list[TagProxy]:
+        """Get all descendant tags of a tag."""
+        tags = self._investigation.get_tag_descendants(tag_name)
+        return [TagProxy(self._investigation, t.key) for t in tags]
 
-        Returns:
-            The parent container
-
-        Raises:
-            KeyError: If the parent or child container does not exist
-        """
-        parent = self._investigation.add_sub_container(parent_key, child_key)
-        return self._container_proxy(parent)
+    def tag_get_ancestors(self, tag_name: str) -> list[TagProxy]:
+        """Get all ancestor tags of a tag."""
+        tags = self._investigation.get_tag_ancestors(tag_name)
+        return [TagProxy(self._investigation, t.key) for t in tags]
 
     # Enrichment methods
 
@@ -929,7 +930,7 @@ class Cyvest:
     def io_save_markdown(
         self,
         filepath: str | Path,
-        include_containers: bool = False,
+        include_tags: bool = False,
         include_enrichments: bool = False,
         include_observables: bool = True,
     ) -> str:
@@ -940,7 +941,7 @@ class Cyvest:
 
         Args:
             filepath: Path to save the Markdown file (relative or absolute)
-            include_containers: Include containers section in the report (default: False)
+            include_tags: Include tags section in the report (default: False)
             include_enrichments: Include enrichments section in the report (default: False)
             include_observables: Include observables section in the report (default: True)
 
@@ -957,13 +958,13 @@ class Cyvest:
             >>> print(path)  # /absolute/path/to/report.md
         """
         save_investigation_markdown(
-            self._investigation, filepath, include_containers, include_enrichments, include_observables
+            self._investigation, filepath, include_tags, include_enrichments, include_observables
         )
         return str(Path(filepath).resolve())
 
     def io_to_markdown(
         self,
-        include_containers: bool = False,
+        include_tags: bool = False,
         include_enrichments: bool = False,
         include_observables: bool = True,
     ) -> str:
@@ -971,7 +972,7 @@ class Cyvest:
         Generate a Markdown report of the investigation.
 
         Args:
-            include_containers: Include containers section in the report (default: False)
+            include_tags: Include tags section in the report (default: False)
             include_enrichments: Include enrichments section in the report (default: False)
             include_observables: Include observables section in the report (default: True)
 
@@ -985,9 +986,7 @@ class Cyvest:
             # Cybersecurity Investigation Report
             ...
         """
-        return generate_markdown_report(
-            self._investigation, include_containers, include_enrichments, include_observables
-        )
+        return generate_markdown_report(self._investigation, include_tags, include_enrichments, include_observables)
 
     def io_to_invest(self, *, include_audit_log: bool = True) -> InvestigationSchema:
         """
@@ -1194,18 +1193,18 @@ class Cyvest:
         """
         return self.check_create(check_name, description, comment, extra, score, level)
 
-    def container(self, path: str, description: str = "") -> ContainerProxy:
+    def tag(self, name: str, description: str = "") -> TagProxy:
         """
-        Create a container with fluent helper methods.
+        Create a tag with fluent helper methods.
 
         Args:
-            path: Container path
-            description: Container description
+            name: Tag name (use ":" as hierarchy delimiter)
+            description: Tag description
 
         Returns:
-            Container proxy exposing mutation helpers for chaining
+            Tag proxy exposing mutation helpers for chaining
         """
-        return self.container_create(path, description)
+        return self.tag_create(name, description)
 
     def root(self) -> ObservableProxy:
         """

--- a/src/cyvest/investigation.py
+++ b/src/cyvest/investigation.py
@@ -14,18 +14,19 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from logurich import logger
 
+from cyvest import keys
 from cyvest.level_score_rules import recalculate_level_for_score
 from cyvest.levels import Level, normalize_level
 from cyvest.model import (
     AuditEvent,
     Check,
-    Container,
     Enrichment,
     InvestigationWhitelist,
     Observable,
     ObservableLink,
     ObservableType,
     Relationship,
+    Tag,
     Taxonomy,
     ThreatIntel,
 )
@@ -63,7 +64,7 @@ class Investigation:
             "fields": {"context", "data"},
             "dict_fields": {"data"},
         },
-        "container": {
+        "tag": {
             "fields": {"description"},
             "dict_fields": set(),
         },
@@ -104,7 +105,7 @@ class Investigation:
         self._checks: dict[str, Check] = {}
         self._threat_intels: dict[str, ThreatIntel] = {}
         self._enrichments: dict[str, Enrichment] = {}
-        self._containers: dict[str, Container] = {}
+        self._tags: dict[str, Tag] = {}
 
         # Internal components
         normalized_score_mode_obs = ScoreMode.normalize(score_mode_obs)
@@ -201,13 +202,10 @@ class Investigation:
         check.observable_links.append(link)
         return True
 
-    def _container_add_check(self, container: Container, check: Check) -> None:
-        if any(existing.key == check.key for existing in container.checks):
+    def _tag_add_check(self, tag: Tag, check: Check) -> None:
+        if any(existing.key == check.key for existing in tag.checks):
             return
-        container.checks.append(check)
-
-    def _container_add_sub_container(self, parent: Container, child: Container) -> None:
-        parent.sub_containers[child.key] = child
+        tag.checks.append(check)
 
     def _infer_object_type(self, obj: Any) -> str | None:
         if isinstance(obj, Observable):
@@ -218,8 +216,8 @@ class Investigation:
             return "threat_intel"
         if isinstance(obj, Enrichment):
             return "enrichment"
-        if isinstance(obj, Container):
-            return "container"
+        if isinstance(obj, Tag):
+            return "tag"
         return None
 
     def apply_score_change(
@@ -561,20 +559,19 @@ class Investigation:
 
         return existing
 
-    def _merge_container(self, existing: Container, incoming: Container) -> Container:
+    def _merge_tag(self, existing: Tag, incoming: Tag) -> Tag:
         """
-        Merge an incoming container into an existing container.
+        Merge an incoming tag into an existing tag.
 
         Strategy:
         - Merge checks (dict-based lookup for efficiency)
-        - Merge sub-containers recursively
 
         Args:
-            existing: The existing container
-            incoming: The incoming container to merge
+            existing: The existing tag
+            incoming: The incoming tag to merge
 
         Returns:
-            The merged container (existing is modified in place)
+            The merged tag (existing is modified in place)
         """
         # Update description if incoming has one
         if incoming.description:
@@ -589,16 +586,7 @@ class Investigation:
                 self._merge_check(existing_checks_dict[incoming_check.key], incoming_check)
             else:
                 # Add new check
-                self._container_add_check(existing, incoming_check)
-
-        # Merge sub-containers recursively
-        for sub_key, incoming_sub in incoming.sub_containers.items():
-            if sub_key in existing.sub_containers:
-                # Merge existing sub-container
-                self._merge_container(existing.sub_containers[sub_key], incoming_sub)
-            else:
-                # Add new sub-container
-                self._container_add_sub_container(existing, incoming_sub)
+                self._tag_add_check(existing, incoming_check)
 
         return existing
 
@@ -787,30 +775,51 @@ class Investigation:
         )
         return enrichment
 
-    def add_container(self, container: Container) -> Container:
+    def add_tag(self, tag: Tag) -> Tag:
         """
-        Add or merge container.
+        Add or merge a tag, automatically creating ancestor tags.
+
+        When adding a tag with a hierarchical name (using ":" delimiter),
+        ancestor tags are automatically created if they don't exist.
+        For example, adding "header:auth:dkim" will auto-create
+        "header" and "header:auth" tags.
 
         Args:
-            container: Container to add or merge
+            tag: Tag to add or merge
 
         Returns:
-            The resulting container (either new or merged)
+            The resulting tag (either new or merged)
         """
-        if container.key in self._containers:
-            r = self._merge_container(self._containers[container.key], container)
+        # Auto-create ancestor tags
+        ancestor_names = keys.get_tag_ancestors(tag.name)
+        for ancestor_name in ancestor_names:
+            ancestor_key = keys.generate_tag_key(ancestor_name)
+            if ancestor_key not in self._tags:
+                ancestor_tag = Tag(name=ancestor_name)
+                self._tags[ancestor_key] = ancestor_tag
+                self._stats.register_tag(ancestor_tag)
+                self._record_event(
+                    event_type="TAG_CREATED",
+                    object_type="tag",
+                    object_key=ancestor_key,
+                    details={"auto_created": True, "descendant": tag.name},
+                )
+
+        # Add or merge the tag itself
+        if tag.key in self._tags:
+            r = self._merge_tag(self._tags[tag.key], tag)
             self._score_engine.recalculate_all()
             return r
 
-        # Register new container
-        self._containers[container.key] = container
-        self._stats.register_container(container)
+        # Register new tag
+        self._tags[tag.key] = tag
+        self._stats.register_tag(tag)
         self._record_event(
-            event_type="CONTAINER_CREATED",
-            object_type="container",
-            object_key=container.key,
+            event_type="TAG_CREATED",
+            object_type="tag",
+            object_key=tag.key,
         )
-        return container
+        return tag
 
     # Relationship and linking methods
 
@@ -943,71 +952,38 @@ class Investigation:
 
         return check
 
-    def add_check_to_container(self, container_key: str, check_key: str) -> Container:
+    def add_check_to_tag(self, tag_key: str, check_key: str) -> Tag:
         """
-        Add a check to a container.
+        Add a check to a tag.
 
         Args:
-            container_key: Key of the container
+            tag_key: Key of the tag
             check_key: Key of the check
 
         Returns:
-            The container
+            The tag
 
         Raises:
-            KeyError: If the container or check does not exist
+            KeyError: If the tag or check does not exist
         """
-        container = self._containers.get(container_key)
+        tag = self._tags.get(tag_key)
         check = self._checks.get(check_key)
 
-        if container is None:
-            raise KeyError(f"container '{container_key}' not found in investigation.")
+        if tag is None:
+            raise KeyError(f"tag '{tag_key}' not found in investigation.")
         if check is None:
             raise KeyError(f"check '{check_key}' not found in investigation.")
 
-        if container and check:
-            self._container_add_check(container, check)
+        if tag and check:
+            self._tag_add_check(tag, check)
             self._record_event(
-                event_type="CONTAINER_CHECK_ADDED",
-                object_type="container",
-                object_key=container.key,
+                event_type="TAG_CHECK_ADDED",
+                object_type="tag",
+                object_key=tag.key,
                 details={"check_key": check.key},
             )
 
-        return container
-
-    def add_sub_container(self, parent_key: str, child_key: str) -> Container:
-        """
-        Add a sub-container to a container.
-
-        Args:
-            parent_key: Key of the parent container
-            child_key: Key of the child container
-
-        Returns:
-            The parent container
-
-        Raises:
-            KeyError: If the parent or child container does not exist
-        """
-        parent = self._containers.get(parent_key)
-        child = self._containers.get(child_key)
-
-        if parent is None:
-            raise KeyError(f"container '{parent_key}' not found in investigation.")
-        if child is None:
-            raise KeyError(f"container '{child_key}' not found in investigation.")
-
-        if parent and child:
-            self._container_add_sub_container(parent, child)
-            self._record_event(
-                event_type="CONTAINER_SUBCONTAINER_ADDED",
-                object_type="container",
-                object_key=parent.key,
-                details={"child_container_key": child.key},
-            )
-
-        return parent
+        return tag
 
     # Query methods
 
@@ -1019,9 +995,88 @@ class Investigation:
         """Get check by full key string."""
         return self._checks.get(key)
 
-    def get_container(self, key: str) -> Container | None:
-        """Get a container by key."""
-        return self._containers.get(key)
+    def get_tag(self, key: str) -> Tag | None:
+        """Get a tag by key."""
+        return self._tags.get(key)
+
+    def get_tag_children(self, tag_name: str) -> list[Tag]:
+        """
+        Get direct child tags of a tag.
+
+        Args:
+            tag_name: Name of the parent tag
+
+        Returns:
+            List of direct child Tag objects
+        """
+        return [t for t in self._tags.values() if keys.is_tag_child_of(t.name, tag_name)]
+
+    def get_tag_descendants(self, tag_name: str) -> list[Tag]:
+        """
+        Get all descendant tags of a tag.
+
+        Args:
+            tag_name: Name of the ancestor tag
+
+        Returns:
+            List of all descendant Tag objects
+        """
+        return [t for t in self._tags.values() if keys.is_tag_descendant_of(t.name, tag_name)]
+
+    def get_tag_ancestors(self, tag_name: str) -> list[Tag]:
+        """
+        Get all ancestor tags of a tag.
+
+        Args:
+            tag_name: Name of the descendant tag
+
+        Returns:
+            List of ancestor Tag objects (in order from root to immediate parent)
+        """
+        ancestor_names = keys.get_tag_ancestors(tag_name)
+        result = []
+        for name in ancestor_names:
+            tag_key = keys.generate_tag_key(name)
+            if tag_key in self._tags:
+                result.append(self._tags[tag_key])
+        return result
+
+    def get_tag_aggregated_score(self, tag_name: str) -> Decimal:
+        """
+        Get aggregated score for a tag including all descendants.
+
+        Args:
+            tag_name: Name of the tag
+
+        Returns:
+            Total score from direct checks and all descendant tag checks
+        """
+        tag_key = keys.generate_tag_key(tag_name)
+        tag = self._tags.get(tag_key)
+        if not tag:
+            return Decimal("0")
+
+        total = tag.get_direct_score()
+
+        # Add scores from direct children only (they will recursively add their children)
+        for child in self.get_tag_children(tag_name):
+            total += self.get_tag_aggregated_score(child.name)
+
+        return total
+
+    def get_tag_aggregated_level(self, tag_name: str) -> Level:
+        """
+        Get aggregated level for a tag including all descendants.
+
+        Args:
+            tag_name: Name of the tag
+
+        Returns:
+            Level based on aggregated score
+        """
+        from cyvest.levels import get_level_from_score
+
+        return get_level_from_score(self.get_tag_aggregated_score(tag_name))
 
     def get_enrichment(self, key: str) -> Enrichment | None:
         """Get an enrichment by key."""
@@ -1055,7 +1110,7 @@ class Investigation:
 
     def update_model_metadata(
         self,
-        model_type: Literal["observable", "check", "threat_intel", "enrichment", "container"],
+        model_type: Literal["observable", "check", "threat_intel", "enrichment", "tag"],
         key: str,
         updates: dict[str, Any],
         *,
@@ -1083,7 +1138,7 @@ class Investigation:
             "check": self._checks,
             "threat_intel": self._threat_intels,
             "enrichment": self._enrichments,
-            "container": self._containers,
+            "tag": self._tags,
         }
         store = store_lookup[model_type]
         target = store.get(key)
@@ -1152,9 +1207,9 @@ class Investigation:
         """Get all enrichments."""
         return self._enrichments.copy()
 
-    def get_all_containers(self) -> dict[str, Container]:
-        """Get all containers."""
-        return self._containers.copy()
+    def get_all_tags(self) -> dict[str, Tag]:
+        """Get all tags."""
+        return self._tags.copy()
 
     # Scoring and statistics
 
@@ -1397,11 +1452,10 @@ class Investigation:
                 "data": deepcopy(enrichment.data),
             }
 
-        def _snapshot_container(container: Container) -> dict[str, Any]:
+        def _snapshot_tag(tag: Tag) -> dict[str, Any]:
             return {
-                "description": container.description,
-                "checks": sorted(check.key for check in container.checks),
-                "sub_containers": sorted(container.sub_containers.keys()),
+                "description": tag.description,
+                "checks": sorted(check.key for check in tag.checks),
             }
 
         merge_summary: list[dict[str, Any]] = []
@@ -1411,7 +1465,7 @@ class Investigation:
             incoming_threat_intels,
             incoming_checks,
             incoming_enrichments,
-            incoming_containers,
+            incoming_tags,
         ) = self._clone_for_merge(other)
 
         # PASS 1: Merge observables and collect deferred relationships
@@ -1524,13 +1578,13 @@ class Investigation:
                 }
             )
 
-        # Merge containers
-        for container in incoming_containers.values():
-            existing_container = self._containers.get(container.key)
-            before = _snapshot_container(existing_container) if existing_container else None
-            self.add_container(container)
-            if existing_container:
-                after = _snapshot_container(existing_container)
+        # Merge tags
+        for tag in incoming_tags.values():
+            existing_tag = self._tags.get(tag.key)
+            before = _snapshot_tag(existing_tag) if existing_tag else None
+            self.add_tag(tag)
+            if existing_tag:
+                after = _snapshot_tag(existing_tag)
                 changed_fields = _diff_fields(before, after) if before else []
                 action = "merged" if changed_fields else "skipped"
             else:
@@ -1538,8 +1592,8 @@ class Investigation:
                 action = "created"
             merge_summary.append(
                 {
-                    "object_type": "container",
-                    "object_key": container.key,
+                    "object_type": "tag",
+                    "object_key": tag.key,
                     "action": action,
                     "changed_fields": changed_fields,
                 }
@@ -1576,7 +1630,7 @@ class Investigation:
         dict[str, ThreatIntel],
         dict[str, Check],
         dict[str, Enrichment],
-        dict[str, Container],
+        dict[str, Tag],
     ]:
         """Clone incoming models while preserving shared object references."""
         incoming_threat_intels = {key: ti.model_copy(deep=True) for key, ti in other._threat_intels.items()}
@@ -1614,31 +1668,28 @@ class Investigation:
             orphan_checks[check.key] = copied
             return copied
 
-        incoming_containers: dict[str, Container] = {}
+        incoming_tags: dict[str, Tag] = {}
 
-        def _copy_container(container: Container) -> Container:
-            existing = incoming_containers.get(container.key)
+        def _copy_tag(tag: Tag) -> Tag:
+            existing = incoming_tags.get(tag.key)
             if existing:
                 return existing
-            copied = Container(
-                path=container.path,
-                description=container.description,
-                checks=[_copy_check(check) for check in container.checks],
-                sub_containers={},
-                key=container.key,
+            copied = Tag(
+                name=tag.name,
+                description=tag.description,
+                checks=[_copy_check(check) for check in tag.checks],
+                key=tag.key,
             )
-            incoming_containers[container.key] = copied
-            for sub_key, sub in container.sub_containers.items():
-                copied.sub_containers[sub_key] = _copy_container(sub)
+            incoming_tags[tag.key] = copied
             return copied
 
-        for container in other._containers.values():
-            _copy_container(container)
+        for tag in other._tags.values():
+            _copy_tag(tag)
 
         return (
             incoming_observables,
             incoming_threat_intels,
             incoming_checks,
             incoming_enrichments,
-            incoming_containers,
+            incoming_tags,
         )

--- a/src/cyvest/io_rich.py
+++ b/src/cyvest/io_rich.py
@@ -387,19 +387,19 @@ def display_summary(
         level = f"[{color_level}]{check.level.name}[/{color_level}]"
         table.add_row(name, score, level)
 
-    # Containers section (if any)
-    if cv.container_get_all():
+    # Tags section (if any)
+    if cv.tag_get_all():
         table.add_section()
-        rule = Rule("[bold magenta]CONTAINERS[/bold magenta]")
+        rule = Rule("[bold magenta]TAGS[/bold magenta]")
         table.add_row(rule, "-", "-")
 
-        for container in cv.container_get_all().values():
-            agg_score = container.get_aggregated_score()
-            agg_level = container.get_aggregated_level()
+        for tag in cv.tag_get_all().values():
+            agg_score = tag.get_aggregated_score()
+            agg_level = tag.get_aggregated_level()
             color_level = get_color_level(agg_level)
             color_score = get_color_score(agg_score)
 
-            name = f"  {container.path}"
+            name = f"  {tag.name}"
             score = f"[{color_score}]{agg_score:.2f}[/{color_score}]"
             level = f"[{color_level}]{agg_level.name}[/{color_level}]"
             table.add_row(name, score, level)

--- a/src/cyvest/io_rich.py
+++ b/src/cyvest/io_rich.py
@@ -50,8 +50,8 @@ def _sort_key_by_score(item: Any) -> tuple[Decimal, str]:
     except (TypeError, ValueError, InvalidOperation):
         decimal_score = Decimal(0)
 
-    item_id = getattr(item, "check_id", "")
-    return (-decimal_score, item_id)
+    item_name = getattr(item, "check_name", "")
+    return (-decimal_score, item_name)
 
 
 def _get_direction_symbol(rel: Relationship, reversed_edge: bool) -> str:
@@ -377,26 +377,15 @@ def display_summary(
     rule = Rule("[bold magenta]CHECKS[/bold magenta]")
     table.add_row(rule, "-", "-")
 
-    # Organize checks by scope
-    checks_by_scope: dict[str, list[Any]] = {}
-    for check in cv.check_get_all().values():
-        if check.level in resolved_excluded_levels:
-            continue
-        if check.scope not in checks_by_scope:
-            checks_by_scope[check.scope] = []
-        checks_by_scope[check.scope].append(check)
-
-    for scope_name, checks in checks_by_scope.items():
-        scope_rule = Align(f"[bold magenta]{scope_name}[/bold magenta]", align="left")
-        table.add_row(scope_rule, "-", "-")
-        checks = sorted(checks, key=_sort_key_by_score)
-        for check in checks:
-            color_level = get_color_level(check.level)
-            color_score = get_color_score(check.score)
-            name = f"  {check.check_id}"
-            score = f"[{color_score}]{check.score_display}[/{color_score}]"
-            level = f"[{color_level}]{check.level.name}[/{color_level}]"
-            table.add_row(name, score, level)
+    checks = [c for c in cv.check_get_all().values() if c.level not in resolved_excluded_levels]
+    checks = sorted(checks, key=_sort_key_by_score)
+    for check in checks:
+        color_level = get_color_level(check.level)
+        color_score = get_color_score(check.score)
+        name = f"  {check.check_name}"
+        score = f"[{color_score}]{check.score_display}[/{color_score}]"
+        level = f"[{color_level}]{check.level.name}[/{color_level}]"
+        table.add_row(name, score, level)
 
     # Containers section (if any)
     if cv.container_get_all():
@@ -437,7 +426,7 @@ def display_summary(
 
             for check in checks:
                 color_score = get_color_score(check.score)
-                name = f"  {check.check_id}"
+                name = f"  {check.check_name}"
                 score = f"[{color_score}]{check.score_display}[/{color_score}]"
                 level = f"[{color_level}]{check.level.name}[/{color_level}]"
                 table.add_row(name, score, level)
@@ -558,11 +547,11 @@ def display_statistics(cv: Cyvest, rich_print: Callable[[Any], None]) -> None:
     # Check statistics table
     rich_print("")
     check_table = Table(title="Check Statistics")
-    check_table.add_column("Scope", style="cyan")
+    check_table.add_column("Level", style="cyan")
     check_table.add_column("Count", justify="right")
 
-    for scope, count in stats.checks_by_scope.items():
-        check_table.add_row(scope, str(count))
+    for level, count in stats.checks_by_level.items():
+        check_table.add_row(level, str(count))
 
     rich_print(check_table)
 

--- a/src/cyvest/io_schema.py
+++ b/src/cyvest/io_schema.py
@@ -26,7 +26,7 @@ def get_investigation_schema() -> dict[str, Any]:
     matches the actual `model_dump()` output structure.
 
     The returned schema automatically includes all referenced entity types
-    (Observable, Check, ThreatIntel, Enrichment, Container, InvestigationWhitelist)
+    (Observable, Check, ThreatIntel, Enrichment, Tag, InvestigationWhitelist)
     in the `$defs` section.
 
     Returns:

--- a/src/cyvest/io_serialization.py
+++ b/src/cyvest/io_serialization.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from cyvest.levels import Level, normalize_level
-from cyvest.model import AuditEvent, Check, Container, Enrichment, Observable, Relationship, ThreatIntel
+from cyvest.model import AuditEvent, Check, Enrichment, Observable, Relationship, Tag, ThreatIntel
 from cyvest.model_enums import ObservableType
 from cyvest.model_schema import InvestigationSchema
 from cyvest.score import ScoreMode
@@ -41,7 +41,7 @@ def serialize_investigation(inv: Investigation, *, include_audit_log: bool = Tru
     observables = dict(inv.get_all_observables())
     threat_intels = dict(inv.get_all_threat_intels())
     enrichments = dict(inv.get_all_enrichments())
-    containers = dict(inv.get_all_containers())
+    tags = dict(inv.get_all_tags())
 
     # Get all checks
     checks = dict(inv.get_all_checks())
@@ -63,7 +63,7 @@ def serialize_investigation(inv: Investigation, *, include_audit_log: bool = Tru
         checks=checks,
         threat_intels=threat_intels,
         enrichments=enrichments,
-        containers=containers,
+        tags=tags,
         stats=inv.get_statistics(),
         data_extraction={
             "root_type": root_type_value,
@@ -91,7 +91,7 @@ def save_investigation_json(inv: Investigation, filepath: str | Path, *, include
 
 def generate_markdown_report(
     inv: Investigation,
-    include_containers: bool = False,
+    include_tags: bool = False,
     include_enrichments: bool = False,
     include_observables: bool = True,
 ) -> str:
@@ -100,7 +100,7 @@ def generate_markdown_report(
 
     Args:
         inv: Investigation
-        include_containers: Include containers section in the report (default: False)
+        include_tags: Include tags section in the report (default: False)
         include_enrichments: Include enrichments section in the report (default: False)
         include_observables: Include observables section in the report (default: True)
 
@@ -198,17 +198,17 @@ def generate_markdown_report(
             lines.append(f"- **Data:** {json.dumps(enr.data, indent=2)}")
             lines.append("")
 
-    # Containers
-    if include_containers and inv.get_all_containers():
-        lines.append("## Containers")
+    # Tags
+    if include_tags and inv.get_all_tags():
+        lines.append("## Tags")
         lines.append("")
-        for ctr in inv.get_all_containers().values():
-            lines.append(f"### {ctr.path}")
-            lines.append(f"- **Description:** {ctr.description}")
-            lines.append(f"- **Aggregated Score:** {ctr.get_aggregated_score():.2f}")
-            lines.append(f"- **Aggregated Level:** {ctr.get_aggregated_level().name}")
-            lines.append(f"- **Checks:** {len(ctr.checks)}")
-            lines.append(f"- **Sub-containers:** {len(ctr.sub_containers)}")
+        for tag in inv.get_all_tags().values():
+            lines.append(f"### {tag.name}")
+            lines.append(f"- **Description:** {tag.description}")
+            lines.append(f"- **Direct Score:** {tag.get_direct_score():.2f}")
+            lines.append(f"- **Aggregated Score:** {inv.get_tag_aggregated_score(tag.name):.2f}")
+            lines.append(f"- **Aggregated Level:** {inv.get_tag_aggregated_level(tag.name).name}")
+            lines.append(f"- **Direct Checks:** {len(tag.checks)}")
             lines.append("")
 
     return "\n".join(lines)
@@ -217,7 +217,7 @@ def generate_markdown_report(
 def save_investigation_markdown(
     inv: Investigation,
     filepath: str | Path,
-    include_containers: bool = False,
+    include_tags: bool = False,
     include_enrichments: bool = False,
     include_observables: bool = True,
 ) -> None:
@@ -227,11 +227,11 @@ def save_investigation_markdown(
     Args:
         inv: Investigation to save
         filepath: Path to save the Markdown file
-        include_containers: Include containers section in the report (default: False)
+        include_tags: Include tags section in the report (default: False)
         include_enrichments: Include enrichments section in the report (default: False)
         include_observables: Include observables section in the report (default: True)
     """
-    markdown = generate_markdown_report(inv, include_containers, include_enrichments, include_observables)
+    markdown = generate_markdown_report(inv, include_tags, include_enrichments, include_observables)
     with open(filepath, "w", encoding="utf-8") as f:
         f.write(markdown)
 
@@ -393,8 +393,7 @@ def load_investigation_json(filepath: str | Path) -> Cyvest:
             "extra": check_info.get("extra", {}),
             "score": Decimal(str(check_info.get("score", 0))),
             "level": check_info.get("level", "NONE"),
-            "origin_investigation_id": check_info.get("origin_investigation_id")
-            or cv._investigation.investigation_id,
+            "origin_investigation_id": check_info.get("origin_investigation_id") or cv._investigation.investigation_id,
             "observable_links": normalized_links,
             "key": check_info.get("key", ""),
         }
@@ -412,29 +411,25 @@ def load_investigation_json(filepath: str | Path) -> Cyvest:
         enrichment = Enrichment.model_validate(enr_data)
         cv._investigation.add_enrichment(enrichment)
 
-    # Containers
-    def build_container(container_info: dict[str, Any]) -> Container:
-        container_data = {
-            "path": container_info.get("path", ""),
-            "description": container_info.get("description", ""),
-            "key": container_info.get("key", ""),
+    # Tags
+    def build_tag(tag_info: dict[str, Any]) -> Tag:
+        tag_data = {
+            "name": tag_info.get("name", ""),
+            "description": tag_info.get("description", ""),
+            "key": tag_info.get("key", ""),
         }
-        container = Container.model_validate(container_data)
-        container = cv._investigation.add_container(container)
+        tag = Tag.model_validate(tag_data)
+        tag = cv._investigation.add_tag(tag)
 
-        for check_key in container_info.get("checks", []):
+        for check_key in tag_info.get("checks", []):
             check = cv._investigation.get_check(check_key)
             if check:
-                cv._investigation.add_check_to_container(container.key, check.key)
+                cv._investigation.add_check_to_tag(tag.key, check.key)
 
-        for sub_info in container_info.get("sub_containers", {}).values():
-            sub_container = build_container(sub_info)
-            cv._investigation.add_sub_container(container.key, sub_container.key)
+        return tag
 
-        return container
-
-    for container_info in data.get("containers", {}).values():
-        build_container(container_info)
+    for tag_info in data.get("tags", {}).values():
+        build_tag(tag_info)
 
     cv._investigation._refresh_check_links()
 

--- a/src/cyvest/io_serialization.py
+++ b/src/cyvest/io_serialization.py
@@ -43,12 +43,8 @@ def serialize_investigation(inv: Investigation, *, include_audit_log: bool = Tru
     enrichments = dict(inv.get_all_enrichments())
     containers = dict(inv.get_all_containers())
 
-    # Build checks organized by scope (resolve proxies)
-    checks_by_scope: dict[str, list[Check]] = {}
-    for check in inv.get_all_checks().values():
-        if check.scope not in checks_by_scope:
-            checks_by_scope[check.scope] = []
-        checks_by_scope[check.scope].append(check)
+    # Get all checks
+    checks = dict(inv.get_all_checks())
 
     # Get root type
     root = inv.get_root()
@@ -64,7 +60,7 @@ def serialize_investigation(inv: Investigation, *, include_audit_log: bool = Tru
         whitelists=list(inv.get_whitelists()),
         audit_log=inv.get_audit_log() if include_audit_log else None,
         observables=observables,
-        checks=checks_by_scope,
+        checks=checks,
         threat_intels=threat_intels,
         enrichments=enrichments,
         containers=containers,
@@ -150,19 +146,16 @@ def generate_markdown_report(
                 lines.append(f"  - Justification: {entry.justification}")
         lines.append("")
 
-    # Checks by Scope
-    lines.append("## Checks by Scope")
+    # Checks
+    lines.append("## Checks")
     lines.append("")
-    for scope, _count in inv.get_statistics().checks_by_scope.items():
-        lines.append(f"### {scope}")
-        lines.append("")
-        for check in inv.get_all_checks().values():
-            if check.scope == scope and check.level != Level.NONE:
-                lines.append(f"- **{check.check_id}**: Score: {check.score_display}, Level: {check.level.name}")
-                lines.append(f"  - Description: {check.description}")
-                if check.comment:
-                    lines.append(f"  - Comment: {check.comment}")
-        lines.append("")
+    for check in inv.get_all_checks().values():
+        if check.level != Level.NONE:
+            lines.append(f"- **{check.check_name}**: Score: {check.score_display}, Level: {check.level.name}")
+            lines.append(f"  - Description: {check.description}")
+            if check.comment:
+                lines.append(f"  - Comment: {check.comment}")
+    lines.append("")
 
     # Observables
     if include_observables and inv.get_all_observables():
@@ -380,35 +373,33 @@ def load_investigation_json(filepath: str | Path) -> Cyvest:
             cv._investigation.add_threat_intel(ti, observable)
 
     # Checks - leverage Pydantic model_validate
-    for scope_checks in data.get("checks", {}).values():
-        for check_info in scope_checks:
-            raw_links = check_info.get("observable_links", []) or []
-            normalized_links = []
-            for link in raw_links:
-                if isinstance(link, dict):
-                    normalized_links.append(
-                        {
-                            "observable_key": link.get("observable_key", ""),
-                            "propagation_mode": link.get("propagation_mode", "LOCAL_ONLY"),
-                        }
-                    )
-                else:
-                    normalized_links.append(link)
-            check_data = {
-                "check_id": check_info.get("check_id", ""),
-                "scope": check_info.get("scope", ""),
-                "description": check_info.get("description", ""),
-                "comment": check_info.get("comment", ""),
-                "extra": check_info.get("extra", {}),
-                "score": Decimal(str(check_info.get("score", 0))),
-                "level": check_info.get("level", "NONE"),
-                "origin_investigation_id": check_info.get("origin_investigation_id")
-                or cv._investigation.investigation_id,
-                "observable_links": normalized_links,
-                "key": check_info.get("key", ""),
-            }
-            check = Check.model_validate(check_data)
-            cv._investigation.add_check(check)
+    for check_info in data.get("checks", {}).values():
+        raw_links = check_info.get("observable_links", []) or []
+        normalized_links = []
+        for link in raw_links:
+            if isinstance(link, dict):
+                normalized_links.append(
+                    {
+                        "observable_key": link.get("observable_key", ""),
+                        "propagation_mode": link.get("propagation_mode", "LOCAL_ONLY"),
+                    }
+                )
+            else:
+                normalized_links.append(link)
+        check_data = {
+            "check_name": check_info.get("check_name", ""),
+            "description": check_info.get("description", ""),
+            "comment": check_info.get("comment", ""),
+            "extra": check_info.get("extra", {}),
+            "score": Decimal(str(check_info.get("score", 0))),
+            "level": check_info.get("level", "NONE"),
+            "origin_investigation_id": check_info.get("origin_investigation_id")
+            or cv._investigation.investigation_id,
+            "observable_links": normalized_links,
+            "key": check_info.get("key", ""),
+        }
+        check = Check.model_validate(check_data)
+        cv._investigation.add_check(check)
 
     # Enrichments - leverage Pydantic model_validate
     for enr_info in data.get("enrichments", {}).values():

--- a/src/cyvest/keys.py
+++ b/src/cyvest/keys.py
@@ -56,22 +56,20 @@ def generate_observable_key(obs_type: str, value: str) -> str:
     return f"obs:{normalized_type}:{normalized_value}"
 
 
-def generate_check_key(check_id: str, scope: str) -> str:
+def generate_check_key(check_name: str) -> str:
     """
     Generate a unique key for a check.
 
-    Format: chk:{check_id}:{scope}
+    Format: chk:{check_name}
 
     Args:
-        check_id: Identifier of the check
-        scope: Scope of the check
+        check_name: Name of the check
 
     Returns:
         Unique check key
     """
-    normalized_id = _normalize_value(check_id)
-    normalized_scope = _normalize_value(scope)
-    return f"chk:{normalized_id}:{normalized_scope}"
+    normalized_name = _normalize_value(check_name)
+    return f"chk:{normalized_name}"
 
 
 def generate_threat_intel_key(source: str, observable_key: str) -> str:

--- a/src/cyvest/keys.py
+++ b/src/cyvest/keys.py
@@ -109,22 +109,67 @@ def generate_enrichment_key(name: str, context: str = "") -> str:
     return f"enr:{normalized_name}"
 
 
-def generate_container_key(path: str) -> str:
+def generate_tag_key(name: str) -> str:
     """
-    Generate a unique key for a container.
+    Generate a unique key for a tag.
 
-    Format: ctr:{normalized_path}
+    Format: tag:{normalized_name}
 
     Args:
-        path: Path of the container (can use / or . as separator)
+        name: Name of the tag (uses : as hierarchy delimiter)
 
     Returns:
-        Unique container key
+        Unique tag key
     """
-    # Normalize path separators
-    normalized_path = path.replace("\\", "/").strip("/")
-    normalized_path = _normalize_value(normalized_path)
-    return f"ctr:{normalized_path}"
+    normalized_name = _normalize_value(name)
+    return f"tag:{normalized_name}"
+
+
+def get_tag_ancestors(name: str) -> list[str]:
+    """
+    Get all ancestor tag names from a hierarchical tag name.
+
+    Uses ":" as the hierarchy delimiter.
+
+    Args:
+        name: Tag name (e.g., "header:auth:dkim")
+
+    Returns:
+        List of ancestor names (e.g., ["header", "header:auth"])
+    """
+    parts = name.split(":")
+    return [":".join(parts[: i + 1]) for i in range(len(parts) - 1)]
+
+
+def is_tag_child_of(child_name: str, parent_name: str) -> bool:
+    """
+    Check if a tag is a direct child of another tag.
+
+    Args:
+        child_name: Potential child tag name
+        parent_name: Potential parent tag name
+
+    Returns:
+        True if child_name is a direct child of parent_name
+    """
+    if not child_name.startswith(parent_name + ":"):
+        return False
+    remaining = child_name[len(parent_name) + 1 :]
+    return ":" not in remaining
+
+
+def is_tag_descendant_of(descendant_name: str, ancestor_name: str) -> bool:
+    """
+    Check if a tag is a descendant (child, grandchild, etc.) of another tag.
+
+    Args:
+        descendant_name: Potential descendant tag name
+        ancestor_name: Potential ancestor tag name
+
+    Returns:
+        True if descendant_name is a descendant of ancestor_name
+    """
+    return descendant_name.startswith(ancestor_name + ":")
 
 
 def parse_key_type(key: str) -> str | None:
@@ -135,7 +180,7 @@ def parse_key_type(key: str) -> str | None:
         key: The key to parse
 
     Returns:
-        Type prefix (obs, chk, ti, enr, ctr) or None if invalid
+        Type prefix (obs, chk, ti, enr, tag) or None if invalid
     """
     if ":" in key:
         return key.split(":", 1)[0]
@@ -183,7 +228,7 @@ def validate_key(key: str, expected_type: str | None = None) -> bool:
         return False
 
     key_type = parse_key_type(key)
-    if key_type not in ("obs", "chk", "ti", "enr", "ctr"):
+    if key_type not in ("obs", "chk", "ti", "enr", "tag"):
         return False
 
     if expected_type and key_type != expected_type:

--- a/src/cyvest/model.py
+++ b/src/cyvest/model.py
@@ -391,8 +391,7 @@ class Check(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    check_id: str = Field(...)
-    scope: str = Field(...)
+    check_name: str = Field(...)
     description: str = Field(...)
     comment: str = Field(...)
     extra: dict[str, Any] = Field(...)
@@ -442,7 +441,7 @@ class Check(BaseModel):
     def generate_key(self) -> Self:
         """Generate key."""
         if not self.key:
-            self.key = keys.generate_check_key(self.check_id, self.scope)
+            self.key = keys.generate_check_key(self.check_name)
         return self
 
     @field_serializer("score")

--- a/src/cyvest/model.py
+++ b/src/cyvest/model.py
@@ -1,7 +1,7 @@
 """
 Core data models for Cyvest investigation framework.
 
-Defines the base classes for Check, Observable, ThreatIntel, Enrichment, Container,
+Defines the base classes for Check, Observable, ThreatIntel, Enrichment, Tag,
 and InvestigationWhitelist using Pydantic BaseModel.
 """
 
@@ -490,27 +490,27 @@ class Enrichment(BaseModel):
         return values
 
 
-class Container(BaseModel):
+class Tag(BaseModel):
     """
-    Groups checks and sub-containers for hierarchical organization.
+    Groups checks for categorical organization.
 
-    Containers allow structuring the investigation into logical sections
-    with aggregated scores and levels.
+    Tags allow structuring the investigation into logical sections
+    with aggregated scores and levels. Hierarchy is automatic based on
+    the ":" delimiter in tag names (e.g., "header:auth:dkim").
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
-    path: str
+    name: str
     description: str = ""
     checks: list[Check] = Field(...)
-    sub_containers: dict[str, Container] = Field(...)
     key: str = Field(...)
 
     @model_validator(mode="after")
     def generate_key(self) -> Self:
         """Generate key."""
         if not self.key:
-            self.key = keys.generate_container_key(self.path)
+            self.key = keys.generate_tag_key(self.name)
         return self
 
     @model_validator(mode="before")
@@ -520,63 +520,64 @@ class Container(BaseModel):
             return values
         if "checks" not in values:
             values["checks"] = []
-        if "sub_containers" not in values:
-            values["sub_containers"] = {}
         if "key" not in values:
             values["key"] = ""
         return values
-
-    @computed_field(return_type=Decimal)
-    @property
-    def aggregated_score(self) -> Decimal:
-        return self.get_aggregated_score()
-
-    @field_serializer("aggregated_score")
-    def serialize_aggregated_score(self, v: Decimal) -> float:
-        return float(v)
-
-    def get_aggregated_score(self) -> Decimal:
-        """
-        Calculate the aggregated score from all checks and sub-containers.
-
-        Returns:
-            Total aggregated score
-        """
-        total = Decimal("0")
-        # Sum scores from direct checks
-        for check in self.checks:
-            total += check.score
-        # Sum scores from sub-containers
-        for sub in self.sub_containers.values():
-            total += sub.get_aggregated_score()
-        return total
-
-    @computed_field(return_type=Level)
-    @property
-    def aggregated_level(self) -> Level:
-        """
-        Calculate the aggregated level from the aggregated score.
-
-        Returns:
-            Level based on aggregated score
-        """
-        return self.get_aggregated_level()
 
     @field_serializer("checks")
     def serialize_checks(self, value: list[Check]) -> list[str]:
         """Serialize checks as keys only."""
         return [check.key for check in value]
 
-    @field_serializer("sub_containers")
-    def serialize_sub_containers(self, value: dict[str, Container]) -> dict[str, Container]:
-        """Serialize sub-containers recursively."""
-        return {key: sub.model_dump() for key, sub in value.items()}
-
-    def get_aggregated_level(self) -> Level:
+    @computed_field(return_type=Decimal)
+    @property
+    def direct_score(self) -> Decimal:
         """
-        Calculate the aggregated level from the aggregated score.
+        Calculate the score from direct checks only (no hierarchy).
+
+        For hierarchical aggregation (including descendant tags), use
+        Investigation.get_tag_aggregated_score() or TagProxy.get_aggregated_score().
 
         Returns:
-            Level based on aggregated score
+            Total score from direct checks
         """
-        return get_level_from_score(self.get_aggregated_score())
+        return self.get_direct_score()
+
+    @field_serializer("direct_score")
+    def serialize_direct_score(self, v: Decimal) -> float:
+        return float(v)
+
+    def get_direct_score(self) -> Decimal:
+        """
+        Calculate the score from direct checks only.
+
+        Returns:
+            Total score from direct checks
+        """
+        total = Decimal("0")
+        for check in self.checks:
+            total += check.score
+        return total
+
+    @computed_field(return_type=Level)
+    @property
+    def direct_level(self) -> Level:
+        """
+        Calculate the level from direct checks only (no hierarchy).
+
+        For hierarchical aggregation (including descendant tags), use
+        Investigation.get_tag_aggregated_level() or TagProxy.get_aggregated_level().
+
+        Returns:
+            Level based on direct score
+        """
+        return self.get_direct_level()
+
+    def get_direct_level(self) -> Level:
+        """
+        Calculate the level from direct score only.
+
+        Returns:
+            Level based on direct score
+        """
+        return get_level_from_score(self.get_direct_score())

--- a/src/cyvest/model_schema.py
+++ b/src/cyvest/model_schema.py
@@ -21,10 +21,10 @@ from cyvest.levels import Level
 from cyvest.model import (
     AuditEvent,
     Check,
-    Container,
     Enrichment,
     InvestigationWhitelist,
     Observable,
+    Tag,
     ThreatIntel,
     _format_score_decimal,
 )
@@ -54,7 +54,7 @@ class StatisticsSchema(BaseModel):
     total_threat_intel: Annotated[int, Field(ge=0)]
     threat_intel_by_source: dict[str, Annotated[int, Field(ge=0)]] = Field(default_factory=dict)
     threat_intel_by_level: dict[str, Annotated[int, Field(ge=0)]] = Field(default_factory=dict)
-    total_containers: Annotated[int, Field(ge=0)]
+    total_tags: Annotated[int, Field(ge=0)]
 
 
 class DataExtractionSchema(BaseModel):
@@ -128,9 +128,9 @@ class InvestigationSchema(BaseModel):
         ...,
         description="Enrichment entries keyed by their unique key.",
     )
-    containers: dict[str, Container] = Field(
+    tags: dict[str, Tag] = Field(
         ...,
-        description="Containers keyed by their unique key.",
+        description="Tags keyed by their unique key.",
     )
     stats: StatisticsSchema = Field(description="Investigation statistics summary.")
     data_extraction: DataExtractionSchema = Field(description="Data extraction metadata.")
@@ -158,6 +158,6 @@ class InvestigationSchema(BaseModel):
         v.setdefault("checks", {})
         v.setdefault("threat_intels", {})
         v.setdefault("enrichments", {})
-        v.setdefault("containers", {})
+        v.setdefault("tags", {})
 
         return v

--- a/src/cyvest/model_schema.py
+++ b/src/cyvest/model_schema.py
@@ -50,7 +50,6 @@ class StatisticsSchema(BaseModel):
     observables_by_type_and_level: dict[str, dict[str, Annotated[int, Field(ge=0)]]] = Field(default_factory=dict)
     total_checks: Annotated[int, Field(ge=0)]
     applied_checks: Annotated[int, Field(ge=0)]
-    checks_by_scope: dict[str, list[str]] = Field(default_factory=dict)
     checks_by_level: dict[str, list[str]] = Field(default_factory=dict)
     total_threat_intel: Annotated[int, Field(ge=0)]
     threat_intel_by_source: dict[str, Annotated[int, Field(ge=0)]] = Field(default_factory=dict)
@@ -117,9 +116,9 @@ class InvestigationSchema(BaseModel):
         ...,
         description="Observables keyed by their unique key.",
     )
-    checks: dict[str, list[Check]] = Field(
+    checks: dict[str, Check] = Field(
         ...,
-        description="Checks organized by scope.",
+        description="Checks keyed by their unique key.",
     )
     threat_intels: dict[str, ThreatIntel] = Field(
         ...,

--- a/src/cyvest/proxies.py
+++ b/src/cyvest/proxies.py
@@ -282,12 +282,8 @@ class CheckProxy(_ReadOnlyProxy[Check]):
         return check
 
     @property
-    def check_id(self) -> str:
-        return self._read_attr("check_id")
-
-    @property
-    def scope(self) -> str:
-        return self._read_attr("scope")
+    def check_name(self) -> str:
+        return self._read_attr("check_name")
 
     @property
     def description(self) -> str:

--- a/src/cyvest/proxies.py
+++ b/src/cyvest/proxies.py
@@ -18,12 +18,12 @@ from cyvest import keys
 from cyvest.levels import Level
 from cyvest.model import (
     Check,
-    Container,
     Enrichment,
     Observable,
     ObservableLink,
     ObservableType,
     Relationship,
+    Tag,
     Taxonomy,
     ThreatIntel,
 )
@@ -346,18 +346,18 @@ class CheckProxy(_ReadOnlyProxy[Check]):
         self._get_investigation().update_model_metadata("check", self.key, updates, dict_merge=dict_merge)
         return self
 
-    def in_container(self, container: Container | ContainerProxy | str) -> CheckProxy:
-        """Add this check to a container."""
-        if isinstance(container, ContainerProxy):
-            container_key = container.key
-        elif isinstance(container, Container):
-            container_key = container.key
-        elif isinstance(container, str):
-            container_key = container
+    def in_tag(self, tag: Tag | TagProxy | str) -> CheckProxy:
+        """Add this check to a tag."""
+        if isinstance(tag, TagProxy):
+            tag_key = tag.key
+        elif isinstance(tag, Tag):
+            tag_key = tag.key
+        elif isinstance(tag, str):
+            tag_key = tag
         else:
-            raise TypeError("Container must provide a key.")
+            raise TypeError("Tag must provide a key.")
 
-        self._get_investigation().add_check_to_container(container_key, self.key)
+        self._get_investigation().add_check_to_tag(tag_key, self.key)
         return self
 
     def link_observable(
@@ -386,18 +386,18 @@ class CheckProxy(_ReadOnlyProxy[Check]):
         return self
 
 
-class ContainerProxy(_ReadOnlyProxy[Container]):
-    """Read-only proxy over a container."""
+class TagProxy(_ReadOnlyProxy[Tag]):
+    """Read-only proxy over a tag."""
 
     def _resolve(self):
-        container = self._get_investigation().get_container(self.key)
-        if container is None:
-            raise ModelNotFoundError(f"Container '{self.key}' no longer exists in this investigation.")
-        return container
+        tag = self._get_investigation().get_tag(self.key)
+        if tag is None:
+            raise ModelNotFoundError(f"Tag '{self.key}' no longer exists in this investigation.")
+        return tag
 
     @property
-    def path(self) -> str:
-        return self._read_attr("path")
+    def name(self) -> str:
+        return self._read_attr("name")
 
     @property
     def description(self) -> str:
@@ -407,20 +407,26 @@ class ContainerProxy(_ReadOnlyProxy[Container]):
     def checks(self) -> list[Check]:
         return self._read_attr("checks")
 
-    @property
-    def sub_containers(self) -> dict[str, Container]:
-        return self._read_attr("sub_containers")
+    def get_direct_score(self):
+        """Return the direct score (checks in this tag only, no hierarchy)."""
+        return self._call_readonly("get_direct_score")
+
+    def get_direct_level(self):
+        """Return the direct level (from direct score only, no hierarchy)."""
+        return self._call_readonly("get_direct_level")
 
     def get_aggregated_score(self):
-        """Return the aggregated score copy."""
-        return self._call_readonly("get_aggregated_score")
+        """Return the aggregated score including all descendant tags."""
+        tag = self._resolve()
+        return self._get_investigation().get_tag_aggregated_score(tag.name)
 
     def get_aggregated_level(self):
-        """Return the aggregated level copy."""
-        return self._call_readonly("get_aggregated_level")
+        """Return the aggregated level including all descendant tags."""
+        tag = self._resolve()
+        return self._get_investigation().get_tag_aggregated_level(tag.name)
 
-    def add_check(self, check: Check | CheckProxy | str) -> ContainerProxy:
-        """Add a check to this container."""
+    def add_check(self, check: Check | CheckProxy | str) -> TagProxy:
+        """Add a check to this tag."""
         if isinstance(check, CheckProxy):
             check_key = check.key
         elif isinstance(check, Check):
@@ -430,19 +436,10 @@ class ContainerProxy(_ReadOnlyProxy[Container]):
         else:
             raise TypeError("Check must provide a key.")
 
-        self._get_investigation().add_check_to_container(self.key, check_key)
+        self._get_investigation().add_check_to_tag(self.key, check_key)
         return self
 
-    def sub_container(self, path: str, description: str = "") -> ContainerProxy:
-        """Create a sub-container nested beneath this container."""
-        parent = self._resolve()
-        full_path = f"{parent.path}/{path}"
-        sub = Container(path=full_path, description=description)
-        sub = self._get_investigation().add_container(sub)
-        self._get_investigation().add_sub_container(self.key, sub.key)
-        return ContainerProxy(self._get_investigation(), sub.key)
-
-    def __enter__(self) -> ContainerProxy:
+    def __enter__(self) -> TagProxy:
         """Context manager entry returning self."""
         return self
 
@@ -450,11 +447,11 @@ class ContainerProxy(_ReadOnlyProxy[Container]):
         """Context manager exit (no-op)."""
         return None
 
-    def update_metadata(self, *, description: str | None = None) -> ContainerProxy:
-        """Update mutable metadata on the container."""
+    def update_metadata(self, *, description: str | None = None) -> TagProxy:
+        """Update mutable metadata on the tag."""
         if description is None:
             return self
-        self._get_investigation().update_model_metadata("container", self.key, {"description": description})
+        self._get_investigation().update_model_metadata("tag", self.key, {"description": description})
         return self
 
 

--- a/src/cyvest/shared.py
+++ b/src/cyvest/shared.py
@@ -393,39 +393,39 @@ class SharedInvestigationContext:
 
     def io_to_markdown(
         self,
-        include_containers: bool = False,
+        include_tags: bool = False,
         include_enrichments: bool = False,
         include_observables: bool = True,
     ) -> str:
         return self._lock.run(
             self._io_to_markdown_unlocked,
-            include_containers,
+            include_tags,
             include_enrichments,
             include_observables,
         )
 
     async def aio_to_markdown(
         self,
-        include_containers: bool = False,
+        include_tags: bool = False,
         include_enrichments: bool = False,
         include_observables: bool = True,
     ) -> str:
         return await self._lock.arun(
             self._io_to_markdown_unlocked,
-            include_containers,
+            include_tags,
             include_enrichments,
             include_observables,
         )
 
     def _io_to_markdown_unlocked(
         self,
-        include_containers: bool,
+        include_tags: bool,
         include_enrichments: bool,
         include_observables: bool,
     ) -> str:
         return generate_markdown_report(
             self._main_investigation,
-            include_containers,
+            include_tags,
             include_enrichments,
             include_observables,
         )
@@ -433,14 +433,14 @@ class SharedInvestigationContext:
     def io_save_markdown(
         self,
         filepath: str | Path,
-        include_containers: bool = False,
+        include_tags: bool = False,
         include_enrichments: bool = False,
         include_observables: bool = True,
     ) -> str:
         return self._lock.run(
             self._io_save_markdown_unlocked,
             filepath,
-            include_containers,
+            include_tags,
             include_enrichments,
             include_observables,
         )
@@ -448,14 +448,14 @@ class SharedInvestigationContext:
     async def aio_save_markdown(
         self,
         filepath: str | Path,
-        include_containers: bool = False,
+        include_tags: bool = False,
         include_enrichments: bool = False,
         include_observables: bool = True,
     ) -> str:
         return await self._lock.arun(
             self._io_save_markdown_unlocked,
             filepath,
-            include_containers,
+            include_tags,
             include_enrichments,
             include_observables,
         )
@@ -463,14 +463,14 @@ class SharedInvestigationContext:
     def _io_save_markdown_unlocked(
         self,
         filepath: str | Path,
-        include_containers: bool,
+        include_tags: bool,
         include_enrichments: bool,
         include_observables: bool,
     ) -> str:
         save_investigation_markdown(
             self._main_investigation,
             filepath,
-            include_containers,
+            include_tags,
             include_enrichments,
             include_observables,
         )

--- a/src/cyvest/shared.py
+++ b/src/cyvest/shared.py
@@ -311,23 +311,23 @@ class SharedInvestigationContext:
         except Exception as e:
             raise ValueError(f"Failed to generate observable key for type='{obs_type}', value='{value}': {e}") from e
 
-    def check_get(self, check_id: str, scope: str) -> Check | None:
-        key = self._check_key(check_id, scope)
+    def check_get(self, check_name: str) -> Check | None:
+        key = self._check_key(check_name)
         return self._lock.run(self._get_check_by_key_unlocked, key)
 
-    async def check_aget(self, check_id: str, scope: str) -> Check | None:
-        key = self._check_key(check_id, scope)
+    async def check_aget(self, check_name: str) -> Check | None:
+        key = self._check_key(check_name)
         return await self._lock.arun(self._get_check_by_key_unlocked, key)
 
     def _get_check_by_key_unlocked(self, key: str) -> Check | None:
         check = self._check_registry.get(key)
         return check.model_copy(deep=True) if check else None
 
-    def _check_key(self, check_id: str, scope: str) -> str:
+    def _check_key(self, check_name: str) -> str:
         try:
-            return keys.generate_check_key(check_id, scope)
+            return keys.generate_check_key(check_name)
         except Exception as e:
-            raise ValueError(f"Failed to generate check key for check_id='{check_id}', scope='{scope}': {e}") from e
+            raise ValueError(f"Failed to generate check key for check_name='{check_name}': {e}") from e
 
     def enrichment_get(self, name: str, context: str = "") -> Enrichment | None:
         key = self._enrichment_key(name, context)

--- a/src/cyvest/stats.py
+++ b/src/cyvest/stats.py
@@ -142,30 +142,6 @@ class InvestigationStats:
         """
         return sum(1 for obs in self._observables.values() if obs.whitelisted)
 
-    def get_check_count_by_scope(self) -> dict[str, int]:
-        """
-        Get count of checks by scope.
-
-        Returns:
-            Dictionary mapping scope to count
-        """
-        counts: dict[str, int] = defaultdict(int)
-        for check in self._checks.values():
-            counts[check.scope] += 1
-        return dict(counts)
-
-    def get_check_keys_by_scope(self) -> dict[str, list[str]]:
-        """
-        Get check keys grouped by scope.
-
-        Returns:
-            Dictionary mapping scope to list of check keys
-        """
-        keys: dict[str, list[str]] = defaultdict(list)
-        for check in self._checks.values():
-            keys[check.scope].append(check.key)
-        return dict(keys)
-
     def get_check_count_by_level(self) -> dict[Level, int]:
         """
         Get count of checks by level.
@@ -307,7 +283,6 @@ class InvestigationStats:
             },
             total_checks=self.get_total_check_count(),
             applied_checks=self.get_applied_check_count(),
-            checks_by_scope=self.get_check_keys_by_scope(),
             checks_by_level={str(k): v for k, v in self.get_check_keys_by_level().items()},
             total_threat_intel=self.get_threat_intel_count(),
             threat_intel_by_source=self.get_threat_intel_count_by_source(),

--- a/src/cyvest/stats.py
+++ b/src/cyvest/stats.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections import defaultdict
 
 from cyvest.levels import Level
-from cyvest.model import Check, Container, Observable, ThreatIntel
+from cyvest.model import Check, Observable, Tag, ThreatIntel
 from cyvest.model_schema import StatisticsSchema
 
 
@@ -27,7 +27,7 @@ class InvestigationStats:
         self._observables: dict[str, Observable] = {}
         self._checks: dict[str, Check] = {}
         self._threat_intels: dict[str, ThreatIntel] = {}
-        self._containers: dict[str, Container] = {}
+        self._tags: dict[str, Tag] = {}
 
     def register_observable(self, observable: Observable) -> None:
         """
@@ -56,14 +56,14 @@ class InvestigationStats:
         """
         self._threat_intels[ti.key] = ti
 
-    def register_container(self, container: Container) -> None:
+    def register_tag(self, tag: Tag) -> None:
         """
-        Register a container for statistics tracking.
+        Register a tag for statistics tracking.
 
         Args:
-            container: Container to track
+            tag: Tag to track
         """
-        self._containers[container.key] = container
+        self._tags[tag.key] = tag
 
     def get_observable_count_by_type(self) -> dict[str, int]:
         """
@@ -217,14 +217,14 @@ class InvestigationStats:
             counts[ti.level] += 1
         return dict(counts)
 
-    def get_container_count(self) -> int:
+    def get_tag_count(self) -> int:
         """
-        Get total number of containers.
+        Get total number of tags.
 
         Returns:
-            Total container count
+            Total tag count
         """
-        return len(self._containers)
+        return len(self._tags)
 
     def get_checks_by_level(self, level: Level) -> list[Check]:
         """
@@ -287,5 +287,5 @@ class InvestigationStats:
             total_threat_intel=self.get_threat_intel_count(),
             threat_intel_by_source=self.get_threat_intel_count_by_source(),
             threat_intel_by_level={str(k): v for k, v in self.get_threat_intel_count_by_level().items()},
-            total_containers=self.get_container_count(),
+            total_tags=self.get_tag_count(),
         )

--- a/tests/test_cyvest.py
+++ b/tests/test_cyvest.py
@@ -75,8 +75,7 @@ def test_facade_getters_accept_component_parameters() -> None:
     assert cv.observable_get(cv.OBS.URL, "https://example.com") is not None
     assert cv.observable_get(obs.key) is not None
 
-    check = cv.check_create("check_id", "scope", "desc")
-    assert cv.check_get("check_id", "scope") is not None
+    check = cv.check_create("check_id", "desc")
     assert cv.check_get(check.key) is not None
 
     ctr = cv.container_create("path/to/container")
@@ -122,7 +121,7 @@ def test_string_levels_are_accepted_by_api() -> None:
     obs = cv.observable_create(Cyvest.OBS.DOMAIN, "example.com", level="safe")
     assert obs.level == Cyvest.LVL.SAFE
 
-    check = cv.check_create("string_level", "scope", "desc", level="notable")
+    check = cv.check_create("string_level", "desc", level="notable")
     assert check.level == Cyvest.LVL.NOTABLE
 
     ti = cv.observable_add_threat_intel(obs.key, source="vt", score=Decimal("5.0"), level="malicious")
@@ -136,9 +135,8 @@ def test_string_levels_are_accepted_by_api() -> None:
 def test_check_creation() -> None:
     """Test creating checks."""
     cv = Cyvest()
-    check = cv.check_create("test_check", "network", "Test description", score=Decimal("5.0"))
-    assert check.check_id == "test_check"
-    assert check.scope == "network"
+    check = cv.check_create("test_check", "Test description", score=Decimal("5.0"))
+    assert check.check_name == "test_check"
     assert check.score == Decimal("5.0")
     assert cv.check_get(check.key) is not None
 
@@ -147,7 +145,7 @@ def test_check_observable_linking() -> None:
     """Test linking observables to checks."""
     cv = Cyvest()
     obs = cv.observable_create(Cyvest.OBS.URL, "https://bad.com")
-    check = cv.check_create("url_check", "analysis", "Check URL")
+    check = cv.check_create("url_check", "Check URL")
     cv.check_link_observable(check.key, obs.key)
     assert any(link.observable_key == obs.key for link in check.observable_links)
 
@@ -163,7 +161,7 @@ def test_container_creation() -> None:
 def test_container_check_addition() -> None:
     """Test adding checks to containers."""
     cv = Cyvest()
-    check = cv.check_create("c1", "s1", "d1")
+    check = cv.check_create("c1", "d1")
     ctr = cv.container_create("test_container")
     cv.container_add_check(ctr.key, check.key)
     assert any(c.key == check.key for c in ctr.checks)
@@ -578,7 +576,7 @@ def test_io_save_load_json_roundtrip() -> None:
 
     cv.observable_add_relationship(obs1.key, obs2.key, "related-to")
 
-    check = cv.check_create("malware_check", "network", "Detected malware communication", score=Decimal("9.0"))
+    check = cv.check_create("malware_check", "Detected malware communication", score=Decimal("9.0"))
     cv.check_link_observable(check.key, obs1.key)
 
     cv.enrichment_create("whois", {"registrar": "Evil Corp"}, context="Domain registration")
@@ -608,7 +606,7 @@ def test_io_save_load_json_roundtrip() -> None:
         assert len(loaded_cv.check_get_all()) == len(cv.check_get_all())
         loaded_check = loaded_cv.check_get(check.key)
         assert loaded_check is not None
-        assert loaded_check.scope == "network"
+        assert loaded_check.check_name == "malware_check"
         assert any(link.observable_key == obs1.key for link in loaded_check.observable_links)
 
         # Verify enrichments
@@ -780,7 +778,7 @@ def test_io_to_markdown_generates_report() -> None:
     cv = Cyvest()
     obs = cv.observable_create(Cyvest.OBS.DOMAIN, "test.com", internal=False)
     cv.observable_add_threat_intel(obs.key, source="abuse.ch", score=Decimal("5.0"))
-    check = cv.check_create("domain_check", "dns", "DNS analysis", score=Decimal("4.0"), level=Cyvest.LVL.SUSPICIOUS)
+    check = cv.check_create("domain_check", "DNS analysis", score=Decimal("4.0"), level=Cyvest.LVL.SUSPICIOUS)
     cv.check_link_observable(check.key, obs.key)
 
     markdown = cv.io_to_markdown()
@@ -789,7 +787,7 @@ def test_io_to_markdown_generates_report() -> None:
     assert "# Cybersecurity Investigation Report" in markdown
     assert "## Statistics" in markdown
     assert "## Observables" in markdown
-    assert "## Checks by Scope" in markdown
+    assert "## Checks" in markdown
 
     # Verify content
     assert "test.com" in markdown

--- a/tests/test_cyvest.py
+++ b/tests/test_cyvest.py
@@ -78,9 +78,9 @@ def test_facade_getters_accept_component_parameters() -> None:
     check = cv.check_create("check_id", "desc")
     assert cv.check_get(check.key) is not None
 
-    ctr = cv.container_create("path/to/container")
-    assert cv.container_get("path/to/container") is not None
-    assert cv.container_get(ctr.key) is not None
+    tag = cv.tag_create("path:to:tag")
+    assert cv.tag_get("path:to:tag") is not None
+    assert cv.tag_get(tag.key) is not None
 
     enr = cv.enrichment_create("metadata", {"key": "value"})
     assert cv.enrichment_get("metadata") is not None
@@ -150,21 +150,21 @@ def test_check_observable_linking() -> None:
     assert any(link.observable_key == obs.key for link in check.observable_links)
 
 
-def test_container_creation() -> None:
-    """Test creating containers."""
+def test_tag_creation() -> None:
+    """Test creating tags."""
     cv = Cyvest()
-    ctr = cv.container_create("network_analysis", "Network analysis container")
-    assert ctr.path == "network_analysis"
-    assert cv.container_get(ctr.key) is not None
+    tag = cv.tag_create("network:analysis", "Network analysis tag")
+    assert tag.name == "network:analysis"
+    assert cv.tag_get(tag.key) is not None
 
 
-def test_container_check_addition() -> None:
-    """Test adding checks to containers."""
+def test_tag_check_addition() -> None:
+    """Test adding checks to tags."""
     cv = Cyvest()
     check = cv.check_create("c1", "d1")
-    ctr = cv.container_create("test_container")
-    cv.container_add_check(ctr.key, check.key)
-    assert any(c.key == check.key for c in ctr.checks)
+    tag = cv.tag_create("test_tag")
+    cv.tag_add_check(tag.key, check.key)
+    assert any(c.key == check.key for c in tag.checks)
 
 
 def test_enrichment_creation() -> None:
@@ -680,7 +680,7 @@ def test_io_to_invest_serialization() -> None:
     assert hasattr(schema, "checks")
     assert hasattr(schema, "threat_intels")
     assert hasattr(schema, "enrichments")
-    assert hasattr(schema, "containers")
+    assert hasattr(schema, "tags")
     assert hasattr(schema, "stats")
     assert hasattr(schema, "whitelists")
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -29,10 +29,9 @@ def test_generate_observable_key() -> None:
 
 def test_generate_check_key() -> None:
     """Test check key generation."""
-    key = generate_check_key("malware_check", "endpoint")
+    key = generate_check_key("malware_check")
     assert key.startswith("chk:")
     assert "malware_check" in key
-    assert "endpoint" in key
 
 
 def test_generate_threat_intel_key() -> None:
@@ -65,7 +64,7 @@ def test_generate_container_key() -> None:
 def test_parse_key_type() -> None:
     """Test key type parsing."""
     assert parse_key_type("obs:url:example.com") == "obs"
-    assert parse_key_type("chk:test:scope") == "chk"
+    assert parse_key_type("chk:test") == "chk"
     assert parse_key_type("ti:vt:obs_key") == "ti"
     assert parse_key_type("enr:name") == "enr"
     assert parse_key_type("ctr:path") == "ctr"
@@ -77,14 +76,14 @@ def test_parse_observable_key() -> None:
     assert parse_observable_key("obs:url:example.com") == ("url", "example.com")
     assert parse_observable_key("obs:url:https://example.com/path") == ("url", "https://example.com/path")
     assert parse_observable_key("obs:url:") is None
-    assert parse_observable_key("chk:test:scope") is None
+    assert parse_observable_key("chk:test") is None
     assert parse_observable_key("invalid") is None
 
 
 def test_validate_key() -> None:
     """Test key validation."""
     assert validate_key("obs:url:example.com") is True
-    assert validate_key("chk:test:scope") is True
+    assert validate_key("chk:test") is True
     assert validate_key("ti:vt:obs_key") is True
     assert validate_key("invalid") is False
     assert validate_key("obs:url:example.com", "obs") is True
@@ -96,4 +95,4 @@ def test_key_determinism() -> None:
     # Same inputs should always produce same keys
     for _ in range(10):
         assert generate_observable_key("ipv4", "192.168.1.1") == "obs:ipv4:192.168.1.1"
-        assert generate_check_key("test", "scope") == "chk:test:scope"
+        assert generate_check_key("test") == "chk:test"

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -4,10 +4,13 @@ Tests for the keys module.
 
 from cyvest.keys import (
     generate_check_key,
-    generate_container_key,
     generate_enrichment_key,
     generate_observable_key,
+    generate_tag_key,
     generate_threat_intel_key,
+    get_tag_ancestors,
+    is_tag_child_of,
+    is_tag_descendant_of,
     parse_key_type,
     parse_observable_key,
     validate_key,
@@ -54,11 +57,11 @@ def test_generate_enrichment_key() -> None:
     assert key != key_ctx
 
 
-def test_generate_container_key() -> None:
-    """Test container key generation."""
-    key = generate_container_key("network/analysis")
-    assert key.startswith("ctr:")
-    assert "network/analysis" in key
+def test_generate_tag_key() -> None:
+    """Test tag key generation."""
+    key = generate_tag_key("header:auth")
+    assert key.startswith("tag:")
+    assert "header:auth" in key
 
 
 def test_parse_key_type() -> None:
@@ -67,7 +70,7 @@ def test_parse_key_type() -> None:
     assert parse_key_type("chk:test") == "chk"
     assert parse_key_type("ti:vt:obs_key") == "ti"
     assert parse_key_type("enr:name") == "enr"
-    assert parse_key_type("ctr:path") == "ctr"
+    assert parse_key_type("tag:header") == "tag"
     assert parse_key_type("invalid") is None
 
 
@@ -96,3 +99,45 @@ def test_key_determinism() -> None:
     for _ in range(10):
         assert generate_observable_key("ipv4", "192.168.1.1") == "obs:ipv4:192.168.1.1"
         assert generate_check_key("test") == "chk:test"
+
+
+def test_get_tag_ancestors() -> None:
+    """Test tag ancestor extraction from hierarchical names."""
+    # Single segment has no ancestors
+    assert get_tag_ancestors("header") == []
+    # Two segments
+    assert get_tag_ancestors("header:auth") == ["header"]
+    # Three segments
+    assert get_tag_ancestors("header:auth:dkim") == ["header", "header:auth"]
+    # Four segments
+    assert get_tag_ancestors("a:b:c:d") == ["a", "a:b", "a:b:c"]
+
+
+def test_is_tag_child_of() -> None:
+    """Test direct child relationship check."""
+    # Direct child
+    assert is_tag_child_of("header:auth", "header") is True
+    # Not a child (same tag)
+    assert is_tag_child_of("header", "header") is False
+    # Not a child (grandchild)
+    assert is_tag_child_of("header:auth:dkim", "header") is False
+    # Not a child (unrelated)
+    assert is_tag_child_of("footer:links", "header") is False
+    # Direct child with deeper parent
+    assert is_tag_child_of("header:auth:dkim", "header:auth") is True
+
+
+def test_is_tag_descendant_of() -> None:
+    """Test descendant relationship check (any depth)."""
+    # Direct child is a descendant
+    assert is_tag_descendant_of("header:auth", "header") is True
+    # Grandchild is a descendant
+    assert is_tag_descendant_of("header:auth:dkim", "header") is True
+    # Great-grandchild is a descendant
+    assert is_tag_descendant_of("a:b:c:d", "a") is True
+    # Not a descendant (same tag)
+    assert is_tag_descendant_of("header", "header") is False
+    # Not a descendant (unrelated)
+    assert is_tag_descendant_of("footer:links", "header") is False
+    # Not a descendant (parent-child reversed)
+    assert is_tag_descendant_of("header", "header:auth") is False

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -9,19 +9,19 @@ from cyvest import Cyvest
 
 def test_merge_local_check() -> None:
     cv_child = Cyvest()
-    cv_child.check("C1", "full", "test").link_observable(
+    cv_child.check("C1", "test").link_observable(
         cv_child.observable(cv_child.OBS.DOMAIN, "example.com").with_ti("VT", score=2)
     )
 
     main_inv = Cyvest()
-    main_inv.check("C2", "full", "test").link_observable(
+    main_inv.check("C2", "test").link_observable(
         main_inv.observable(main_inv.OBS.DOMAIN, "example.com").with_ti("OTX", score=4)
     )
 
     main_inv.merge_investigation(cv_child)
 
-    c1 = main_inv.check_get("C1", "full")
-    c2 = main_inv.check_get("C2", "full")
+    c1 = main_inv.check_get("chk:c1")
+    c2 = main_inv.check_get("chk:c2")
     o = main_inv.observable_get(Cyvest.OBS.DOMAIN, "example.com")
     global_score = main_inv.get_global_score()
 
@@ -33,20 +33,20 @@ def test_merge_local_check() -> None:
 
 def test_merge_global_check() -> None:
     cv_child = Cyvest()
-    cv_child.check("C1", "full", "test").link_observable(
+    cv_child.check("C1", "test").link_observable(
         cv_child.observable(cv_child.OBS.DOMAIN, "example.com").with_ti("VT", score=2),
         propagation_mode=cv_child.PROP.GLOBAL,
     )
 
     main_inv = Cyvest()
-    main_inv.check("C2", "full", "test").link_observable(
+    main_inv.check("C2", "test").link_observable(
         main_inv.observable(main_inv.OBS.DOMAIN, "example.com").with_ti("OTX", score=4)
     )
 
     main_inv.merge_investigation(cv_child)
 
-    c1 = main_inv.check_get("C1", "full")
-    c2 = main_inv.check_get("C2", "full")
+    c1 = main_inv.check_get("chk:c1")
+    c2 = main_inv.check_get("chk:c2")
     o = main_inv.observable_get(Cyvest.OBS.DOMAIN, "example.com")
     global_score = main_inv.get_global_score()
 
@@ -58,12 +58,12 @@ def test_merge_global_check() -> None:
 
 def test_merge_local_check_multiple_child() -> None:
     cv_child = Cyvest()
-    cv_child.check("C1", "full", "test").link_observable(
+    cv_child.check("C1", "test").link_observable(
         cv_child.observable(Cyvest.OBS.DOMAIN, "example.com").with_ti("VT", score=2)
     )
 
     cv_child2 = Cyvest()
-    cv_child2.check("C1", "full", "test").link_observable(
+    cv_child2.check("C1", "test").link_observable(
         cv_child2.observable(Cyvest.OBS.DOMAIN, "example.com").with_ti("VT", score=5)
     )
 
@@ -71,7 +71,7 @@ def test_merge_local_check_multiple_child() -> None:
     main_inv.merge_investigation(cv_child)
     main_inv.merge_investigation(cv_child2)
 
-    c1 = main_inv.check_get("C1", "full")
+    c1 = main_inv.check_get("chk:c1")
     o = main_inv.observable_get(Cyvest.OBS.DOMAIN, "example.com")
     global_score = main_inv.get_global_score()
 
@@ -84,7 +84,7 @@ def test_local_only_link_does_not_affect_foreign_check() -> None:
     cv_main = Cyvest()
     cv_other = Cyvest()
 
-    foreign_check = cv_other.check_create("foreign", "scope", "Created in other investigation")
+    foreign_check = cv_other.check_create("foreign", "Created in other investigation")
 
     cv_main.merge_investigation(cv_other)
 
@@ -103,7 +103,7 @@ def test_global_link_can_affect_foreign_check() -> None:
     cv_main = Cyvest()
     cv_other = Cyvest()
 
-    foreign_check = cv_other.check_create("foreign", "scope", "Created in other investigation")
+    foreign_check = cv_other.check_create("foreign", "Created in other investigation")
     cv_main.merge_investigation(cv_other)
 
     obs = cv_main.observable_create(Cyvest.OBS.IPV4, "10.0.0.52")
@@ -126,12 +126,12 @@ def test_check_reconciliation_preserves_origin_and_links() -> None:
 
     obs1 = cv1.observable_create(Cyvest.OBS.IPV4, "10.0.0.60")
     cv1.observable_add_threat_intel(obs1.key, source="s1", score=Decimal("4.0"))
-    check1 = cv1.check_create("recon", "scope", "Same semantic check")
+    check1 = cv1.check_create("recon", "Same semantic check")
     cv1.check_link_observable(check1.key, obs1.key)
 
     obs2 = cv2.observable_create(Cyvest.OBS.IPV4, "10.0.0.61")
     cv2.observable_add_threat_intel(obs2.key, source="s2", score=Decimal("9.0"))
-    check2 = cv2.check_create("recon", "scope", "Same semantic check")
+    check2 = cv2.check_create("recon", "Same semantic check")
     cv2.check_link_observable(check2.key, obs2.key)
 
     cv1.merge_investigation(cv2)
@@ -153,7 +153,7 @@ def test_foreign_check_global_updates_local_only_freezes_after_merge() -> None:
     cv_main = Cyvest()
     cv_other = Cyvest()
 
-    foreign_check = cv_other.check_create("foreign", "scope", "Created in other investigation")
+    foreign_check = cv_other.check_create("foreign", "Created in other investigation")
     cv_main.merge_investigation(cv_other)
 
     obs_local = cv_main.observable_create(Cyvest.OBS.IPV4, "10.0.0.51")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,10 +10,10 @@ from cyvest.investigation import Investigation
 from cyvest.levels import Level
 from cyvest.model import (
     Check,
-    Container,
     Enrichment,
     Observable,
     RelationshipDirection,
+    Tag,
     ThreatIntel,
     _format_score_decimal,
 )
@@ -203,20 +203,19 @@ def test_enrichment_creation() -> None:
     assert enr.key.startswith("enr:")
 
 
-def test_container_creation() -> None:
-    """Test creating container."""
-    ctr = Container(path="network/analysis", description="Network analysis container")
-    assert ctr.path == "network/analysis"
-    assert ctr.description == "Network analysis container"
-    assert ctr.key.startswith("ctr:")
-    assert len(ctr.checks) == 0
-    assert len(ctr.sub_containers) == 0
+def test_tag_creation() -> None:
+    """Test creating tag."""
+    tag = Tag(name="network:analysis", description="Network analysis tag")
+    assert tag.name == "network:analysis"
+    assert tag.description == "Network analysis tag"
+    assert tag.key.startswith("tag:")
+    assert len(tag.checks) == 0
 
 
-def test_container_aggregated_score() -> None:
-    """Test container score aggregation."""
+def test_tag_direct_score() -> None:
+    """Test tag direct score calculation."""
     inv = Investigation(root_data={})
-    ctr = inv.add_container(Container(path="test"))
+    tag = inv.add_tag(Tag(name="test"))
     check1 = Check(
         check_name="c1",
         description="d1",
@@ -231,17 +230,20 @@ def test_container_aggregated_score() -> None:
     )
     inv.add_check(check1)
     inv.add_check(check2)
-    inv.add_check_to_container(ctr.key, check1.key)
-    inv.add_check_to_container(ctr.key, check2.key)
-    assert ctr.get_aggregated_score() == Decimal("8.0")
-    assert ctr.get_aggregated_level() == Level.MALICIOUS
+    inv.add_check_to_tag(tag.key, check1.key)
+    inv.add_check_to_tag(tag.key, check2.key)
+    assert tag.get_direct_score() == Decimal("8.0")
+    assert tag.get_direct_level() == Level.MALICIOUS
 
 
-def test_container_nested_aggregation() -> None:
-    """Test nested container score aggregation."""
+def test_tag_hierarchical_aggregation() -> None:
+    """Test tag hierarchical score aggregation."""
     inv = Investigation(root_data={})
-    parent = inv.add_container(Container(path="parent"))
-    child = inv.add_container(Container(path="parent/child"))
+    # Creating a child tag auto-creates parent
+    child = inv.add_tag(Tag(name="parent:child"))
+    parent = inv.get_tag("tag:parent")
+    assert parent is not None
+
     check1 = Check(
         check_name="c1",
         description="d",
@@ -256,11 +258,12 @@ def test_container_nested_aggregation() -> None:
     )
     inv.add_check(check1)
     inv.add_check(check2)
-    inv.add_check_to_container(parent.key, check1.key)
-    inv.add_check_to_container(child.key, check2.key)
-    inv.add_sub_container(parent.key, child.key)
-    # Should sum both parent and child checks
-    assert parent.get_aggregated_score() == Decimal("5.0")
+    inv.add_check_to_tag(parent.key, check1.key)
+    inv.add_check_to_tag(child.key, check2.key)
+    # Aggregated should sum parent + child checks
+    assert inv.get_tag_aggregated_score("parent") == Decimal("5.0")
+    # Direct should only be parent's checks
+    assert parent.get_direct_score() == Decimal("2.0")
 
 
 def test_explicit_level_setting() -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -78,13 +78,11 @@ def test_observable_relationships() -> None:
 def test_check_creation() -> None:
     """Test creating a check."""
     check = Check(
-        check_id="test_check",
-        scope="network",
+        check_name="test_check",
         description="Test description",
         origin_investigation_id=_ORIGIN,
     )
-    assert check.check_id == "test_check"
-    assert check.scope == "network"
+    assert check.check_name == "test_check"
     assert check.description == "Test description"
     assert check.score == Decimal("0")
     assert check.level == Level.NONE
@@ -94,14 +92,12 @@ def test_check_creation() -> None:
 def test_check_creation_with_score() -> None:
     """Test creating a check."""
     check = Check(
-        check_id="test_check",
-        scope="network",
+        check_name="test_check",
         description="Test description",
         score=0.3,
         origin_investigation_id=_ORIGIN,
     )
-    assert check.check_id == "test_check"
-    assert check.scope == "network"
+    assert check.check_name == "test_check"
     assert check.description == "Test description"
     assert check.score == Decimal("0.3")
     assert check.level == Level.NOTABLE
@@ -111,7 +107,7 @@ def test_check_creation_with_score() -> None:
 def test_check_score_update() -> None:
     """Test updating check score."""
     inv = Investigation(root_data={})
-    check = Check(check_id="test", scope="scope", description="desc", origin_investigation_id=inv.investigation_id)
+    check = Check(check_name="test", description="desc", origin_investigation_id=inv.investigation_id)
     inv.add_check(check)
     inv.apply_score_change(check, Decimal("3.5"), reason="Update reason")
     assert check.score == Decimal("3.5")
@@ -121,7 +117,7 @@ def test_check_score_update() -> None:
 def test_check_add_observable_link_upgrades_level() -> None:
     """Test that adding an effective observable link to a check with level NONE upgrades it to INFO."""
     inv = Investigation(root_data={})
-    check = Check(check_id="test", scope="scope", description="desc", origin_investigation_id=inv.investigation_id)
+    check = Check(check_name="test", description="desc", origin_investigation_id=inv.investigation_id)
     inv.add_check(check)
     assert check.level == Level.NONE  # Default level for new checks
 
@@ -138,8 +134,7 @@ def test_check_add_observable_link_preserves_higher_level() -> None:
     """Test that adding an observable link doesn't downgrade an existing higher level."""
     inv = Investigation(root_data={})
     check = Check(
-        check_id="test",
-        scope="scope",
+        check_name="test",
         description="desc",
         level=Level.SUSPICIOUS,
         origin_investigation_id=inv.investigation_id,
@@ -157,7 +152,7 @@ def test_check_add_observable_link_preserves_higher_level() -> None:
 def test_check_add_observable_link_no_duplicate() -> None:
     """Test that adding the same observable link twice doesn't create duplicates."""
     inv = Investigation(root_data={})
-    check = Check(check_id="test", scope="scope", description="desc", origin_investigation_id=inv.investigation_id)
+    check = Check(check_name="test", description="desc", origin_investigation_id=inv.investigation_id)
     inv.add_check(check)
     obs = Observable(obs_type="url", value="https://example.com")
     inv.add_observable(obs)
@@ -223,15 +218,13 @@ def test_container_aggregated_score() -> None:
     inv = Investigation(root_data={})
     ctr = inv.add_container(Container(path="test"))
     check1 = Check(
-        check_id="c1",
-        scope="s1",
+        check_name="c1",
         description="d1",
         score=Decimal("3.0"),
         origin_investigation_id=inv.investigation_id,
     )
     check2 = Check(
-        check_id="c2",
-        scope="s2",
+        check_name="c2",
         description="d2",
         score=Decimal("5.0"),
         origin_investigation_id=inv.investigation_id,
@@ -250,15 +243,13 @@ def test_container_nested_aggregation() -> None:
     parent = inv.add_container(Container(path="parent"))
     child = inv.add_container(Container(path="parent/child"))
     check1 = Check(
-        check_id="c1",
-        scope="s",
+        check_name="c1",
         description="d",
         score=Decimal("2.0"),
         origin_investigation_id=inv.investigation_id,
     )
     check2 = Check(
-        check_id="c2",
-        scope="s",
+        check_name="c2",
         description="d",
         score=Decimal("3.0"),
         origin_investigation_id=inv.investigation_id,
@@ -294,8 +285,7 @@ def test_string_level_inputs_are_normalized() -> None:
     assert obs.level == Level.MALICIOUS
 
     check = Check(
-        check_id="string_level",
-        scope="scope",
+        check_name="string_level",
         description="desc",
         level="notable",
         origin_investigation_id=inv.investigation_id,

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -151,8 +151,7 @@ def test_proxy_dir_exposes_public_fields() -> None:
             "key",
         },
         check: {
-            "check_id",
-            "scope",
+            "check_name",
             "description",
             "comment",
             "extra",

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -118,13 +118,13 @@ def test_enrichment_proxy_update_metadata() -> None:
     assert enrichment.data == {"host": {"ip": "10.0.0.2"}}
 
 
-def test_container_proxy_update_metadata() -> None:
-    """ContainerProxy.update_metadata should update description."""
+def test_tag_proxy_update_metadata() -> None:
+    """TagProxy.update_metadata should update description."""
     cv = Cyvest()
-    container = cv.container_create("path", "old description")
+    tag = cv.tag_create("tagname", "old description")
 
-    container.update_metadata(description="new description")
-    assert container.description == "new description"
+    tag.update_metadata(description="new description")
+    assert tag.description == "new description"
 
 
 def test_proxy_dir_exposes_public_fields() -> None:
@@ -132,7 +132,7 @@ def test_proxy_dir_exposes_public_fields() -> None:
     cv = Cyvest()
     obs = cv.observable_create(Cyvest.OBS.URL, "https://example.com")
     check = cv.check_create("check-id", "scope", "desc")
-    container = cv.container_create("root")
+    tag = cv.tag_create("root")
     ti = cv.observable_add_threat_intel(obs.key, source="vt", score=Decimal("1"), comment="c")
     enrichment = cv.enrichment_create("metadata", {"k": "v"}, context="ctx")
     assert ti is not None
@@ -161,11 +161,10 @@ def test_proxy_dir_exposes_public_fields() -> None:
             "observable_links",
             "key",
         },
-        container: {
-            "path",
+        tag: {
+            "name",
             "description",
             "checks",
-            "sub_containers",
             "key",
         },
         ti: {
@@ -198,8 +197,8 @@ def test_proxy_public_fields_are_deep_copied() -> None:
     linked_check = cv.check_link_observable(check.key, obs.key)
     assert linked_check is not None
 
-    container = cv.container_create("root")
-    container.add_check(check)
+    tag = cv.tag_create("root")
+    tag.add_check(check)
 
     ti = cv.observable_add_threat_intel(
         obs.key,
@@ -220,9 +219,9 @@ def test_proxy_public_fields_are_deep_copied() -> None:
     links_copy.clear()
     assert len(check.observable_links) == 1
 
-    checks_copy = container.checks
+    checks_copy = tag.checks
     checks_copy.clear()
-    assert len(container.checks) == 1
+    assert len(tag.checks) == 1
 
     taxonomies_copy = ti.taxonomies
     taxonomies_copy.append({"level": Cyvest.LVL.SUSPICIOUS, "name": "confidence", "value": "low"})

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,7 +8,7 @@ import pytest
 
 from cyvest import Cyvest
 from cyvest.io_schema import get_investigation_schema
-from cyvest.model import Check, Container, Observable, ThreatIntel
+from cyvest.model import Check, Observable, Tag, ThreatIntel
 from cyvest.model_schema import InvestigationSchema
 
 
@@ -51,20 +51,20 @@ def test_level_required_in_serialization_schema() -> None:
             assert {"origin_investigation_id", "observable_links", "score"} <= required
 
 
-def test_container_aggregated_level_schema() -> None:
-    """aggregated_level is exposed as a Level enum in the schema."""
-    schema = Container.model_json_schema(mode="serialization")
+def test_tag_direct_level_schema() -> None:
+    """direct_level is exposed as a Level enum in the schema."""
+    schema = Tag.model_json_schema(mode="serialization")
 
     # If Pydantic emits a root $ref (common for self-recursive models), follow it.
     if "$ref" in schema:
-        ref = schema["$ref"]  # e.g. "#/$defs/Container"
+        ref = schema["$ref"]  # e.g. "#/$defs/Tag"
         name = ref.rsplit("/", 1)[-1]
         schema = schema["$defs"][name]
 
-    agg_level_schema = schema["properties"]["aggregated_level"]
+    direct_level_schema = schema["properties"]["direct_level"]
 
-    assert {"aggregated_level", "sub_containers", "checks", "key"} <= set(schema["properties"])
-    assert {"sub_containers", "checks", "key"} <= set(schema.get("required", []))
+    assert {"direct_level", "checks", "key"} <= set(schema["properties"])
+    assert {"checks", "key"} <= set(schema.get("required", []))
 
     def _has_level(subschema: dict[str, object]) -> bool:
         if "$ref" in subschema:
@@ -73,10 +73,10 @@ def test_container_aggregated_level_schema() -> None:
             return set(subschema["enum"]) >= {level.value for level in Cyvest.LVL}
         return False
 
-    if "allOf" in agg_level_schema:
-        assert any(_has_level(subschema) for subschema in agg_level_schema["allOf"])
+    if "allOf" in direct_level_schema:
+        assert any(_has_level(subschema) for subschema in direct_level_schema["allOf"])
     else:
-        assert _has_level(agg_level_schema)
+        assert _has_level(direct_level_schema)
 
 
 def test_investigation_schema_level_required_and_defaults() -> None:
@@ -95,7 +95,7 @@ def test_investigation_schema_level_required_and_defaults() -> None:
         "checks",
         "threat_intels",
         "enrichments",
-        "containers",
+        "tags",
     } <= required
 
     inst = InvestigationSchema.model_validate(
@@ -117,7 +117,7 @@ def test_investigation_schema_level_required_and_defaults() -> None:
                 "total_threat_intel": 0,
                 "threat_intel_by_source": {},
                 "threat_intel_by_level": {},
-                "total_containers": 0,
+                "total_tags": 0,
             },
             "data_extraction": {"root_type": None, "score_mode_obs": "max"},
         }
@@ -128,4 +128,4 @@ def test_investigation_schema_level_required_and_defaults() -> None:
     assert inst.checks == {}
     assert inst.threat_intels == {}
     assert inst.enrichments == {}
-    assert inst.containers == {}
+    assert inst.tags == {}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -113,7 +113,6 @@ def test_investigation_schema_level_required_and_defaults() -> None:
                 "observables_by_type_and_level": {},
                 "total_checks": 0,
                 "applied_checks": 0,
-                "checks_by_scope": {},
                 "checks_by_level": {},
                 "total_threat_intel": 0,
                 "threat_intel_by_source": {},

--- a/tests/test_serialization_config.py
+++ b/tests/test_serialization_config.py
@@ -1,7 +1,7 @@
 from cyvest import Cyvest
 from cyvest.io_serialization import load_investigation_json
 from cyvest.levels import Level
-from cyvest.model import Container, Enrichment, Observable, ObservableType
+from cyvest.model import Enrichment, Observable, ObservableType, Tag
 from cyvest.score import ScoreMode
 
 
@@ -34,45 +34,45 @@ def test_serialization_preserves_whitelisted_flag(tmp_path) -> None:
     assert any(entry.identifier == "wl-1" and entry.justification == "FP justification" for entry in whitelists)
 
 
-def test_markdown_excludes_containers_by_default() -> None:
-    """Test that containers section is excluded by default in markdown report."""
+def test_markdown_excludes_tags_by_default() -> None:
+    """Test that tags section is excluded by default in markdown report."""
     cv = Cyvest()
 
     # Add an observable
     obs = Observable(obs_type=ObservableType.DOMAIN, value="example.com", level=Level.INFO)
     cv._investigation.add_observable(obs)
 
-    # Add a container
-    container = Container(path="/test/container", description="Test container")
-    cv._investigation.add_container(container)
+    # Add a tag
+    tag = Tag(name="test:tag", description="Test tag")
+    cv._investigation.add_tag(tag)
 
-    # Generate markdown without include_containers
+    # Generate markdown without include_tags
     markdown = cv.io_to_markdown()
 
-    # Verify containers section is not present
-    assert "## Containers" not in markdown
-    assert "/test/container" not in markdown
+    # Verify tags section is not present
+    assert "## Tags" not in markdown
+    assert "test:tag" not in markdown
 
 
-def test_markdown_includes_containers_when_enabled() -> None:
-    """Test that containers section is included when include_containers=True."""
+def test_markdown_includes_tags_when_enabled() -> None:
+    """Test that tags section is included when include_tags=True."""
     cv = Cyvest()
 
     # Add an observable
     obs = Observable(obs_type=ObservableType.DOMAIN, value="example.com", level=Level.INFO)
     cv._investigation.add_observable(obs)
 
-    # Add a container
-    container = Container(path="/test/container", description="Test container")
-    cv._investigation.add_container(container)
+    # Add a tag
+    tag = Tag(name="test:tag", description="Test tag")
+    cv._investigation.add_tag(tag)
 
-    # Generate markdown with include_containers=True
-    markdown = cv.io_to_markdown(include_containers=True)
+    # Generate markdown with include_tags=True
+    markdown = cv.io_to_markdown(include_tags=True)
 
-    # Verify containers section is present
-    assert "## Containers" in markdown
-    assert "/test/container" in markdown
-    assert "Test container" in markdown
+    # Verify tags section is present
+    assert "## Tags" in markdown
+    assert "test:tag" in markdown
+    assert "Test tag" in markdown
 
 
 def test_markdown_excludes_enrichments_by_default() -> None:
@@ -164,12 +164,12 @@ def test_markdown_wrapper_methods_support_optional_parameters() -> None:
     """Test that Cyvest wrapper methods support optional parameters."""
     cv = Cyvest()
 
-    # Add observable, container, and enrichment
+    # Add observable, tag, and enrichment
     obs = Observable(obs_type=ObservableType.DOMAIN, value="example.com", level=Level.INFO)
     cv._investigation.add_observable(obs)
 
-    container = Container(path="/test", description="Test")
-    cv._investigation.add_container(container)
+    tag = Tag(name="test", description="Test")
+    cv._investigation.add_tag(tag)
 
     enrichment = Enrichment(name="Test", data={})
     cv._investigation.add_enrichment(enrichment)
@@ -177,22 +177,22 @@ def test_markdown_wrapper_methods_support_optional_parameters() -> None:
     # Test default behavior (excludes both)
     markdown_default = cv.io_to_markdown()
     assert "## Observables" in markdown_default
-    assert "## Containers" not in markdown_default
+    assert "## Tags" not in markdown_default
     assert "## Enrichments" not in markdown_default
 
-    # Test with containers enabled
-    markdown_containers = cv.io_to_markdown(include_containers=True)
-    assert "## Containers" in markdown_containers
-    assert "## Enrichments" not in markdown_containers
+    # Test with tags enabled
+    markdown_tags = cv.io_to_markdown(include_tags=True)
+    assert "## Tags" in markdown_tags
+    assert "## Enrichments" not in markdown_tags
 
     # Test with enrichments enabled
     markdown_enrichments = cv.io_to_markdown(include_enrichments=True)
-    assert "## Containers" not in markdown_enrichments
+    assert "## Tags" not in markdown_enrichments
     assert "## Enrichments" in markdown_enrichments
 
     # Test with both enabled
-    markdown_both = cv.io_to_markdown(include_containers=True, include_enrichments=True)
-    assert "## Containers" in markdown_both
+    markdown_both = cv.io_to_markdown(include_tags=True, include_enrichments=True)
+    assert "## Tags" in markdown_both
     assert "## Enrichments" in markdown_both
 
     # Test with observables disabled

--- a/tests/test_shared_context.py
+++ b/tests/test_shared_context.py
@@ -1283,9 +1283,7 @@ def test_export_comprehensive_investigation(tmp_path):
         url_obs.relate_to(domain_obs, Cyvest.REL.RELATED_TO)
 
         # Checks
-        cy.check("sender_reputation", "High risk sender detected").link_observable(email_obs).with_score(
-            Decimal("8.5")
-        )
+        cy.check("sender_reputation", "High risk sender detected").link_observable(email_obs).with_score(Decimal("8.5"))
         cy.check("url_analysis", "Malicious URL detected").link_observable(url_obs).with_score(Decimal("9.0"))
 
         # Enrichments

--- a/tests/test_shared_context.py
+++ b/tests/test_shared_context.py
@@ -73,11 +73,11 @@ def test_auto_reconcile_on_context_exit():
 
     with shared.create_cyvest() as cy:
         cy.observable(Cyvest.OBS.EMAIL, "user@domain.com")
-        cy.check("email_check", "header", "Test check")
+        cy.check("email_check", "Test check")
 
     # After exiting context, observable should be in registry
     assert "obs:email:user@domain.com" in shared._observable_registry
-    assert "chk:email_check:header" in shared._check_registry
+    assert "chk:email_check" in shared._check_registry
 
 
 def test_manual_reconcile():
@@ -88,14 +88,14 @@ def test_manual_reconcile():
     # Create Cyvest without auto-reconcile
     cy = Cyvest({"test": "data"}, root_type=Cyvest.OBS.ARTIFACT)
     cy.observable(Cyvest.OBS.DOMAIN, "example.com")
-    cy.check("domain_check", "network", "Test")
+    cy.check("domain_check", "Test")
 
     # Manually reconcile
     shared.reconcile(cy)
 
     # Should be in registry
     assert "obs:domain:example.com" in shared._observable_registry
-    assert "chk:domain_check:network" in shared._check_registry
+    assert "chk:domain_check" in shared._check_registry
 
 
 def test_get_observable():
@@ -132,15 +132,14 @@ def test_get_check():
     shared = SharedInvestigationContext(root_cy)
 
     with shared.create_cyvest() as cy:
-        original = cy.check("test_check", "scope", "Description")
+        original = cy.check("test_check", "Description")
         original_check = cy._investigation.get_check(original.key)
 
     # Retrieve check
-    retrieved = shared.check_get("test_check", "scope")
+    retrieved = shared.check_get("test_check")
 
     assert retrieved is not None
-    assert retrieved.check_id == "test_check"
-    assert retrieved.scope == "scope"
+    assert retrieved.check_name == "test_check"
     # Should be a deep copy
     assert retrieved is not original_check
 
@@ -163,10 +162,10 @@ def test_has_check():
     shared = SharedInvestigationContext(root_cy)
 
     with shared.create_cyvest() as cy:
-        cy.check("my_check", "category", "Description")
+        cy.check("my_check", "Description")
 
-    assert shared.check_get("my_check", "category") is not None
-    assert shared.check_get("other_check", "category") is None
+    assert shared.check_get("my_check") is not None
+    assert shared.check_get("other_check") is None
 
 
 def test_list_observables():
@@ -191,11 +190,11 @@ def test_list_checks():
     shared = SharedInvestigationContext(root_cy)
 
     with shared.create_cyvest() as cy:
-        cy.check("check1", "scope1", "Description 1")
-        cy.check("check2", "scope2", "Description 2")
+        cy.check("check1", "Description 1")
+        cy.check("check2", "Description 2")
 
-    assert shared.check_get("check1", "scope1") is not None
-    assert shared.check_get("check2", "scope2") is not None
+    assert shared.check_get("check1") is not None
+    assert shared.check_get("check2") is not None
 
 
 def test_observable_get_and_list_observables():
@@ -388,7 +387,7 @@ def test_shared_context_with_checks_and_observables():
         email_obs = cy.observable(Cyvest.OBS.EMAIL, data["email"])
         email_obs.with_ti("EmailRep", Decimal("7.0"))
 
-        check = cy.check("email_analysis", "header", "Analyze sender")
+        check = cy.check("email_analysis", "Analyze sender")
         check.link_observable(email_obs)
 
     # Task 2: Analyze URL, reference email check
@@ -398,11 +397,11 @@ def test_shared_context_with_checks_and_observables():
         url_obs.with_ti("VT", Decimal("9.0"))
 
         # Verify we can see the email check
-        email_check = shared.check_get("email_analysis", "header")
+        email_check = shared.check_get("email_analysis")
         assert email_check is not None
-        assert email_check.check_id == "email_analysis"
+        assert email_check.check_name == "email_analysis"
 
-        check = cy.check("url_analysis", "body", "Analyze malicious URL")
+        check = cy.check("url_analysis", "Analyze malicious URL")
         check.link_observable(url_obs)
 
     # Verify final state
@@ -410,8 +409,8 @@ def test_shared_context_with_checks_and_observables():
     assert len(shared._check_registry) == 2
     assert shared.observable_get(Cyvest.OBS.EMAIL, "phishing@malicious.com") is not None
     assert shared.observable_get(Cyvest.OBS.URL, "https://malicious.com/payload") is not None
-    assert shared.check_get("email_analysis", "header") is not None
-    assert shared.check_get("url_analysis", "body") is not None
+    assert shared.check_get("email_analysis") is not None
+    assert shared.check_get("url_analysis") is not None
 
 
 def test_deep_copy_prevents_modification():
@@ -453,20 +452,17 @@ def test_observable_get_with_parameters():
 
 
 def test_check_get_with_parameters():
-    """Test check_get using check_id and scope parameters."""
+    """Test check_get using check_name parameter."""
     root_cy = Cyvest({"test": "data"}, root_type=Cyvest.OBS.ARTIFACT)
     shared = SharedInvestigationContext(root_cy)
 
     with shared.create_cyvest() as cy:
-        cy.check("malware_scan", "attachment", "Scan for malware")
+        cy.check("malware_scan", "Scan for malware")
 
     # Test parameter-based lookup
-    check = shared.check_get("malware_scan", "attachment")
+    check = shared.check_get("malware_scan")
     assert check is not None
-    assert check.check_id == "malware_scan"
-    assert check.scope == "attachment"
-
-    assert check.check_id == "malware_scan"
+    assert check.check_name == "malware_scan"
 
 
 def test_existence_checks_via_getters():
@@ -476,12 +472,12 @@ def test_existence_checks_via_getters():
 
     with shared.create_cyvest() as cy:
         cy.observable(Cyvest.OBS.DOMAIN, "malicious.com")
-        cy.check("url_reputation", "body", "Check URL reputation")
+        cy.check("url_reputation", "Check URL reputation")
 
     assert shared.observable_get(Cyvest.OBS.DOMAIN, "malicious.com") is not None
     assert shared.observable_get(Cyvest.OBS.DOMAIN, "safe.com") is None
-    assert shared.check_get("url_reputation", "body") is not None
-    assert shared.check_get("email_reputation", "header") is None
+    assert shared.check_get("url_reputation") is not None
+    assert shared.check_get("email_reputation") is None
 
 
 def test_cyvest_get_observable_with_parameters():
@@ -499,16 +495,16 @@ def test_cyvest_get_observable_with_parameters():
 
 
 def test_cyvest_get_check_with_parameters():
-    """Test Cyvest.check_get using parameters for API consistency."""
+    """Test Cyvest.check_get using key for lookup."""
     cy = Cyvest({"test": "data"}, root_type=Cyvest.OBS.ARTIFACT)
-    check_proxy = cy.check("dns_lookup", "network", "DNS reputation check")
+    check_proxy = cy.check("dns_lookup", "DNS reputation check")
 
-    # Test parameter-based lookup
-    check = cy.check_get("dns_lookup", "network")
+    # Test key-based lookup
+    check = cy.check_get(check_proxy.key)
     assert check is not None
-    assert check.check_id == "dns_lookup"
+    assert check.check_name == "dns_lookup"
 
-    # Test key-based lookup (backward compatibility)
+    # Test key-based lookup (same method)
     check_key = cy.check_get(check_proxy.key)
     assert check_key is not None
 
@@ -545,7 +541,7 @@ def test_getters_invalid_arguments_raise_typeerror():
         shared.observable_get("type", "value", "extra")  # type: ignore[arg-type]
 
     with pytest.raises(TypeError):
-        shared.check_get("id")  # type: ignore[arg-type]
+        shared.check_get("id", "extra")  # type: ignore[arg-type]
 
 
 def test_parameter_based_api_in_parallel_tasks():
@@ -556,14 +552,14 @@ def test_parameter_based_api_in_parallel_tasks():
     def task1(shared_ctx):
         with shared_ctx.create_cyvest() as cy:
             cy.observable(Cyvest.OBS.EMAIL, "sender@malicious.com").with_ti("EmailRep", Decimal("8.0"))
-            cy.check("sender_check", "header", "Analyze sender")
+            cy.check("sender_check", "Analyze sender")
 
     def task2(shared_ctx):
         with shared_ctx.create_cyvest() as cy:
             # Use parameter-based lookup to get observable from task1
             sender = shared_ctx.observable_get(Cyvest.OBS.EMAIL, "sender@malicious.com")
             if sender and sender.score > 5:
-                cy.check("high_risk_sender", "risk", "High risk detected").with_score(Decimal("9.0"))
+                cy.check("high_risk_sender", "High risk detected").with_score(Decimal("9.0"))
 
     # Execute tasks in parallel
     with ThreadPoolExecutor(max_workers=2) as executor:
@@ -574,8 +570,8 @@ def test_parameter_based_api_in_parallel_tasks():
 
     # Verify both tasks completed and parameter-based lookups worked
     assert shared.observable_get(Cyvest.OBS.EMAIL, "sender@malicious.com") is not None
-    assert shared.check_get("sender_check", "header") is not None
-    assert shared.check_get("high_risk_sender", "risk") is not None
+    assert shared.check_get("sender_check") is not None
+    assert shared.check_get("high_risk_sender") is not None
 
     sender_obs = shared.observable_get(Cyvest.OBS.EMAIL, "sender@malicious.com")
     assert sender_obs.score >= Decimal("8.0")
@@ -689,12 +685,12 @@ def test_async_context_manager_auto_reconcile():
     async def run():
         async with shared.create_cyvest() as cy:
             cy.observable(Cyvest.OBS.EMAIL, "async@domain.com")
-            cy.check("async_check", "scope", "Async check")
+            cy.check("async_check", "Async check")
 
     asyncio.run(run())
 
     assert shared.observable_get(Cyvest.OBS.EMAIL, "async@domain.com") is not None
-    assert shared.check_get("async_check", "scope") is not None
+    assert shared.check_get("async_check") is not None
 
 
 def test_areconcile_and_observable_aget():
@@ -949,7 +945,7 @@ def test_get_global_score():
     assert initial_score == Decimal("0")
 
     with shared.create_cyvest() as cy:
-        cy.check("test", "test", description="test").link_observable(cy.root(), propagation_mode="GLOBAL")
+        cy.check("test", description="test").link_observable(cy.root(), propagation_mode="GLOBAL")
 
     # Directly add threat to main investigation's root
     root = inv.get_root()
@@ -982,7 +978,7 @@ def test_get_global_level_reflects_main_investigation():
     assert shared.get_global_level() == Cyvest.LVL.INFO
 
     with shared.create_cyvest() as cy:
-        cy.check("c1", "s1", "desc").with_score(Decimal("10"))
+        cy.check("c1", "desc").with_score(Decimal("10"))
 
     assert shared.get_global_level() == Cyvest.LVL.MALICIOUS
 
@@ -1076,7 +1072,7 @@ def test_io_to_invest_basic():
 
     with shared.create_cyvest() as cy:
         cy.observable(Cyvest.OBS.IPV4, "192.168.1.1").with_ti("SEKOIA", Decimal("6.0"))
-        cy.check("ip_reputation", "network", "Check IP reputation").with_score(Decimal("5.0"))
+        cy.check("ip_reputation", "Check IP reputation").with_score(Decimal("5.0"))
 
     schema = shared.io_to_invest()
 
@@ -1088,7 +1084,7 @@ def test_io_to_invest_basic():
     assert hasattr(schema, "checks")
     assert hasattr(schema, "stats")
     assert "obs:ipv4:192.168.1.1" in schema.observables
-    assert "network" in schema.checks  # checks are grouped by scope
+    assert "chk:ip_reputation" in schema.checks  # checks keyed by key
 
 
 def test_io_save_json_creates_file(tmp_path):
@@ -1098,7 +1094,7 @@ def test_io_save_json_creates_file(tmp_path):
 
     with shared.create_cyvest() as cy:
         cy.observable(Cyvest.OBS.URL, "https://malicious.com/payload").with_ti("VT", Decimal("10.0"))
-        cy.check("url_check", "body", "Analyze URL")
+        cy.check("url_check", "Analyze URL")
 
     filepath = tmp_path / "shared_investigation.json"
     result_path = shared.io_save_json(filepath)
@@ -1287,10 +1283,10 @@ def test_export_comprehensive_investigation(tmp_path):
         url_obs.relate_to(domain_obs, Cyvest.REL.RELATED_TO)
 
         # Checks
-        cy.check("sender_reputation", "header", "High risk sender detected").link_observable(email_obs).with_score(
+        cy.check("sender_reputation", "High risk sender detected").link_observable(email_obs).with_score(
             Decimal("8.5")
         )
-        cy.check("url_analysis", "body", "Malicious URL detected").link_observable(url_obs).with_score(Decimal("9.0"))
+        cy.check("url_analysis", "Malicious URL detected").link_observable(url_obs).with_score(Decimal("9.0"))
 
         # Enrichments
         cy.enrichment_create("whois", {"registrar": "Evil Registrar", "created": "2024-01-01"}, context="evil.com")
@@ -1318,8 +1314,8 @@ def test_export_comprehensive_investigation(tmp_path):
 
     # Verify schema structure
     assert len(schema.observables) >= 4  # 3 created + 1 root
-    assert "header" in schema.checks  # checks grouped by scope
-    assert "body" in schema.checks
+    assert "chk:sender_reputation" in schema.checks  # checks keyed by key
+    assert "chk:url_analysis" in schema.checks
     assert len(schema.enrichments) == 2
 
     # Verify files exist and are valid
@@ -1368,7 +1364,7 @@ def test_export_parallel_updates(tmp_path):
     def create_observable(index: int):
         with shared.create_cyvest() as cy:
             cy.observable(Cyvest.OBS.IPV4, f"10.0.0.{index}")
-            cy.check(f"check_{index}", "scope", f"Check {index}")
+            cy.check(f"check_{index}", f"Check {index}")
 
     with ThreadPoolExecutor(max_workers=5) as executor:
         futures = [executor.submit(create_observable, i) for i in range(10)]
@@ -1378,7 +1374,7 @@ def test_export_parallel_updates(tmp_path):
     # Export should capture all observables and checks
     schema = shared.io_to_invest()
     assert len(schema.observables) == 11  # 10 created + 1 root
-    assert len(schema.stats.checks_by_scope["scope"]) == 10
+    assert schema.stats.total_checks == 10
 
     # Save and verify
     json_path = tmp_path / "parallel.json"


### PR DESCRIPTION
- Changed Check model to use `check_name` instead of `check_id` and `scope`.
- Updated serialization logic to directly use checks without grouping by scope.
- Modified key generation for checks to only require `check_name`.
- Removed scope-related statistics and methods from InvestigationStats.
- Adjusted tests to reflect changes in Check creation and retrieval.
- Updated documentation and comments to align with new Check structure.