### PR TITLE
feat: add investigation comparison functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - 💾 **Multiple Export Formats**: JSON and Markdown output for reporting and LLM consumption
 - 🎨 **Rich Console Output**: Beautiful terminal displays with the Rich library
 - 🧩 **Fluent helpers**: Convenient API with method chaining for rapid development
+- 🔬 **Investigation Comparison**: Compare investigations with tolerance rules and visual diff output
 
 ## Installation
 
@@ -361,6 +362,88 @@ Its key is derived from type + value (e.g. `obs:file:root` or `obs:artifact:root
 
 This design enables flexible investigation structures while preventing unintended score contamination.
 
+### Comparing Investigations
+
+Compare two investigations to identify differences in checks, observables, and threat intelligence:
+
+```python
+from decimal import Decimal
+from cyvest import Cyvest, ExpectedResult, Level, compare_investigations
+from cyvest.io_rich import display_diff
+
+# Create expected and actual investigations
+expected = Cyvest(investigation_name="expected")
+expected.check_create("domain-check", "Verify domain", score=Decimal("1.0"))
+
+actual = Cyvest(investigation_name="actual")
+actual.check_create("domain-check", "Verify domain", score=Decimal("2.0"))
+actual.check_create("new-check", "New detection", score=Decimal("1.5"))
+
+# Compare investigations
+diffs = compare_investigations(actual, expected)
+# diffs contains:
+#   - MISMATCH for domain-check (score changed 1.0 -> 2.0)
+#   - ADDED for new-check
+```
+
+**Tolerance Rules**
+
+Use `result_expected` rules to define acceptable score variations:
+
+```python
+# Define tolerance rules
+rules = [
+    # Accept any score >= 1.0 for this check
+    ExpectedResult(check_name="domain-check", score=">= 1.0"),
+    # Accept any score < 3.0 for roger-ai
+    ExpectedResult(key="chk:roger-ai", level=Level.SUSPICIOUS, score="< 3.0"),
+]
+
+# Compare with tolerance - checks satisfying rules are not flagged as diffs
+diffs = compare_investigations(actual, expected, result_expected=rules)
+```
+
+Supported operators: `>=`, `<=`, `>`, `<`, `==`, `!=`
+
+**Visual Diff Display**
+
+Display differences in a rich table format:
+
+```python
+from cyvest.io_rich import display_diff
+from logurich import logger
+
+# Display diff table with tree structure showing observables and threat intel
+display_diff(diffs, lambda r: logger.rich("INFO", r), title="Investigation Diff")
+```
+
+Output:
+```
+╭────────────────────────────────────────────────┬────────────────────┬─────────────────┬────────╮
+│ Key                                            │      Expected      │     Actual      │ Status │
+├────────────────────────────────────────────────┼────────────────────┼─────────────────┼────────┤
+│ chk:new-check                                  │         -          │  NOTABLE 1.50   │   +    │
+│ └── domain: example.com                        │         -          │   INFO 0.00     │        │
+│     └── VirusTotal                             │         -          │   INFO 0.00     │        │
+├────────────────────────────────────────────────┼────────────────────┼─────────────────┼────────┤
+│ chk:domain-check                               │   NOTABLE 1.00     │  NOTABLE 2.00   │   ✗    │
+╰────────────────────────────────────────────────┴────────────────────┴─────────────────┴────────╯
+```
+
+Status symbols: `+` (added), `-` (removed), `✗` (mismatch)
+
+**Convenience Methods**
+
+Use methods directly on Cyvest objects:
+
+```python
+# Compare and get diff items
+diffs = actual.compare(expected=expected, result_expected=rules)
+
+# Compare and display in one call
+actual.display_diff(expected=expected, title="My Investigation Diff")
+```
+
 ## Examples
 
 See the `examples/` directory for complete examples:
@@ -370,6 +453,7 @@ See the `examples/` directory for complete examples:
 - **03_merge_demo.py**: Multi-process investigation merging
 - **04_email.py**: Multi-threaded investigation with SharedInvestigationContext
 - **05_visualization.py**: Interactive HTML visualization showcasing scores, levels, and relationship flows
+- **06_compare_investigations.py**: Compare investigations with tolerance rules and visual diff output
 
 Run an example:
 
@@ -500,6 +584,7 @@ Cyvest is designed for:
 - **Malware Analysis**: Track relationships between artifacts
 - **Phishing Analysis**: Analyze emails and linked resources
 - **Integration**: Combine results from multiple security tools
+- **Regression Testing**: Compare investigation outputs across rule or detection updates
 
 ## Architecture Highlights
 
@@ -509,6 +594,7 @@ Cyvest is designed for:
 - **Score Propagation**: Automatic hierarchical score calculation
 - **Flexible Export**: JSON for storage, Markdown for LLM analysis
 - **Audit Trail**: Score change history for debugging
+- **Investigation Comparison**: Compare investigations with tolerance rules for regression testing
 
 ## Future Enhancements
 

--- a/docs/comparing-investigations.md
+++ b/docs/comparing-investigations.md
@@ -1,0 +1,233 @@
+# Comparing Investigations
+
+Cyvest provides tools to compare two investigations and identify differences in checks, observables, and threat intelligence. This is useful for regression testing, validating detection rules, and tracking changes between investigation runs.
+
+---
+
+## Basic Comparison
+
+Compare two investigations using `compare_investigations()`:
+
+```python
+from decimal import Decimal
+from cyvest import Cyvest, compare_investigations
+
+# Create expected (baseline) investigation
+expected = Cyvest(investigation_name="expected")
+expected.check_create("domain-check", "Verify domain", score=Decimal("1.0"))
+
+# Create actual investigation
+actual = Cyvest(investigation_name="actual")
+actual.check_create("domain-check", "Verify domain", score=Decimal("2.0"))
+actual.check_create("new-check", "New detection", score=Decimal("1.5"))
+
+# Compare
+diffs = compare_investigations(actual, expected)
+```
+
+The function returns a list of `DiffItem` objects representing:
+
+| Status | Symbol | Description |
+|--------|--------|-------------|
+| ADDED | `+` | Check exists in actual but not in expected |
+| REMOVED | `-` | Check exists in expected but not in actual |
+| MISMATCH | `✗` | Check exists in both but score/level differs |
+
+---
+
+## Tolerance Rules
+
+Use `ExpectedResult` rules to define acceptable score variations. When the actual score satisfies a tolerance rule, the difference is not flagged.
+
+```python
+from cyvest import ExpectedResult, Level
+
+rules = [
+    # Accept any score >= 1.0 for this check
+    ExpectedResult(check_name="domain-check", score=">= 1.0"),
+
+    # Accept any score < 3.0 for roger-ai
+    ExpectedResult(key="chk:roger-ai", level=Level.SUSPICIOUS, score="< 3.0"),
+
+    # Exact match required
+    ExpectedResult(check_name="critical-check", score="== 5.0"),
+]
+
+diffs = compare_investigations(actual, expected, result_expected=rules)
+```
+
+### Supported Operators
+
+| Operator | Description |
+|----------|-------------|
+| `>=` | Greater than or equal |
+| `<=` | Less than or equal |
+| `>` | Greater than |
+| `<` | Less than |
+| `==` | Equal |
+| `!=` | Not equal |
+
+### ExpectedResult Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `check_name` | One of `check_name` or `key` | Check name (key will be derived) |
+| `key` | One of `check_name` or `key` | Full check key (e.g., `chk:my-check`) |
+| `level` | No | Expected level (informational) |
+| `score` | No | Tolerance rule string |
+
+---
+
+## Displaying Differences
+
+Use `display_diff()` to render differences as a rich table:
+
+```python
+from cyvest.io_rich import display_diff
+from logurich import logger
+
+display_diff(diffs, lambda r: logger.rich("INFO", r), title="Investigation Diff")
+```
+
+Output:
+
+```
+╭────────────────────────────────────────────────┬────────────────────┬─────────────────┬────────╮
+│ Key                                            │      Expected      │     Actual      │ Status │
+├────────────────────────────────────────────────┼────────────────────┼─────────────────┼────────┤
+│ chk:new-check                                  │         -          │  NOTABLE 1.50   │   +    │
+│ └── domain: example.com                        │         -          │   INFO 0.00     │        │
+│     └── VirusTotal                             │         -          │   INFO 0.00     │        │
+├────────────────────────────────────────────────┼────────────────────┼─────────────────┼────────┤
+│ chk:domain-check                               │   NOTABLE 1.00     │  NOTABLE 2.00   │   ✗    │
+╰────────────────────────────────────────────────┴────────────────────┴─────────────────┴────────╯
+```
+
+The table shows:
+
+- **Key**: Check key with linked observables and threat intel as a tree
+- **Expected**: Level and score from expected investigation (or tolerance rule)
+- **Actual**: Level and score from actual investigation
+- **Status**: Diff status symbol
+
+---
+
+## Convenience Methods
+
+Use methods directly on `Cyvest` objects:
+
+```python
+# Get diff items
+diffs = actual.compare(expected=expected, result_expected=rules)
+
+# Compare and display in one call
+actual.display_diff(expected=expected, title="My Investigation Diff")
+```
+
+---
+
+## DiffItem Structure
+
+Each `DiffItem` contains:
+
+```python
+class DiffItem:
+    status: DiffStatus          # ADDED, REMOVED, or MISMATCH
+    key: str                    # Check key
+    check_name: str             # Check name
+    expected_level: Level       # Expected level
+    expected_score: Decimal     # Expected score
+    expected_score_rule: str    # Tolerance rule (if any)
+    actual_level: Level         # Actual level
+    actual_score: Decimal       # Actual score
+    observable_diffs: list      # Linked observable differences
+```
+
+### ObservableDiff
+
+For each linked observable:
+
+```python
+class ObservableDiff:
+    observable_key: str
+    obs_type: str
+    value: str
+    expected_score: Decimal
+    expected_level: Level
+    actual_score: Decimal
+    actual_level: Level
+    threat_intel_diffs: list    # Threat intel differences
+```
+
+### ThreatIntelDiff
+
+For each threat intel source:
+
+```python
+class ThreatIntelDiff:
+    source: str
+    expected_score: Decimal
+    expected_level: Level
+    actual_score: Decimal
+    actual_level: Level
+```
+
+---
+
+## Use Cases
+
+### Regression Testing
+
+Compare investigation outputs before and after rule changes:
+
+```python
+# Run investigation with old rules
+old_cv = run_investigation(email, rules_v1)
+old_cv.io_save_json("baseline.json")
+
+# Run investigation with new rules
+new_cv = run_investigation(email, rules_v2)
+
+# Compare
+baseline = Cyvest.io_load_json("baseline.json")
+diffs = compare_investigations(new_cv, baseline)
+
+if diffs:
+    print(f"Found {len(diffs)} differences")
+    display_diff(diffs, print, title="Rule Changes Impact")
+```
+
+### Validation with Tolerance
+
+Define expected outcomes with acceptable variations:
+
+```python
+# Expected results for test case
+expected_results = [
+    ExpectedResult(check_name="spam-score", score=">= 5.0"),
+    ExpectedResult(check_name="phishing-score", score=">= 7.0"),
+    ExpectedResult(check_name="ai-analysis", score=">= 1.0"),  # Allow variation
+]
+
+diffs = compare_investigations(actual, expected, result_expected=expected_results)
+
+# Assert no unexpected differences
+assert len(diffs) == 0, f"Unexpected differences: {[d.key for d in diffs]}"
+```
+
+---
+
+## Example
+
+See `examples/06_compare_investigations.py` for a complete example demonstrating:
+
+- Creating expected and actual investigations
+- Comparing without tolerance rules
+- Comparing with tolerance rules
+- Using convenience methods
+
+Run it with:
+
+```bash
+python examples/06_compare_investigations.py
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ Build, score, and narrate cybersecurity investigations with a single fluent Pyth
 | **Deterministic scoring** | MAX/SUM propagation, centralized audit log, and automatic level classification | `cyvest.score`, [Scoring System](getting-started/concepts.md#scoring-system) |
 | **Fluent helpers** | Builder-style methods with deterministic keys and safe merges | `cyvest.cyvest`, [Quick Start](getting-started/quickstart.md#using-the-fluent-api) |
 | **Shared context** | Thread-safe fragments that can reconcile into a single story | `cyvest.shared.SharedInvestigationContext`, [Guide](shared-investigation-context.md) |
+| **Comparison** | Compare investigations with tolerance rules for regression testing | `cyvest.compare`, [Guide](comparing-investigations.md) |
 | **Reporting** | Export JSON, Markdown, or render rich terminal summaries | `cyvest.io_serialization`, `cyvest.io_rich`, [Quick Start](getting-started/quickstart.md#exporting-results) |
 
 ---
@@ -89,6 +90,7 @@ Cyvest (facade + fluent proxies)
 | Evaluate Cyvest in <10 minutes | [Getting Started](getting-started/quickstart.md) |
 | Understand observables vs. checks | [Core Concepts](getting-started/concepts.md#investigation-structure) |
 | Share state across threads | [Shared Investigation Context](shared-investigation-context.md) |
+| Compare investigations or regression test | [Comparing Investigations](comparing-investigations.md) |
 | Extend scoring or fluent helpers | [Contributing](contributing.md#architecture-overview) |
 | Embed results in other tools | [Quick Start → Exporting Results](getting-started/quickstart.md#exporting-results) |
 

--- a/examples/06_compare_investigations.py
+++ b/examples/06_compare_investigations.py
@@ -1,0 +1,166 @@
+"""
+Example 6: Compare Investigations
+
+Demonstrates how to compare two Cyvest investigations with optional tolerance rules.
+Shows differences in checks, observables, and threat intelligence between investigations.
+"""
+
+from decimal import Decimal
+
+from logurich import init_logger, logger
+
+from cyvest import Cyvest, ExpectedResult, Level, compare_investigations
+from cyvest.io_rich import display_diff
+
+init_logger("INFO")
+logger.enable("cyvest")
+
+
+def create_expected_investigation() -> Cyvest:
+    """Create an expected/baseline investigation for comparison."""
+    cv = Cyvest(root_data={"type": "email", "subject": "Test Email"}, investigation_name="expected")
+
+    # Create observables
+    domain = cv.observable(cv.OBS.DOMAIN, "example.com", internal=False)
+    domain.with_ti("VirusTotal", score=Decimal("0.0"), level=Level.INFO)
+    domain.with_ti("MISP Warning List", score=Decimal("0.0"), level=Level.SAFE)
+
+    ip = cv.observable(cv.OBS.IPV4, "192.168.1.1", internal=False)
+    ip.with_ti("VirusTotal", score=Decimal("0.0"), level=Level.INFO)
+    ip.with_ti("SEKOIA", score=Decimal("0.0"), level=Level.INFO)
+
+    # Create checks
+    domain_check = cv.check_create(
+        "domain-reputation",
+        "Domain reputation check",
+        score=Decimal("0.5"),
+        level=Level.NOTABLE,
+    )
+    domain_check.link_observable(domain)
+
+    ip_check = cv.check_create(
+        "ip-reputation",
+        "IP reputation check",
+        score=Decimal("0.0"),
+        level=Level.INFO,
+    )
+    ip_check.link_observable(ip)
+
+    cv.check_create(
+        "roger-ai",
+        "AI-based analysis",
+        score=Decimal("1.11"),
+        level=Level.SUSPICIOUS,
+    )
+
+    return cv
+
+
+def create_actual_investigation() -> Cyvest:
+    """Create an actual investigation with some differences."""
+    cv = Cyvest(root_data={"type": "email", "subject": "Test Email"}, investigation_name="actual")
+
+    # Create observables - with different scores
+    domain = cv.observable(cv.OBS.DOMAIN, "example.com", internal=False)
+    domain.with_ti("VirusTotal", score=Decimal("0.5"), level=Level.NOTABLE)  # Different score
+    domain.with_ti("MISP Warning List", score=Decimal("0.0"), level=Level.SAFE)
+
+    ip = cv.observable(cv.OBS.IPV4, "192.168.1.1", internal=False)
+    ip.with_ti("VirusTotal", score=Decimal("0.0"), level=Level.INFO)
+    ip.with_ti("SEKOIA", score=Decimal("0.0"), level=Level.INFO)
+
+    # New observable not in expected
+    malicious_domain = cv.observable(cv.OBS.DOMAIN, "malicious.com", internal=False)
+    malicious_domain.with_ti("VirusTotal", score=Decimal("8.5"), level=Level.MALICIOUS)
+    malicious_domain.with_ti("MISP", score=Decimal("7.0"), level=Level.MALICIOUS)
+
+    # Create checks - with some differences
+    domain_check = cv.check_create(
+        "domain-reputation",
+        "Domain reputation check",
+        score=Decimal("1.0"),  # Higher score than expected
+        level=Level.NOTABLE,
+    )
+    domain_check.link_observable(domain)
+
+    ip_check = cv.check_create(
+        "ip-reputation",
+        "IP reputation check",
+        score=Decimal("0.0"),  # Same as expected
+        level=Level.INFO,
+    )
+    ip_check.link_observable(ip)
+
+    cv.check_create(
+        "roger-ai",
+        "AI-based analysis",
+        score=Decimal("1.07"),  # Slightly different score
+        level=Level.SUSPICIOUS,
+    )
+
+    # New check not in expected
+    new_check = cv.check_create(
+        "new-detection",
+        "Newly added detection rule",
+        score=Decimal("2.5"),
+        level=Level.NOTABLE,
+    )
+    new_check.link_observable(malicious_domain)
+
+    return cv
+
+
+def main() -> None:
+    """Run the comparison example."""
+    logger.info("[bold magenta]Cyvest Investigation Comparison Example[/bold magenta]")
+    logger.info("")
+
+    # Create investigations
+    expected = create_expected_investigation()
+    actual = create_actual_investigation()
+
+    # Compare without tolerance rules
+    logger.info("[bold cyan]1. Comparing without tolerance rules:[/bold cyan]")
+    logger.info("")
+
+    diffs = compare_investigations(actual, expected)
+    display_diff(diffs, lambda r: logger.rich("INFO", r, width=150), title="Diff: Without Tolerance Rules")
+
+    logger.info("")
+    logger.info(f"Total differences found: {len(diffs)}")
+    logger.info("")
+
+    # Compare with tolerance rules
+    logger.info("[bold cyan]2. Comparing with tolerance rules:[/bold cyan]")
+    logger.info("")
+
+    tolerance_rules = [
+        # Allow roger-ai score to be >= 1.0
+        ExpectedResult(check_name="roger-ai", level=Level.SUSPICIOUS, score=">= 1.0"),
+        # Allow domain-reputation score to be < 2.0
+        ExpectedResult(key="chk:domain-reputation", score="< 2.0"),
+    ]
+
+    diffs_with_rules = compare_investigations(actual, expected, result_expected=tolerance_rules)
+    display_diff(
+        diffs_with_rules,
+        lambda r: logger.rich("INFO", r, width=150),
+        title="Diff: With Tolerance Rules",
+    )
+
+    logger.info("")
+    logger.info(f"Total differences found (with tolerance): {len(diffs_with_rules)}")
+    logger.info("")
+
+    # Using the Cyvest convenience methods
+    logger.info("[bold cyan]3. Using Cyvest convenience methods:[/bold cyan]")
+    logger.info("")
+
+    actual.display_diff(expected=expected, title="Diff: Using Cyvest.display_diff()")
+
+    logger.info("")
+    logger.info("[green]Example complete![/green]")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Quickstart: getting-started/quickstart.md
       - Concepts: getting-started/concepts.md
   - Shared Investigation Context: shared-investigation-context.md
+  - Comparing Investigations: comparing-investigations.md
   - JavaScript Packages: js-packages.md
   - Contributing: contributing.md
 

--- a/src/cyvest/__init__.py
+++ b/src/cyvest/__init__.py
@@ -7,6 +7,14 @@ programmatically with automatic scoring, level calculation, and rich reporting c
 
 from logurich import logger
 
+from cyvest.compare import (
+    DiffItem,
+    DiffStatus,
+    ExpectedResult,
+    ObservableDiff,
+    ThreatIntelDiff,
+    compare_investigations,
+)
 from cyvest.cyvest import Cyvest
 from cyvest.levels import Level
 from cyvest.model import Check, Enrichment, InvestigationWhitelist, Observable, Tag, Taxonomy, ThreatIntel
@@ -18,16 +26,20 @@ __version__ = "5.0.4"
 logger.disable("cyvest")
 
 __all__ = [
+    # Core class
     "Cyvest",
+    # Enums
     "Level",
     "ObservableType",
     "RelationshipDirection",
     "RelationshipType",
+    # Proxies
     "CheckProxy",
     "ObservableProxy",
     "ThreatIntelProxy",
     "EnrichmentProxy",
     "TagProxy",
+    # Models
     "Tag",
     "Enrichment",
     "InvestigationWhitelist",
@@ -35,4 +47,11 @@ __all__ = [
     "Observable",
     "ThreatIntel",
     "Taxonomy",
+    # Comparison module
+    "compare_investigations",
+    "ExpectedResult",
+    "DiffItem",
+    "DiffStatus",
+    "ObservableDiff",
+    "ThreatIntelDiff",
 ]

--- a/src/cyvest/cli.py
+++ b/src/cyvest/cli.py
@@ -17,6 +17,8 @@ from logurich.opt_click import click_logger_params
 from rich.console import Console
 
 from cyvest import __version__
+from cyvest.compare import ExpectedResult, compare_investigations
+from cyvest.io_rich import display_diff
 from cyvest.io_schema import get_investigation_schema
 from cyvest.io_serialization import load_investigation_json
 from cyvest.io_visualization import VisualizationDependencyMissingError
@@ -354,6 +356,66 @@ def visualize(
 
     if not no_browser:
         logger.info("[cyan]Opening visualization in browser...[/cyan]")
+
+
+@cli.command()
+@click.argument("actual", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("expected", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "-r",
+    "--rules",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="JSON file with ExpectedResult tolerance rules.",
+)
+@click.option(
+    "--title",
+    default="Investigation Diff",
+    show_default=True,
+    help="Title for the diff table.",
+)
+def diff(actual: Path, expected: Path, rules: Path | None, title: str) -> None:
+    """
+    Compare two investigation JSON files and display differences.
+
+    ACTUAL is the investigation to validate (actual results).
+    EXPECTED is the reference investigation (expected results).
+
+    Optionally provide a rules file with tolerance rules in JSON format:
+
+    \b
+    [
+      {"check_name": "domain-check", "score": ">= 1.0"},
+      {"key": "chk:ai-analysis", "level": "SUSPICIOUS", "score": "< 3.0"}
+    ]
+
+    Supported operators: >=, <=, >, <, ==, !=
+    """
+    logger.info("[cyan]Comparing investigations...[/cyan]")
+    logger.info(f"  Actual:   {actual}")
+    logger.info(f"  Expected: {expected}")
+
+    actual_cv = load_investigation_json(actual)
+    expected_cv = load_investigation_json(expected)
+
+    # Load tolerance rules if provided
+    result_expected: list[ExpectedResult] | None = None
+    if rules:
+        logger.info(f"  Rules:    {rules}")
+        with rules.open("r", encoding="utf-8") as f:
+            rules_data = json.load(f)
+        result_expected = [ExpectedResult(**r) for r in rules_data]
+
+    logger.info("")
+
+    # Compare investigations
+    diffs = compare_investigations(actual_cv, expected_cv, result_expected=result_expected)
+
+    if not diffs:
+        logger.info("[green]✓ No differences found[/green]")
+        return
+
+    # Display diff table
+    display_diff(diffs, lambda r: logger.rich("INFO", r, width=150), title=title)
 
 
 def main() -> None:

--- a/src/cyvest/compare.py
+++ b/src/cyvest/compare.py
@@ -1,0 +1,310 @@
+"""
+Comparison module for Cyvest investigations.
+
+Provides functionality to compare two investigations with optional tolerance rules,
+identifying differences in checks, observables, and threat intelligence.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field, model_validator
+
+from cyvest.keys import generate_check_key
+from cyvest.levels import Level
+
+if TYPE_CHECKING:
+    from cyvest.cyvest import Cyvest
+    from cyvest.proxies import CheckProxy
+
+
+class ExpectedResult(BaseModel):
+    """Tolerance rule for a specific check."""
+
+    check_name: str | None = None
+    key: str | None = None
+    level: Level | None = None
+    score: str | None = None  # Tolerance rule: ">= 0.01", "< 3", "== 1.0"
+
+    @model_validator(mode="after")
+    def validate_key_or_name(self) -> ExpectedResult:
+        if not self.check_name and not self.key:
+            raise ValueError("Either check_name or key must be provided")
+        # Derive key from check_name if not provided
+        if self.check_name and not self.key:
+            self.key = generate_check_key(self.check_name)
+        return self
+
+    model_config = {"extra": "forbid"}
+
+
+class DiffStatus(str, Enum):
+    """Status indicating the type of difference found."""
+
+    ADDED = "+"
+    REMOVED = "-"
+    MISMATCH = "\u2717"  # ✗
+
+
+class ThreatIntelDiff(BaseModel):
+    """Diff info for threat intel attached to an observable."""
+
+    source: str
+    expected_score: Decimal | None = None
+    expected_level: Level | None = None
+    actual_score: Decimal | None = None
+    actual_level: Level | None = None
+
+
+class ObservableDiff(BaseModel):
+    """Diff info for an observable linked to a check."""
+
+    observable_key: str
+    obs_type: str
+    value: str
+    expected_score: Decimal | None = None
+    expected_level: Level | None = None
+    actual_score: Decimal | None = None
+    actual_level: Level | None = None
+    threat_intel_diffs: list[ThreatIntelDiff] = Field(default_factory=list)
+
+
+class DiffItem(BaseModel):
+    """A single difference found between investigations."""
+
+    status: DiffStatus
+    key: str
+    check_name: str
+    # Expected values (from expected investigation or rule)
+    expected_level: Level | None = None
+    expected_score: Decimal | None = None
+    expected_score_rule: str | None = None  # e.g., ">= 1.0"
+    # Actual values
+    actual_level: Level | None = None
+    actual_score: Decimal | None = None
+    # Linked observables with their diffs
+    observable_diffs: list[ObservableDiff] = Field(default_factory=list)
+
+
+def parse_score_rule(rule: str) -> tuple[str, Decimal]:
+    """
+    Parse score rule like '>= 0.01' into (operator, value).
+
+    Args:
+        rule: A score rule string (e.g., ">= 0.01", "< 3", "== 1.0")
+
+    Returns:
+        Tuple of (operator, threshold)
+
+    Raises:
+        ValueError: If the rule format is invalid
+    """
+    match = re.match(r"(>=|<=|>|<|==|!=)\s*(-?\d+\.?\d*)", rule.strip())
+    if not match:
+        raise ValueError(f"Invalid score rule: {rule}")
+    return match.group(1), Decimal(match.group(2))
+
+
+def evaluate_score_rule(actual_score: Decimal, rule: str) -> bool:
+    """
+    Check if actual_score satisfies the rule.
+
+    Args:
+        actual_score: The score to evaluate
+        rule: A score rule string (e.g., ">= 0.01")
+
+    Returns:
+        True if the score satisfies the rule, False otherwise
+    """
+    operator, threshold = parse_score_rule(rule)
+    ops = {
+        ">=": lambda a, b: a >= b,
+        "<=": lambda a, b: a <= b,
+        ">": lambda a, b: a > b,
+        "<": lambda a, b: a < b,
+        "==": lambda a, b: a == b,
+        "!=": lambda a, b: a != b,
+    }
+    return ops[operator](actual_score, threshold)
+
+
+def compare_investigations(
+    actual: Cyvest,
+    expected: Cyvest | None = None,
+    result_expected: list[ExpectedResult] | None = None,
+) -> list[DiffItem]:
+    """
+    Compare two investigations with optional tolerance rules.
+
+    Args:
+        actual: The investigation to validate (actual results)
+        expected: The reference investigation (expected results), optional
+        result_expected: Tolerance rules for specific checks
+
+    Returns:
+        List of DiffItem for all differences found
+    """
+    diffs: list[DiffItem] = []
+    rules = {r.key: r for r in (result_expected or [])}
+
+    actual_checks = actual.check_get_all()
+    expected_checks = expected.check_get_all() if expected else {}
+
+    all_keys = set(actual_checks.keys()) | set(expected_checks.keys())
+
+    for key in sorted(all_keys):
+        actual_check = actual_checks.get(key)
+        expected_check = expected_checks.get(key)
+        rule = rules.get(key)
+
+        if actual_check and not expected_check:
+            # Check added in actual
+            diffs.append(
+                _create_diff_item(
+                    status=DiffStatus.ADDED,
+                    actual_check=actual_check,
+                    actual_cv=actual,
+                    expected_cv=expected,
+                )
+            )
+        elif expected_check and not actual_check:
+            # Check removed from actual
+            diffs.append(
+                _create_diff_item(
+                    status=DiffStatus.REMOVED,
+                    expected_check=expected_check,
+                    rule=rule,
+                    expected_cv=expected,
+                )
+            )
+        else:
+            # Check exists in both - compare values
+            if _is_mismatch(expected_check, actual_check, rule):
+                diffs.append(
+                    _create_diff_item(
+                        status=DiffStatus.MISMATCH,
+                        expected_check=expected_check,
+                        actual_check=actual_check,
+                        rule=rule,
+                        actual_cv=actual,
+                        expected_cv=expected,
+                    )
+                )
+
+    return diffs
+
+
+def _is_mismatch(
+    expected: CheckProxy,
+    actual: CheckProxy,
+    rule: ExpectedResult | None,
+) -> bool:
+    """Check if there's a mismatch, considering tolerance rules."""
+    # If scores and levels are equal, no mismatch
+    if expected.score == actual.score and expected.level == actual.level:
+        return False
+
+    # If there's a tolerance rule with score condition
+    if rule and rule.score:
+        # If actual satisfies the rule, it's OK (not a mismatch)
+        if evaluate_score_rule(actual.score, rule.score):
+            return False
+
+    # Scores/levels differ and no tolerance allows it
+    return True
+
+
+def _create_diff_item(
+    status: DiffStatus,
+    actual_check: CheckProxy | None = None,
+    expected_check: CheckProxy | None = None,
+    rule: ExpectedResult | None = None,
+    actual_cv: Cyvest | None = None,
+    expected_cv: Cyvest | None = None,
+) -> DiffItem:
+    """Create a DiffItem with observable and threat intel context."""
+    check = actual_check or expected_check
+
+    # Build observable diffs from linked observables
+    observable_diffs: list[ObservableDiff] = []
+
+    # Collect observable keys from both checks
+    obs_keys: set[str] = set()
+    if actual_check:
+        obs_keys.update(link.observable_key for link in actual_check.observable_links)
+    if expected_check:
+        obs_keys.update(link.observable_key for link in expected_check.observable_links)
+
+    for obs_key in sorted(obs_keys):
+        actual_obs = actual_cv.observable_get(obs_key) if actual_cv else None
+        expected_obs = expected_cv.observable_get(obs_key) if expected_cv else None
+        obs = actual_obs or expected_obs
+
+        if not obs:
+            continue
+
+        # Build threat intel diffs for this observable
+        ti_diffs: list[ThreatIntelDiff] = []
+        ti_sources: set[str] = set()
+
+        if actual_obs:
+            ti_sources.update(ti.source for ti in actual_obs.threat_intels)
+        if expected_obs:
+            ti_sources.update(ti.source for ti in expected_obs.threat_intels)
+
+        for source in sorted(ti_sources):
+            actual_ti = (
+                next(
+                    (ti for ti in actual_obs.threat_intels if ti.source == source),
+                    None,
+                )
+                if actual_obs
+                else None
+            )
+            expected_ti = (
+                next(
+                    (ti for ti in expected_obs.threat_intels if ti.source == source),
+                    None,
+                )
+                if expected_obs
+                else None
+            )
+
+            ti_diffs.append(
+                ThreatIntelDiff(
+                    source=source,
+                    expected_score=expected_ti.score if expected_ti else None,
+                    expected_level=expected_ti.level if expected_ti else None,
+                    actual_score=actual_ti.score if actual_ti else None,
+                    actual_level=actual_ti.level if actual_ti else None,
+                )
+            )
+
+        observable_diffs.append(
+            ObservableDiff(
+                observable_key=obs_key,
+                obs_type=str(obs.obs_type.value if hasattr(obs.obs_type, "value") else obs.obs_type),
+                value=obs.value,
+                expected_score=expected_obs.score if expected_obs else None,
+                expected_level=expected_obs.level if expected_obs else None,
+                actual_score=actual_obs.score if actual_obs else None,
+                actual_level=actual_obs.level if actual_obs else None,
+                threat_intel_diffs=ti_diffs,
+            )
+        )
+
+    return DiffItem(
+        status=status,
+        key=check.key,
+        check_name=check.check_name,
+        expected_level=expected_check.level if expected_check else (rule.level if rule else None),
+        expected_score=expected_check.score if expected_check else None,
+        expected_score_rule=rule.score if rule else None,
+        actual_level=actual_check.level if actual_check else None,
+        actual_score=actual_check.score if actual_check else None,
+        observable_diffs=observable_diffs,
+    )

--- a/src/cyvest/cyvest.py
+++ b/src/cyvest/cyvest.py
@@ -11,7 +11,7 @@ and investigation export (io_to_invest, io_to_markdown) methods.
 from __future__ import annotations
 
 import threading
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Literal, overload
@@ -19,8 +19,9 @@ from typing import TYPE_CHECKING, Any, Final, Literal, overload
 from logurich import logger
 
 from cyvest import keys
+from cyvest.compare import compare_investigations
 from cyvest.investigation import Investigation, InvestigationWhitelist
-from cyvest.io_rich import display_statistics, display_summary
+from cyvest.io_rich import display_diff, display_statistics, display_summary
 from cyvest.io_serialization import (
     generate_markdown_report,
     load_investigation_json,
@@ -28,6 +29,7 @@ from cyvest.io_serialization import (
     save_investigation_markdown,
     serialize_investigation,
 )
+from cyvest.io_visualization import generate_network_graph
 from cyvest.levels import Level
 from cyvest.model import Check, Enrichment, Observable, Tag, Taxonomy, ThreatIntel
 from cyvest.model_enums import ObservableType, PropagationMode, RelationshipDirection, RelationshipType
@@ -1010,8 +1012,6 @@ class Cyvest:
         """
         return serialize_investigation(self._investigation, include_audit_log=include_audit_log)
 
-    # Merge methods
-
     def merge_investigation(self, other: Cyvest) -> None:
         """
         Merge another investigation into this one.
@@ -1030,22 +1030,93 @@ class Cyvest:
         """
         self._investigation.finalize_relationships()
 
+    def compare(
+        self,
+        expected: Cyvest | None = None,
+        result_expected: list | None = None,
+    ) -> list:
+        """
+        Compare this investigation against expected results.
+
+        Args:
+            expected: The reference investigation (expected results), optional
+            result_expected: List of ExpectedResult tolerance rules for specific checks
+
+        Returns:
+            List of DiffItem for all differences found
+        """
+        return compare_investigations(actual=self, expected=expected, result_expected=result_expected)
+
     def display_summary(
         self,
         show_graph: bool = True,
         exclude_levels: Level | Iterable[Level] = Level.NONE,
         show_audit_log: bool = False,
+        rich_print: Callable[[Any], None] | None = None,
     ) -> None:
+        """
+        Display a comprehensive summary of the investigation using Rich.
+
+        Args:
+            show_graph: Whether to display the observable graph
+            exclude_levels: Level(s) to omit from the report (default: Level.NONE)
+            show_audit_log: Whether to display the investigation audit log
+            rich_print: Optional callable that takes a renderable and returns None
+        """
+        if rich_print is None:
+
+            def rich_print(renderables: Any) -> None:
+                logger.rich("INFO", renderables)
+
         display_summary(
             self,
-            lambda renderables: logger.rich("INFO", renderables),
+            rich_print,
             show_graph=show_graph,
             exclude_levels=exclude_levels,
             show_audit_log=show_audit_log,
         )
 
-    def display_statistics(self) -> None:
-        display_statistics(self, lambda renderables: logger.rich("INFO", renderables))
+    def display_statistics(
+        self,
+        rich_print: Callable[[Any], None] | None = None,
+    ) -> None:
+        """
+        Display investigation statistics using Rich.
+
+        Args:
+            rich_print: Optional callable that takes a renderable and returns None.
+                        If not provided, uses the default logger.
+        """
+        if rich_print is None:
+
+            def rich_print(renderables: Any) -> None:
+                logger.rich("INFO", renderables)
+
+        display_statistics(self, rich_print)
+
+    def display_diff(
+        self,
+        expected: Cyvest | None = None,
+        result_expected: list | None = None,
+        title: str = "Diff",
+        rich_print: Callable[[Any], None] | None = None,
+    ) -> None:
+        """
+        Compare and display diff against expected results.
+
+        Args:
+            expected: The reference investigation (expected results), optional
+            result_expected: List of ExpectedResult tolerance rules for specific checks
+            title: Title for the diff table
+            rich_print: Optional callable that takes a renderable and returns None
+        """
+        if rich_print is None:
+
+            def rich_print(renderables):
+                return logger.rich("INFO", renderables, width=150)
+
+        diffs = compare_investigations(actual=self, expected=expected, result_expected=result_expected)
+        display_diff(diffs, rich_print, title=title)
 
     def display_network(
         self,
@@ -1084,8 +1155,6 @@ class Cyvest:
             >>> cv.display_network()
             '/tmp/cyvest_12345/cyvest_network.html'
         """
-        from cyvest.io_visualization import generate_network_graph
-
         return generate_network_graph(
             self,
             output_dir=output_dir,

--- a/src/cyvest/io_rich.py
+++ b/src/cyvest/io_rich.py
@@ -566,3 +566,118 @@ def display_statistics(cv: Cyvest, rich_print: Callable[[Any], None]) -> None:
             ti_table.add_row(source, str(count))
 
         rich_print(ti_table)
+
+
+def _format_level_score(
+    level: Level | None,
+    score: Decimal | None,
+    score_rule: str | None = None,
+) -> str:
+    """Format level and score for display."""
+    if level is None and score is None and not score_rule:
+        return "[dim]-[/dim]"
+
+    parts: list[str] = []
+    if level:
+        color = get_color_level(level)
+        parts.append(f"[{color}]{level.name}[/{color}]")
+
+    if score_rule:
+        parts.append(score_rule)
+    elif score is not None:
+        color = get_color_score(score)
+        parts.append(f"[{color}]{_format_score_decimal(score)}[/{color}]")
+
+    return " ".join(parts) if parts else "[dim]-[/dim]"
+
+
+def display_diff(
+    diffs: list,
+    rich_print: Callable[[Any], None],
+    title: str = "Diff",
+) -> None:
+    """
+    Display investigation diff in a rich table with tree structure.
+
+    Args:
+        diffs: List of DiffItem objects representing differences
+        rich_print: A rich renderable handler called with renderables for output
+        title: Title for the diff table
+    """
+    # Import here to avoid circular dependency
+    from cyvest.compare import DiffStatus
+
+    # Count diffs by status
+    added = sum(1 for d in diffs if d.status == DiffStatus.ADDED)
+    removed = sum(1 for d in diffs if d.status == DiffStatus.REMOVED)
+    mismatch = sum(1 for d in diffs if d.status == DiffStatus.MISMATCH)
+
+    # Build caption with combined legend and counts
+    caption = (
+        f"[green]+ {added}[/green] added | [red]- {removed}[/red] removed | [yellow]\u2717 {mismatch}[/yellow] mismatch"
+    )
+
+    table = Table(title=title, caption=caption, expand=True)
+    table.add_column("Key")
+    table.add_column("Expected", justify="center")
+    table.add_column("Actual", justify="center")
+    table.add_column("Status", justify="center", width=8)
+
+    status_styles = {
+        DiffStatus.ADDED: "green",
+        DiffStatus.REMOVED: "red",
+        DiffStatus.MISMATCH: "yellow",
+    }
+
+    for idx, diff in enumerate(diffs):
+        # Add section separator between checks (except before first)
+        if idx > 0:
+            table.add_section()
+
+        status_style = status_styles.get(diff.status, "white")
+
+        # Check row (main row)
+        expected_str = _format_level_score(diff.expected_level, diff.expected_score, diff.expected_score_rule)
+        actual_str = _format_level_score(diff.actual_level, diff.actual_score)
+
+        table.add_row(
+            escape(diff.key),
+            expected_str,
+            actual_str,
+            f"[{status_style}]{diff.status.value}[/{status_style}]",
+        )
+
+        # Observable rows (indented with └──)
+        for obs_idx, obs in enumerate(diff.observable_diffs):
+            is_last_obs = obs_idx == len(diff.observable_diffs) - 1
+            obs_prefix = "└──" if is_last_obs else "├──"
+
+            obs_label = obs.observable_key
+            obs_expected = _format_level_score(obs.expected_level, obs.expected_score)
+            obs_actual = _format_level_score(obs.actual_level, obs.actual_score)
+
+            table.add_row(
+                f"{obs_prefix} [cyan]{escape(obs_label)}[/cyan]",
+                obs_expected,
+                obs_actual,
+                "",
+            )
+
+            # Threat intel rows (indented further with │   └── or     └──)
+            for ti_idx, ti in enumerate(obs.threat_intel_diffs):
+                is_last_ti = ti_idx == len(obs.threat_intel_diffs) - 1
+                # Use │ continuation if not last observable, else spaces
+                continuation = "│   " if not is_last_obs else "    "
+                ti_prefix = "└──" if is_last_ti else "├──"
+
+                ti_expected = _format_level_score(ti.expected_level, ti.expected_score)
+                ti_actual = _format_level_score(ti.actual_level, ti.actual_score)
+
+                table.add_row(
+                    f"{continuation}{ti_prefix} [magenta]{escape(ti.source)}[/magenta]",
+                    ti_expected,
+                    ti_actual,
+                    "",
+                )
+
+    rich_print(table)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,3 +177,93 @@ def test_display_summary_audit_log_table() -> None:
 
     assert "Audit Log" in rendered
     assert "virustotal" in rendered
+
+
+def test_cli_diff_no_differences(tmp_path: Path) -> None:
+    """CLI 'diff' command succeeds for identical investigations."""
+    from decimal import Decimal
+
+    cv = Cyvest()
+    cv.check("test-check", "test", "Test check").with_score(Decimal("1.0"))
+
+    file1 = tmp_path / "inv1.json"
+    file2 = tmp_path / "inv2.json"
+    cv.io_save_json(file1)
+    cv.io_save_json(file2)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["diff", str(file1), str(file2)])
+
+    assert result.exit_code == 0
+
+
+def test_cli_diff_with_differences(tmp_path: Path) -> None:
+    """CLI 'diff' command succeeds when differences exist."""
+    from decimal import Decimal
+
+    from cyvest.compare import compare_investigations
+
+    # Create actual investigation
+    actual = Cyvest(investigation_name="actual")
+    actual.check("check-a", "test", "Check A").with_score(Decimal("2.0"))
+    actual.check("check-new", "test", "New check").with_score(Decimal("1.0"))
+
+    # Create expected investigation
+    expected = Cyvest(investigation_name="expected")
+    expected.check("check-a", "test", "Check A").with_score(Decimal("1.0"))
+    expected.check("check-old", "test", "Old check").with_score(Decimal("1.0"))
+
+    actual_file = tmp_path / "actual.json"
+    expected_file = tmp_path / "expected.json"
+    actual.io_save_json(actual_file)
+    expected.io_save_json(expected_file)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["diff", str(actual_file), str(expected_file)])
+
+    assert result.exit_code == 0
+
+    # Verify differences using the compare module directly
+    diffs = compare_investigations(actual, expected)
+    assert len(diffs) == 3  # Added, Removed, Mismatch
+    diff_keys = {d.key for d in diffs}
+    assert "chk:check-new" in diff_keys
+    assert "chk:check-old" in diff_keys
+    assert "chk:check-a" in diff_keys
+
+
+def test_cli_diff_with_rules_file(tmp_path: Path) -> None:
+    """CLI 'diff' command applies tolerance rules from file."""
+    import json
+    from decimal import Decimal
+
+    from cyvest.compare import ExpectedResult, compare_investigations
+
+    # Create investigations with different scores
+    actual = Cyvest(investigation_name="actual")
+    actual.check("tolerant-check", "test", "Tolerant check").with_score(Decimal("1.5"))
+
+    expected = Cyvest(investigation_name="expected")
+    expected.check("tolerant-check", "test", "Tolerant check").with_score(Decimal("1.0"))
+
+    actual_file = tmp_path / "actual.json"
+    expected_file = tmp_path / "expected.json"
+    actual.io_save_json(actual_file)
+    expected.io_save_json(expected_file)
+
+    # Create rules file that tolerates the difference
+    rules_file = tmp_path / "rules.json"
+    rules_file.write_text(
+        json.dumps([{"check_name": "tolerant-check", "score": ">= 1.0"}]),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["diff", str(actual_file), str(expected_file), "-r", str(rules_file)])
+
+    assert result.exit_code == 0
+
+    # Verify tolerance rules work
+    rules = [ExpectedResult(check_name="tolerant-check", score=">= 1.0")]
+    diffs = compare_investigations(actual, expected, result_expected=rules)
+    assert len(diffs) == 0  # No differences with tolerance

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,395 @@
+"""
+Tests for the Cyvest comparison module.
+"""
+
+from decimal import Decimal
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+from cyvest import Cyvest, Level
+from cyvest.compare import (
+    DiffItem,
+    DiffStatus,
+    ExpectedResult,
+    ObservableDiff,
+    ThreatIntelDiff,
+    compare_investigations,
+    evaluate_score_rule,
+    parse_score_rule,
+)
+from cyvest.io_rich import display_diff
+
+
+class TestParseScoreRule:
+    """Tests for score rule parsing."""
+
+    def test_parse_greater_equal(self) -> None:
+        operator, value = parse_score_rule(">= 0.01")
+        assert operator == ">="
+        assert value == Decimal("0.01")
+
+    def test_parse_less_than(self) -> None:
+        operator, value = parse_score_rule("< 3")
+        assert operator == "<"
+        assert value == Decimal("3")
+
+    def test_parse_equal(self) -> None:
+        operator, value = parse_score_rule("== 1.0")
+        assert operator == "=="
+        assert value == Decimal("1.0")
+
+    def test_parse_not_equal(self) -> None:
+        operator, value = parse_score_rule("!= 5.5")
+        assert operator == "!="
+        assert value == Decimal("5.5")
+
+    def test_parse_greater_than(self) -> None:
+        operator, value = parse_score_rule("> 2")
+        assert operator == ">"
+        assert value == Decimal("2")
+
+    def test_parse_less_equal(self) -> None:
+        operator, value = parse_score_rule("<= 10")
+        assert operator == "<="
+        assert value == Decimal("10")
+
+    def test_parse_negative_value(self) -> None:
+        operator, value = parse_score_rule(">= -1")
+        assert operator == ">="
+        assert value == Decimal("-1")
+
+    def test_parse_with_spaces(self) -> None:
+        operator, value = parse_score_rule("  >=   0.5  ")
+        assert operator == ">="
+        assert value == Decimal("0.5")
+
+    def test_parse_invalid_rule(self) -> None:
+        with pytest.raises(ValueError, match="Invalid score rule"):
+            parse_score_rule("invalid")
+
+    def test_parse_missing_operator(self) -> None:
+        with pytest.raises(ValueError, match="Invalid score rule"):
+            parse_score_rule("0.5")
+
+
+class TestEvaluateScoreRule:
+    """Tests for score rule evaluation."""
+
+    def test_greater_equal_true(self) -> None:
+        assert evaluate_score_rule(Decimal("1.0"), ">= 0.5") is True
+
+    def test_greater_equal_exact(self) -> None:
+        assert evaluate_score_rule(Decimal("0.5"), ">= 0.5") is True
+
+    def test_greater_equal_false(self) -> None:
+        assert evaluate_score_rule(Decimal("0.4"), ">= 0.5") is False
+
+    def test_less_than_true(self) -> None:
+        assert evaluate_score_rule(Decimal("2.0"), "< 3") is True
+
+    def test_less_than_false(self) -> None:
+        assert evaluate_score_rule(Decimal("3.0"), "< 3") is False
+
+    def test_equal_true(self) -> None:
+        assert evaluate_score_rule(Decimal("1.0"), "== 1.0") is True
+
+    def test_equal_false(self) -> None:
+        assert evaluate_score_rule(Decimal("1.1"), "== 1.0") is False
+
+    def test_not_equal_true(self) -> None:
+        assert evaluate_score_rule(Decimal("1.1"), "!= 1.0") is True
+
+    def test_not_equal_false(self) -> None:
+        assert evaluate_score_rule(Decimal("1.0"), "!= 1.0") is False
+
+
+class TestExpectedResult:
+    """Tests for ExpectedResult model validation."""
+
+    def test_create_with_key(self) -> None:
+        rule = ExpectedResult(key="chk:test-check", level=Level.NOTABLE, score=">= 1.0")
+        assert rule.key == "chk:test-check"
+        assert rule.level == Level.NOTABLE
+        assert rule.score == ">= 1.0"
+
+    def test_create_with_check_name(self) -> None:
+        rule = ExpectedResult(check_name="test-check", score=">= 1.0")
+        assert rule.check_name == "test-check"
+        assert rule.key == "chk:test-check"  # Derived from check_name
+
+    def test_create_without_key_or_name_fails(self) -> None:
+        with pytest.raises(ValueError, match="Either check_name or key must be provided"):
+            ExpectedResult(level=Level.NOTABLE, score=">= 1.0")
+
+    def test_create_with_both_key_and_name(self) -> None:
+        rule = ExpectedResult(check_name="my-check", key="chk:custom-key", score=">= 1.0")
+        assert rule.check_name == "my-check"
+        assert rule.key == "chk:custom-key"  # Provided key takes precedence
+
+
+class TestCompareInvestigations:
+    """Tests for compare_investigations function."""
+
+    def test_no_differences_same_investigation(self) -> None:
+        cv1 = Cyvest()
+        cv1.check_create("test-check", "Test description", score=Decimal("1.0"), level=Level.NOTABLE)
+
+        cv2 = Cyvest()
+        cv2.check_create("test-check", "Test description", score=Decimal("1.0"), level=Level.NOTABLE)
+
+        diffs = compare_investigations(cv1, cv2)
+        assert len(diffs) == 0
+
+    def test_check_added(self) -> None:
+        expected = Cyvest()
+
+        actual = Cyvest()
+        actual.check_create("new-check", "New check", score=Decimal("1.0"), level=Level.NOTABLE)
+
+        diffs = compare_investigations(actual, expected)
+        assert len(diffs) == 1
+        assert diffs[0].status == DiffStatus.ADDED
+        assert diffs[0].key == "chk:new-check"
+
+    def test_check_removed(self) -> None:
+        expected = Cyvest()
+        expected.check_create("old-check", "Old check", score=Decimal("1.0"), level=Level.NOTABLE)
+
+        actual = Cyvest()
+
+        diffs = compare_investigations(actual, expected)
+        assert len(diffs) == 1
+        assert diffs[0].status == DiffStatus.REMOVED
+        assert diffs[0].key == "chk:old-check"
+
+    def test_check_mismatch_score(self) -> None:
+        expected = Cyvest()
+        expected.check_create("test-check", "Test", score=Decimal("1.0"), level=Level.NOTABLE)
+
+        actual = Cyvest()
+        actual.check_create("test-check", "Test", score=Decimal("2.0"), level=Level.NOTABLE)
+
+        diffs = compare_investigations(actual, expected)
+        assert len(diffs) == 1
+        assert diffs[0].status == DiffStatus.MISMATCH
+        assert diffs[0].expected_score == Decimal("1.0")
+        assert diffs[0].actual_score == Decimal("2.0")
+
+    def test_check_mismatch_level(self) -> None:
+        expected = Cyvest()
+        expected.check_create("test-check", "Test", score=Decimal("1.0"), level=Level.NOTABLE)
+
+        actual = Cyvest()
+        actual.check_create("test-check", "Test", score=Decimal("1.0"), level=Level.SUSPICIOUS)
+
+        diffs = compare_investigations(actual, expected)
+        assert len(diffs) == 1
+        assert diffs[0].status == DiffStatus.MISMATCH
+        assert diffs[0].expected_level == Level.NOTABLE
+        assert diffs[0].actual_level == Level.SUSPICIOUS
+
+    def test_tolerance_rule_satisfied(self) -> None:
+        """Test that tolerance rules can mark differences as OK."""
+        expected = Cyvest()
+        expected.check_create("test-check", "Test", score=Decimal("1.11"), level=Level.NOTABLE)
+
+        actual = Cyvest()
+        actual.check_create("test-check", "Test", score=Decimal("1.07"), level=Level.NOTABLE)
+
+        # Without tolerance rule - should be a mismatch
+        diffs_no_rule = compare_investigations(actual, expected)
+        assert len(diffs_no_rule) == 1
+        assert diffs_no_rule[0].status == DiffStatus.MISMATCH
+
+        # With tolerance rule - should be OK
+        rules = [ExpectedResult(key="chk:test-check", score=">= 1.0")]
+        diffs_with_rule = compare_investigations(actual, expected, result_expected=rules)
+        assert len(diffs_with_rule) == 0
+
+    def test_tolerance_rule_violated(self) -> None:
+        """Test that violations of tolerance rules are still flagged."""
+        expected = Cyvest()
+        expected.check_create("test-check", "Test", score=Decimal("1.11"), level=Level.NOTABLE)
+
+        actual = Cyvest()
+        actual.check_create("test-check", "Test", score=Decimal("0.5"), level=Level.NOTABLE)
+
+        rules = [ExpectedResult(key="chk:test-check", score=">= 1.0")]
+        diffs = compare_investigations(actual, expected, result_expected=rules)
+        assert len(diffs) == 1
+        assert diffs[0].status == DiffStatus.MISMATCH
+        assert diffs[0].expected_score_rule == ">= 1.0"
+
+    def test_observable_diffs_included(self) -> None:
+        """Test that observable diffs are populated."""
+        expected = Cyvest()
+        expected_check = expected.check_create("test-check", "Test", score=Decimal("1.0"), level=Level.NOTABLE)
+        expected_obs = expected.observable_create(Cyvest.OBS.DOMAIN, "example.com")
+        expected_check.link_observable(expected_obs)
+
+        actual = Cyvest()
+        actual_check = actual.check_create("test-check", "Test", score=Decimal("2.0"), level=Level.NOTABLE)
+        actual_obs = actual.observable_create(Cyvest.OBS.DOMAIN, "example.com")
+        actual_check.link_observable(actual_obs)
+
+        diffs = compare_investigations(actual, expected)
+        assert len(diffs) == 1
+        assert len(diffs[0].observable_diffs) == 1
+        obs_diff = diffs[0].observable_diffs[0]
+        assert obs_diff.value == "example.com"
+        assert obs_diff.obs_type == "domain"
+
+    def test_threat_intel_diffs_included(self) -> None:
+        """Test that threat intel diffs are populated."""
+        expected = Cyvest()
+        expected_check = expected.check_create("test-check", "Test", score=Decimal("1.0"), level=Level.NOTABLE)
+        expected_obs = expected.observable_create(Cyvest.OBS.DOMAIN, "example.com")
+        expected_obs.with_ti("VirusTotal", score=Decimal("0.0"), level=Level.INFO)
+        expected_check.link_observable(expected_obs)
+
+        actual = Cyvest()
+        actual_check = actual.check_create("test-check", "Test", score=Decimal("2.0"), level=Level.NOTABLE)
+        actual_obs = actual.observable_create(Cyvest.OBS.DOMAIN, "example.com")
+        actual_obs.with_ti("VirusTotal", score=Decimal("1.0"), level=Level.NOTABLE)
+        actual_check.link_observable(actual_obs)
+
+        diffs = compare_investigations(actual, expected)
+        assert len(diffs) == 1
+        assert len(diffs[0].observable_diffs) == 1
+        obs_diff = diffs[0].observable_diffs[0]
+        assert len(obs_diff.threat_intel_diffs) == 1
+        ti_diff = obs_diff.threat_intel_diffs[0]
+        assert ti_diff.source == "VirusTotal"
+        assert ti_diff.expected_score == Decimal("0.0")
+        assert ti_diff.actual_score == Decimal("1.0")
+
+
+class TestDisplayDiff:
+    """Tests for display_diff function."""
+
+    def test_display_empty_diff(self) -> None:
+        output = StringIO()
+        console = Console(file=output, force_terminal=True, width=120)
+        display_diff([], console.print, title="Empty Diff")
+        rendered = output.getvalue()
+        assert "Empty Diff" in rendered
+
+    def test_display_added_check(self) -> None:
+        output = StringIO()
+        console = Console(file=output, force_terminal=True, width=120)
+
+        diffs = [
+            DiffItem(
+                status=DiffStatus.ADDED,
+                key="chk:new-check",
+                check_name="new-check",
+                actual_level=Level.NOTABLE,
+                actual_score=Decimal("0.02"),
+            )
+        ]
+        display_diff(diffs, console.print, title="Test Diff")
+        rendered = output.getvalue()
+        assert "chk:new-check" in rendered
+        assert "+" in rendered
+
+    def test_display_removed_check(self) -> None:
+        output = StringIO()
+        console = Console(file=output, force_terminal=True, width=120)
+
+        diffs = [
+            DiffItem(
+                status=DiffStatus.REMOVED,
+                key="chk:old-check",
+                check_name="old-check",
+                expected_level=Level.SUSPICIOUS,
+                expected_score=Decimal("1.0"),
+            )
+        ]
+        display_diff(diffs, console.print, title="Test Diff")
+        rendered = output.getvalue()
+        assert "chk:old-check" in rendered
+        assert "-" in rendered
+
+    def test_display_mismatch_with_rule(self) -> None:
+        output = StringIO()
+        console = Console(file=output, force_terminal=True, width=120)
+
+        diffs = [
+            DiffItem(
+                status=DiffStatus.MISMATCH,
+                key="chk:roger-ai",
+                check_name="roger-ai",
+                expected_level=Level.SUSPICIOUS,
+                expected_score=Decimal("1.11"),
+                expected_score_rule="== 1.11",
+                actual_level=Level.SUSPICIOUS,
+                actual_score=Decimal("1.07"),
+            )
+        ]
+        display_diff(diffs, console.print, title="Test Diff")
+        rendered = output.getvalue()
+        assert "chk:roger-ai" in rendered
+        # The ✗ character for mismatch
+        assert "\u2717" in rendered or "✗" in rendered
+
+    def test_display_with_observable_tree(self) -> None:
+        output = StringIO()
+        console = Console(file=output, force_terminal=True, width=120)
+
+        diffs = [
+            DiffItem(
+                status=DiffStatus.ADDED,
+                key="chk:domain-check",
+                check_name="domain-check",
+                actual_level=Level.NOTABLE,
+                actual_score=Decimal("0.02"),
+                observable_diffs=[
+                    ObservableDiff(
+                        observable_key="obs:domain:example.com",
+                        obs_type="domain",
+                        value="example.com",
+                        actual_level=Level.INFO,
+                        actual_score=Decimal("0.0"),
+                        threat_intel_diffs=[
+                            ThreatIntelDiff(
+                                source="VirusTotal",
+                                actual_level=Level.INFO,
+                                actual_score=Decimal("0.0"),
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+        display_diff(diffs, console.print, title="Test Diff")
+        rendered = output.getvalue()
+        assert "example.com" in rendered
+        assert "VirusTotal" in rendered
+
+
+class TestCyvestCompareMethod:
+    """Tests for Cyvest.compare() and display_diff() methods."""
+
+    def test_cyvest_compare_method(self) -> None:
+        expected = Cyvest()
+        expected.check_create("test-check", "Test", score=Decimal("1.0"), level=Level.NOTABLE)
+
+        actual = Cyvest()
+        actual.check_create("test-check", "Test", score=Decimal("2.0"), level=Level.NOTABLE)
+
+        diffs = actual.compare(expected=expected)
+        assert len(diffs) == 1
+        assert diffs[0].status == DiffStatus.MISMATCH
+
+    def test_cyvest_compare_with_rules(self) -> None:
+        expected = Cyvest()
+        expected.check_create("test-check", "Test", score=Decimal("1.0"), level=Level.NOTABLE)
+
+        actual = Cyvest()
+        actual.check_create("test-check", "Test", score=Decimal("2.0"), level=Level.NOTABLE)
+
+        rules = [ExpectedResult(key="chk:test-check", score=">= 1.0")]
+        diffs = actual.compare(expected=expected, result_expected=rules)
+        assert len(diffs) == 0


### PR DESCRIPTION
- Introduced a new comparison module to compare investigations with tolerance rules.
- Added CLI command to compare two investigation JSON files and display differences.
- Enhanced the Cyvest class with a compare method for direct comparison of investigations.
- Updated the display functions to visualize differences in a structured format.
- Added tests for the comparison logic, including tolerance rules and observable diffs.
- Updated documentation to include new comparison features.