### PR TITLE
refactor(observable): refactor observable types and keys for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cv = Cyvest()
 
 url_obs = cv.observable_create(cv.OBS.URL, "https://malicious.com", internal=False)
 
-ip_obs = cv.observable_create(cv.OBS.IPV4_ADDR, "192.0.2.1", internal=False)
+ip_obs = cv.observable_create(cv.OBS.IPV4, "192.0.2.1", internal=False)
 
 cv.observable_add_relationship(
     url_obs,  # Can pass ObservableProxy directly
@@ -235,7 +235,7 @@ def email_analysis(shared_context):
     # create_cyvest() yields a task-local Cyvest that auto-merges on context exit
     with shared_context.create_cyvest() as cy:
         data = cy.root().extra
-        cy.observable(cy.OBS.DOMAIN_NAME, data.get("domain"))
+        cy.observable(cy.OBS.DOMAIN, data.get("domain"))
 
 # Create shared context
 main_cy = Cyvest(root_data=email_data, root_type=Cyvest.OBS.ARTIFACT)
@@ -314,7 +314,7 @@ The SAFE level has special protection for trusted/whitelisted observables:
 ```python
 # Mark a known-good domain as SAFE
 trusted = cv.observable_create(
-    cv.OBS.DOMAIN_NAME,
+    cv.OBS.DOMAIN,
     "trusted.example.com",
     level=cv.LVL.SAFE
 )
@@ -328,7 +328,7 @@ cv.observable_add_threat_intel(trusted.key, "source2", score=Decimal("6.0"))
 # Level upgrades to MALICIOUS, score updates to 6.0
 
 # Threat intel with SAFE level can also mark observables as SAFE
-uncertain = cv.observable_create(cv.OBS.DOMAIN_NAME, "example.com")
+uncertain = cv.observable_create(cv.OBS.DOMAIN, "example.com")
 cv.observable_add_threat_intel(
     uncertain.key,
     "whitelist_service",

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -64,33 +64,20 @@ Each observable has:
 from cyvest import Cyvest
 
 # Network observables
-Cyvest.OBS.IPV4_ADDR          # "ipv4-addr"
-Cyvest.OBS.IPV6_ADDR          # "ipv6-addr"
-Cyvest.OBS.DOMAIN_NAME        # "domain-name"
-Cyvest.OBS.URL                # "url"
-Cyvest.OBS.MAC_ADDR           # "mac-addr"
-Cyvest.OBS.NETWORK_TRAFFIC    # "network-traffic"
+Cyvest.OBS.IPV4              # "ipv4"
+Cyvest.OBS.IPV6              # "ipv6"
+Cyvest.OBS.DOMAIN            # "domain"
+Cyvest.OBS.URL               # "url"
+
+# Hash observables
+Cyvest.OBS.HASH              # "hash"
 
 # Email observables
-Cyvest.OBS.EMAIL_ADDR         # "email-addr"
-Cyvest.OBS.EMAIL_MESSAGE      # "email-message"
-Cyvest.OBS.EMAIL_MIME_PART    # "email-mime-part"
+Cyvest.OBS.EMAIL             # "email"
 
 # File observables
-Cyvest.OBS.FILE               # "file"
-Cyvest.OBS.DIRECTORY          # "directory"
-Cyvest.OBS.ARTIFACT           # "artifact"
-
-# System observables
-Cyvest.OBS.PROCESS            # "process"
-Cyvest.OBS.SOFTWARE           # "software"
-Cyvest.OBS.USER_ACCOUNT       # "user-account"
-Cyvest.OBS.WINDOWS_REGISTRY_KEY  # "windows-registry-key"
-
-# Other observables
-Cyvest.OBS.AUTONOMOUS_SYSTEM  # "autonomous-system"
-Cyvest.OBS.MUTEX              # "mutex"
-Cyvest.OBS.X509_CERTIFICATE   # "x509-certificate"
+Cyvest.OBS.FILE              # "file"
+Cyvest.OBS.ARTIFACT          # "artifact"
 ```
 
 Use the facade namespace for autocomplete:
@@ -223,7 +210,7 @@ All meaningful changes are recorded in a centralized, append-only audit log at t
 
 ```python
 # Observable score changes
-obs = cv.observable_create(cv.OBS.IPV4_ADDR, "10.0.0.1")
+obs = cv.observable_create(cv.OBS.IPV4, "10.0.0.1")
 cv.observable_add_threat_intel(obs.key, "source1", score=Decimal("5.0"))
 cv.observable_add_threat_intel(obs.key, "source2", score=Decimal("8.0"))
 
@@ -298,10 +285,10 @@ When root appears as a child of other observables, it is **SKIPPED** in their sc
 
 ```python
 # Example: Cross-contamination prevention
-domain = cv.observable(cv.OBS.DOMAIN_NAME, "branch1.com")
+domain = cv.observable(cv.OBS.DOMAIN, "branch1.com")
 domain.with_ti("source1", score=Decimal("9.0"))
 
-ip = cv.observable(cv.OBS.IPV4_ADDR, "192.0.2.1")
+ip = cv.observable(cv.OBS.IPV4, "192.0.2.1")
 ip.with_ti("source2", score=Decimal("1.0"))
 
 root = cv.root()
@@ -354,10 +341,10 @@ from decimal import Decimal
 cv = Cyvest()
 
 # Example 1: OUTBOUND - Domain → IP (IP is child)
-domain = cv.observable_create(cv.OBS.DOMAIN_NAME, "malware.com")
+domain = cv.observable_create(cv.OBS.DOMAIN, "malware.com")
 cv.observable_add_threat_intel(domain.key, "virustotal", score=Decimal("2.0"))
 
-ip = cv.observable_create(cv.OBS.IPV4_ADDR, "198.51.100.42")
+ip = cv.observable_create(cv.OBS.IPV4, "198.51.100.42")
 cv.observable_add_threat_intel(ip.key, "abuseipdb", score=Decimal("8.0"))
 
 # Domain resolves to IP (OUTBOUND by default)
@@ -384,10 +371,10 @@ print(f"URL score: {url.score}")        # 9.0 (includes child file score)
 
 
 # Example 3: BIDIRECTIONAL - No hierarchy
-host1 = cv.observable_create(cv.OBS.IPV4_ADDR, "10.0.1.10")
+host1 = cv.observable_create(cv.OBS.IPV4, "10.0.1.10")
 cv.observable_add_threat_intel(host1.key, "ids", score=Decimal("7.0"))
 
-host2 = cv.observable_create(cv.OBS.IPV4_ADDR, "10.0.1.20")
+host2 = cv.observable_create(cv.OBS.IPV4, "10.0.1.20")
 cv.observable_add_threat_intel(host2.key, "ids", score=Decimal("2.0"))
 
 # Hosts communicate (BIDIRECTIONAL by default)
@@ -399,10 +386,10 @@ print(f"Host2 score: {host2.score}")  # 2.0
 
 
 # Example 4: Override semantic defaults
-domain2 = cv.observable_create(cv.OBS.DOMAIN_NAME, "example.com")
+domain2 = cv.observable_create(cv.OBS.DOMAIN, "example.com")
 cv.observable_add_threat_intel(domain2.key, "source", score=Decimal("1.0"))
 
-ip2 = cv.observable_create(cv.OBS.IPV4_ADDR, "192.0.2.1")
+ip2 = cv.observable_create(cv.OBS.IPV4, "192.0.2.1")
 cv.observable_add_threat_intel(ip2.key, "source", score=Decimal("5.0"))
 
 # Override default to BIDIRECTIONAL (no hierarchy)
@@ -423,13 +410,13 @@ Score propagation works recursively through multiple levels:
 
 ```python
 # Grandparent → Parent → Child hierarchy
-grandparent = cv.observable_create(cv.OBS.DOMAIN_NAME, "root.com")
+grandparent = cv.observable_create(cv.OBS.DOMAIN, "root.com")
 cv.observable_add_threat_intel(grandparent.key, "source1", score=Decimal("1.0"))
 
-parent = cv.observable_create(cv.OBS.DOMAIN_NAME, "sub.root.com")
+parent = cv.observable_create(cv.OBS.DOMAIN, "sub.root.com")
 cv.observable_add_threat_intel(parent.key, "source2", score=Decimal("2.0"))
 
-child = cv.observable_create(cv.OBS.IPV4_ADDR, "203.0.113.10")
+child = cv.observable_create(cv.OBS.IPV4, "203.0.113.10")
 cv.observable_add_threat_intel(child.key, "source3", score=Decimal("9.0"))
 
 cv.observable_add_relationship(grandparent.key, parent.key, cv.REL.RELATED_TO, cv.DIR.OUTBOUND)
@@ -502,7 +489,7 @@ cv = Cyvest()
 
 # Create a SAFE observable (e.g., known-good domain)
 trusted = cv.observable_create(
-    cv.OBS.DOMAIN_NAME,
+    cv.OBS.DOMAIN,
     "trusted.example.com",
     score=0,
     level=cv.LVL.SAFE
@@ -539,7 +526,7 @@ print(f"Score: {trusted.score}, Level: {trusted.level}")
 # Output: Score: 6.0, Level: MALICIOUS
 
 # Threat intel with SAFE level can also mark observables as SAFE
-uncertain = cv.observable_create(cv.OBS.DOMAIN_NAME, "example.com")
+uncertain = cv.observable_create(cv.OBS.DOMAIN, "example.com")
 cv.observable_add_threat_intel(
     uncertain.key,
     "whitelist_service",
@@ -594,14 +581,14 @@ cv = Cyvest()
 check = cv.check_create("domain_check", "Analyze domain reputation")
 
 # Link a SAFE observable
-safe_domain = cv.observable_create(cv.OBS.DOMAIN_NAME, "trusted.example.com", level=cv.LVL.SAFE)
+safe_domain = cv.observable_create(cv.OBS.DOMAIN, "trusted.example.com", level=cv.LVL.SAFE)
 cv.check_link_observable(check.key, safe_domain.key)
 
 # Check inherits SAFE level from the observable
 print(f"Check level: {check.level}")  # Output: Check level: SAFE
 
 # Add INFO-level observables - check remains SAFE
-info_ip = cv.observable_create(cv.OBS.IPV4_ADDR, "192.0.2.1")
+info_ip = cv.observable_create(cv.OBS.IPV4, "192.0.2.1")
 cv.check_link_observable(check.key, info_ip.key)
 print(f"Check level: {check.level}")  # Output: Check level: SAFE
 
@@ -796,7 +783,7 @@ inv1 = Cyvest()
 inv1.observable_create(inv1.OBS.URL, "https://example.com")
 
 inv2 = Cyvest()
-inv2.observable_create(inv2.OBS.IPV4_ADDR, "192.168.1.1")
+inv2.observable_create(inv2.OBS.IPV4, "192.168.1.1")
 
 # Merge inv2 into inv1 - automatic deduplication
 inv1.merge_investigation(inv2)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -84,16 +84,16 @@ from cyvest import Cyvest
 
 cv = Cyvest()
 url = cv.observable_create(cv.OBS.URL, "http://c2-server.com")
-ip = cv.observable_create(cv.OBS.IPV4_ADDR, "192.0.2.100", internal=False)
+ip = cv.observable_create(cv.OBS.IPV4, "192.0.2.100", internal=False)
 cv.observable_add_relationship(url, ip, cv.REL.RELATED_TO)  # BIDIRECTIONAL
 
 domain = (
-    cv.observable(cv.OBS.DOMAIN_NAME, "c2-server.com", internal=False)
+    cv.observable(cv.OBS.DOMAIN, "c2-server.com", internal=False)
     .relate_to(ip, cv.REL.RELATED_TO)
 )
 
-host1 = cv.observable_create(cv.OBS.IPV4_ADDR, "10.0.1.10", internal=True)
-host2 = cv.observable_create(cv.OBS.IPV4_ADDR, "10.0.1.20", internal=True)
+host1 = cv.observable_create(cv.OBS.IPV4, "10.0.1.10", internal=True)
+host2 = cv.observable_create(cv.OBS.IPV4, "10.0.1.20", internal=True)
 cv.observable_add_relationship(host1, host2, cv.REL.RELATED_TO)  # BIDIRECTIONAL
 
 malware = cv.observable_create(cv.OBS.FILE, "payload.exe", internal=False)

--- a/docs/shared-investigation-context.md
+++ b/docs/shared-investigation-context.md
@@ -34,7 +34,7 @@ shared_context = main_cy.shared_context()
 def my_worker(shared_context):
     with shared_context.create_cyvest() as cy:
         data = cy.root().extra
-        cy.observable(cy.OBS.EMAIL_ADDR, data.get("email"))
+        cy.observable(cy.OBS.EMAIL, data.get("email"))
 ```
 
 ## Cross-Task Observable Sharing
@@ -45,16 +45,16 @@ Tasks can access observables created by other tasks:
 def email_from(shared_context):
     with shared_context.create_cyvest() as cy:
         data = cy.root().extra
-        cy.observable(cy.OBS.DOMAIN_NAME, data.get("domain"))
+        cy.observable(cy.OBS.DOMAIN, data.get("domain"))
 
 
 def bodies_url(shared_context):
     with shared_context.create_cyvest() as cy:
         data = cy.root().extra
-        domain_info = shared_context.observable_get(cy.OBS.DOMAIN_NAME, "malicious.com")
+        domain_info = shared_context.observable_get(cy.OBS.DOMAIN, "malicious.com")
         if domain_info:
             cy.observable(cy.OBS.URL, data.get("url")).relate_to(
-                cy.observable(cy.OBS.DOMAIN_NAME, domain_info.value),
+                cy.observable(cy.OBS.DOMAIN, domain_info.value),
                 cy.REL.RELATED_TO,
             )
 ```
@@ -117,13 +117,13 @@ Retrieves a shared observable by type and value.
 ```python
 from cyvest import Cyvest
 
-domain = shared_context.observable_get(Cyvest.OBS.DOMAIN_NAME, "malicious.com")
-email = shared_context.observable_get(Cyvest.OBS.EMAIL_ADDR, "user@example.com")
+domain = shared_context.observable_get(Cyvest.OBS.DOMAIN, "malicious.com")
+email = shared_context.observable_get(Cyvest.OBS.EMAIL, "user@example.com")
 
 # Use in task to reference observables from other tasks
 if domain:
     cy.observable(cy.OBS.URL, "https://example.com").relate_to(
-        cy.observable(cy.OBS.DOMAIN_NAME, domain.value),
+        cy.observable(cy.OBS.DOMAIN, domain.value),
         cy.REL.RELATED_TO,
     )
 ```
@@ -250,7 +250,7 @@ from cyvest.shared import SharedInvestigationContext
 
 async def worker(shared: SharedInvestigationContext):
     async with shared.create_cyvest() as cy:
-        cy.observable(cy.OBS.DOMAIN_NAME, "example.com")
+        cy.observable(cy.OBS.DOMAIN, "example.com")
 
 asyncio.run(worker(shared_context))
 ```

--- a/js/packages/cyvest-js/src/finders.ts
+++ b/js/packages/cyvest-js/src/finders.ts
@@ -23,12 +23,12 @@ import { isLevelAtLeast, isLevelHigherThan, LEVEL_VALUES } from "./levels";
  * Find all observables of a specific type.
  *
  * @param inv - The investigation to search
- * @param type - Observable type (e.g., "ipv4-addr", "url", "domain-name")
+ * @param type - Observable type (e.g., "ipv4", "url", "domain")
  * @returns Array of matching observables
  *
  * @example
  * ```ts
- * const ips = findObservablesByType(investigation, "ipv4-addr");
+ * const ips = findObservablesByType(investigation, "ipv4");
  * const urls = findObservablesByType(investigation, "url");
  * ```
  */
@@ -346,7 +346,7 @@ export function findTagsByNamePattern(
  *
  * @example
  * ```ts
- * const checks = findChecksForObservable(investigation, "obs:ipv4-addr:192.168.1.1");
+ * const checks = findChecksForObservable(investigation, "obs:ipv4:192.168.1.1");
  * ```
  */
 export function findChecksForObservable(

--- a/js/packages/cyvest-js/src/getters.ts
+++ b/js/packages/cyvest-js/src/getters.ts
@@ -21,12 +21,12 @@ import { getLevelFromScore } from "./levels";
  * Get an observable by its key.
  *
  * @param inv - The investigation to search
- * @param key - Observable key (e.g., "obs:ipv4-addr:192.168.1.1")
+ * @param key - Observable key (e.g., "obs:ipv4:192.168.1.1")
  * @returns The observable or undefined if not found
  *
  * @example
  * ```ts
- * const obs = getObservable(investigation, "obs:ipv4-addr:192.168.1.1");
+ * const obs = getObservable(investigation, "obs:ipv4:192.168.1.1");
  * if (obs) {
  *   console.log(obs.value, obs.level);
  * }
@@ -43,13 +43,13 @@ export function getObservable(
  * Get an observable by type and value.
  *
  * @param inv - The investigation to search
- * @param type - Observable type (e.g., "ipv4-addr", "url")
+ * @param type - Observable type (e.g., "ipv4", "url")
  * @param value - Observable value
  * @returns The observable or undefined if not found
  *
  * @example
  * ```ts
- * const obs = getObservableByTypeValue(investigation, "ipv4-addr", "192.168.1.1");
+ * const obs = getObservableByTypeValue(investigation, "ipv4", "192.168.1.1");
  * ```
  */
 export function getObservableByTypeValue(
@@ -156,7 +156,7 @@ export function getAllChecks(inv: CyvestInvestigation): Check[] {
  * Get a threat intel entry by its key.
  *
  * @param inv - The investigation to search
- * @param key - Threat intel key (e.g., "ti:virustotal:obs:ipv4-addr:192.168.1.1")
+ * @param key - Threat intel key (e.g., "ti:virustotal:obs:ipv4:192.168.1.1")
  * @returns The threat intel or undefined if not found
  */
 export function getThreatIntel(

--- a/js/packages/cyvest-js/src/graph.ts
+++ b/js/packages/cyvest-js/src/graph.ts
@@ -73,7 +73,7 @@ export interface InvestigationGraph {
  *
  * @example
  * ```ts
- * const related = getRelatedObservables(investigation, "obs:email-addr:test@example.com");
+ * const related = getRelatedObservables(investigation, "obs:email:test@example.com");
  * ```
  */
 export function getRelatedObservables(

--- a/js/packages/cyvest-js/src/keys.ts
+++ b/js/packages/cyvest-js/src/keys.ts
@@ -45,8 +45,8 @@ function hashString(content: string, length: number = 16): string {
  *
  * @example
  * ```ts
- * generateObservableKey("ipv4-addr", "192.168.1.1")
- * // => "obs:ipv4-addr:192.168.1.1"
+ * generateObservableKey("ipv4", "192.168.1.1")
+ * // => "obs:ipv4:192.168.1.1"
  * ```
  */
 export function generateObservableKey(obsType: string, value: string): string {
@@ -85,8 +85,8 @@ export function generateCheckKey(checkName: string): string {
  *
  * @example
  * ```ts
- * generateThreatIntelKey("virustotal", "obs:ipv4-addr:192.168.1.1")
- * // => "ti:virustotal:obs:ipv4-addr:192.168.1.1"
+ * generateThreatIntelKey("virustotal", "obs:ipv4:192.168.1.1")
+ * // => "ti:virustotal:obs:ipv4:192.168.1.1"
  * ```
  */
 export function generateThreatIntelKey(
@@ -210,7 +210,7 @@ export function isTagDescendantOf(descendantName: string, ancestorName: string):
  *
  * @example
  * ```ts
- * parseKeyType("obs:ipv4-addr:192.168.1.1") // => "obs"
+ * parseKeyType("obs:ipv4:192.168.1.1") // => "obs"
  * parseKeyType("invalid") // => null
  * ```
  */
@@ -233,9 +233,9 @@ export function parseKeyType(key: string): KeyType | null {
  *
  * @example
  * ```ts
- * validateKey("obs:ipv4-addr:192.168.1.1") // => true
- * validateKey("obs:ipv4-addr:192.168.1.1", "obs") // => true
- * validateKey("obs:ipv4-addr:192.168.1.1", "chk") // => false
+ * validateKey("obs:ipv4:192.168.1.1") // => true
+ * validateKey("obs:ipv4:192.168.1.1", "obs") // => true
+ * validateKey("obs:ipv4:192.168.1.1", "chk") // => false
  * validateKey("invalid") // => false
  * ```
  */
@@ -264,8 +264,8 @@ export function validateKey(key: string, expectedType?: KeyType): boolean {
  *
  * @example
  * ```ts
- * parseObservableKey("obs:ipv4-addr:192.168.1.1")
- * // => { type: "ipv4-addr", value: "192.168.1.1" }
+ * parseObservableKey("obs:ipv4:192.168.1.1")
+ * // => { type: "ipv4", value: "192.168.1.1" }
  * ```
  */
 export function parseObservableKey(
@@ -319,8 +319,8 @@ export function parseCheckKey(
  *
  * @example
  * ```ts
- * parseThreatIntelKey("ti:virustotal:obs:ipv4-addr:192.168.1.1")
- * // => { source: "virustotal", observableKey: "obs:ipv4-addr:192.168.1.1" }
+ * parseThreatIntelKey("ti:virustotal:obs:ipv4:192.168.1.1")
+ * // => { source: "virustotal", observableKey: "obs:ipv4:192.168.1.1" }
  * ```
  */
 export function parseThreatIntelKey(

--- a/js/packages/cyvest-js/tests/getters-finders.test.ts
+++ b/js/packages/cyvest-js/tests/getters-finders.test.ts
@@ -68,9 +68,9 @@ function createTestInvestigation(): CyvestInvestigation {
       },
     ],
     observables: {
-      "obs:ipv4-addr:192.168.1.1": {
-        key: "obs:ipv4-addr:192.168.1.1",
-        type: "ipv4-addr",
+      "obs:ipv4:192.168.1.1": {
+        key: "obs:ipv4:192.168.1.1",
+        type: "ipv4",
         value: "192.168.1.1",
         internal: true,
         whitelisted: false,
@@ -81,7 +81,7 @@ function createTestInvestigation(): CyvestInvestigation {
         level: "INFO",
         relationships: [
           {
-            target_key: "obs:domain-name:example.com",
+            target_key: "obs:domain:example.com",
             relationship_type: "related-to",
             direction: "outbound",
           },
@@ -89,9 +89,9 @@ function createTestInvestigation(): CyvestInvestigation {
         threat_intels: [],
         check_links: ["chk:ip_check:network"],
       },
-      "obs:ipv4-addr:8.8.8.8": {
-        key: "obs:ipv4-addr:8.8.8.8",
-        type: "ipv4-addr",
+      "obs:ipv4:8.8.8.8": {
+        key: "obs:ipv4:8.8.8.8",
+        type: "ipv4",
         value: "8.8.8.8",
         internal: false,
         whitelisted: true,
@@ -104,9 +104,9 @@ function createTestInvestigation(): CyvestInvestigation {
         threat_intels: [],
         check_links: [],
       },
-      "obs:domain-name:example.com": {
-        key: "obs:domain-name:example.com",
-        type: "domain-name",
+      "obs:domain:example.com": {
+        key: "obs:domain:example.com",
+        type: "domain",
         value: "example.com",
         internal: false,
         whitelisted: false,
@@ -116,7 +116,7 @@ function createTestInvestigation(): CyvestInvestigation {
         score_display: "5.00",
         level: "MALICIOUS",
         relationships: [],
-        threat_intels: ["ti:virustotal:obs:domain-name:example.com"],
+        threat_intels: ["ti:virustotal:obs:domain:example.com"],
         check_links: ["chk:domain_check:dns"],
       },
       "obs:url:http://malware.com/bad": {
@@ -148,7 +148,7 @@ function createTestInvestigation(): CyvestInvestigation {
         origin_investigation_id: "01HXYZTESTINVESTIGATION",
         observable_links: [
           {
-            observable_key: "obs:ipv4-addr:192.168.1.1",
+            observable_key: "obs:ipv4:192.168.1.1",
           },
         ],
       },
@@ -164,7 +164,7 @@ function createTestInvestigation(): CyvestInvestigation {
         origin_investigation_id: "01HXYZTESTINVESTIGATION",
         observable_links: [
           {
-            observable_key: "obs:domain-name:example.com",
+            observable_key: "obs:domain:example.com",
           },
         ],
       },
@@ -182,10 +182,10 @@ function createTestInvestigation(): CyvestInvestigation {
       },
     },
     threat_intels: {
-      "ti:virustotal:obs:domain-name:example.com": {
-        key: "ti:virustotal:obs:domain-name:example.com",
+      "ti:virustotal:obs:domain:example.com": {
+        key: "ti:virustotal:obs:domain:example.com",
         source: "virustotal",
-        observable_key: "obs:domain-name:example.com",
+        observable_key: "obs:domain:example.com",
         comment: "",
         extra: {},
         score: 5,
@@ -241,7 +241,7 @@ function createTestInvestigation(): CyvestInvestigation {
       internal_observables: 1,
       external_observables: 3,
       whitelisted_observables: 1,
-      observables_by_type: { "ipv4-addr": 2, "domain-name": 1, url: 1 },
+      observables_by_type: { "ipv4": 2, "domain": 1, url: 1 },
       observables_by_level: { INFO: 1, TRUSTED: 1, MALICIOUS: 2 },
       observables_by_type_and_level: {},
       total_checks: 3,
@@ -268,7 +268,7 @@ describe("Getters", () => {
 
   describe("getObservable", () => {
     it("returns observable by key", () => {
-      const obs = getObservable(inv, "obs:ipv4-addr:192.168.1.1");
+      const obs = getObservable(inv, "obs:ipv4:192.168.1.1");
       expect(obs).toBeDefined();
       expect(obs?.value).toBe("192.168.1.1");
     });
@@ -280,9 +280,9 @@ describe("Getters", () => {
 
   describe("getObservableByTypeValue", () => {
     it("finds observable by type and value", () => {
-      const obs = getObservableByTypeValue(inv, "ipv4-addr", "192.168.1.1");
+      const obs = getObservableByTypeValue(inv, "ipv4", "192.168.1.1");
       expect(obs).toBeDefined();
-      expect(obs?.key).toBe("obs:ipv4-addr:192.168.1.1");
+      expect(obs?.key).toBe("obs:ipv4:192.168.1.1");
     });
 
     it("is case insensitive", () => {
@@ -318,7 +318,7 @@ describe("Getters", () => {
     it("returns threat intel by key", () => {
       const ti = getThreatIntel(
         inv,
-        "ti:virustotal:obs:domain-name:example.com"
+        "ti:virustotal:obs:domain:example.com"
       );
       expect(ti).toBeDefined();
       expect(ti?.source).toBe("virustotal");
@@ -387,7 +387,7 @@ describe("Finders", () => {
 
   describe("findObservablesByType", () => {
     it("finds observables of specific type", () => {
-      const ips = findObservablesByType(inv, "ipv4-addr");
+      const ips = findObservablesByType(inv, "ipv4");
       expect(ips).toHaveLength(2);
     });
 
@@ -443,7 +443,7 @@ describe("Finders", () => {
 
   describe("findChecksForObservable", () => {
     it("finds checks that reference observable", () => {
-      const checks = findChecksForObservable(inv, "obs:ipv4-addr:192.168.1.1");
+      const checks = findChecksForObservable(inv, "obs:ipv4:192.168.1.1");
       expect(checks).toHaveLength(1);
       expect(checks[0].check_name).toBe("ip_check");
     });
@@ -453,7 +453,7 @@ describe("Finders", () => {
     it("finds threat intel for observable", () => {
       const tis = findThreatIntelsForObservable(
         inv,
-        "obs:domain-name:example.com"
+        "obs:domain:example.com"
       );
       expect(tis).toHaveLength(1);
       expect(tis[0].source).toBe("virustotal");
@@ -494,8 +494,8 @@ describe("Finders", () => {
   describe("getAllObservableTypes", () => {
     it("returns all observable types", () => {
       const types = getAllObservableTypes(inv);
-      expect(types).toContain("ipv4-addr");
-      expect(types).toContain("domain-name");
+      expect(types).toContain("ipv4");
+      expect(types).toContain("domain");
       expect(types).toContain("url");
     });
   });

--- a/js/packages/cyvest-js/tests/graph.test.ts
+++ b/js/packages/cyvest-js/tests/graph.test.ts
@@ -37,9 +37,9 @@ function createGraphTestInvestigation(): CyvestInvestigation {
     ],
     whitelists: [],
     observables: {
-      "obs:email-message:msg1": {
-        key: "obs:email-message:msg1",
-        type: "email-message",
+      "obs:file:msg1": {
+        key: "obs:file:msg1",
+        type: "file",
         value: "msg1",
         internal: false,
         whitelisted: false,
@@ -50,12 +50,12 @@ function createGraphTestInvestigation(): CyvestInvestigation {
         level: "INFO",
         relationships: [
           {
-            target_key: "obs:email-addr:sender@example.com",
+            target_key: "obs:email:sender@example.com",
             relationship_type: "from",
             direction: "outbound",
           },
           {
-            target_key: "obs:ipv4-addr:192.168.1.1",
+            target_key: "obs:ipv4:192.168.1.1",
             relationship_type: "originated-from",
             direction: "outbound",
           },
@@ -63,9 +63,9 @@ function createGraphTestInvestigation(): CyvestInvestigation {
         threat_intels: [],
         check_links: [],
       },
-      "obs:email-addr:sender@example.com": {
-        key: "obs:email-addr:sender@example.com",
-        type: "email-addr",
+      "obs:email:sender@example.com": {
+        key: "obs:email:sender@example.com",
+        type: "email",
         value: "sender@example.com",
         internal: false,
         whitelisted: false,
@@ -76,7 +76,7 @@ function createGraphTestInvestigation(): CyvestInvestigation {
         level: "INFO",
         relationships: [
           {
-            target_key: "obs:domain-name:example.com",
+            target_key: "obs:domain:example.com",
             relationship_type: "related-to",
             direction: "outbound",
           },
@@ -84,9 +84,9 @@ function createGraphTestInvestigation(): CyvestInvestigation {
         threat_intels: [],
         check_links: [],
       },
-      "obs:ipv4-addr:192.168.1.1": {
-        key: "obs:ipv4-addr:192.168.1.1",
-        type: "ipv4-addr",
+      "obs:ipv4:192.168.1.1": {
+        key: "obs:ipv4:192.168.1.1",
+        type: "ipv4",
         value: "192.168.1.1",
         internal: true,
         whitelisted: false,
@@ -99,9 +99,9 @@ function createGraphTestInvestigation(): CyvestInvestigation {
         threat_intels: [],
         check_links: [],
       },
-      "obs:domain-name:example.com": {
-        key: "obs:domain-name:example.com",
-        type: "domain-name",
+      "obs:domain:example.com": {
+        key: "obs:domain:example.com",
+        type: "domain",
         value: "example.com",
         internal: false,
         whitelisted: false,
@@ -114,9 +114,9 @@ function createGraphTestInvestigation(): CyvestInvestigation {
         threat_intels: [],
         check_links: [],
       },
-      "obs:file-hash:abc123": {
-        key: "obs:file-hash:abc123",
-        type: "file-hash",
+      "obs:hash:abc123": {
+        key: "obs:hash:abc123",
+        type: "hash",
         value: "abc123",
         internal: false,
         whitelisted: false,
@@ -166,7 +166,7 @@ describe("Graph Traversal", () => {
 
   describe("getRelatedObservables", () => {
     it("returns all directly connected observables", () => {
-      const related = getRelatedObservables(inv, "obs:email-message:msg1");
+      const related = getRelatedObservables(inv, "obs:file:msg1");
       expect(related).toHaveLength(2);
       const values = related.map((o) => o.value);
       expect(values).toContain("sender@example.com");
@@ -180,7 +180,7 @@ describe("Graph Traversal", () => {
     it("includes inbound relationships", () => {
       const related = getRelatedObservables(
         inv,
-        "obs:email-addr:sender@example.com"
+        "obs:email:sender@example.com"
       );
       // Has outbound to domain and inbound from email message
       expect(related.length).toBeGreaterThanOrEqual(2);
@@ -189,12 +189,12 @@ describe("Graph Traversal", () => {
 
   describe("getObservableChildren", () => {
     it("returns outbound related observables", () => {
-      const children = getObservableChildren(inv, "obs:email-message:msg1");
+      const children = getObservableChildren(inv, "obs:file:msg1");
       expect(children).toHaveLength(2);
     });
 
     it("returns empty for leaf nodes", () => {
-      const children = getObservableChildren(inv, "obs:ipv4-addr:192.168.1.1");
+      const children = getObservableChildren(inv, "obs:ipv4:192.168.1.1");
       expect(children).toHaveLength(0);
     });
   });
@@ -203,14 +203,14 @@ describe("Graph Traversal", () => {
     it("returns observables pointing to this one", () => {
       const parents = getObservableParents(
         inv,
-        "obs:email-addr:sender@example.com"
+        "obs:email:sender@example.com"
       );
       expect(parents).toHaveLength(1);
       expect(parents[0].value).toBe("msg1");
     });
 
     it("returns empty for root nodes", () => {
-      const parents = getObservableParents(inv, "obs:email-message:msg1");
+      const parents = getObservableParents(inv, "obs:file:msg1");
       expect(parents).toHaveLength(0);
     });
   });
@@ -219,7 +219,7 @@ describe("Graph Traversal", () => {
     it("filters by relationship type", () => {
       const fromRelated = getRelatedObservablesByType(
         inv,
-        "obs:email-message:msg1",
+        "obs:file:msg1",
         "from"
       );
       expect(fromRelated).toHaveLength(1);
@@ -241,10 +241,10 @@ describe("Graph Traversal", () => {
     it("nodes have correct structure", () => {
       const graph = getObservableGraph(inv);
       const emailNode = graph.nodes.find(
-        (n) => n.id === "obs:email-message:msg1"
+        (n) => n.id === "obs:file:msg1"
       );
       expect(emailNode).toBeDefined();
-      expect(emailNode?.type).toBe("email-message");
+      expect(emailNode?.type).toBe("file");
       expect(emailNode?.value).toBe("msg1");
       expect(emailNode?.level).toBe("INFO");
     });
@@ -253,15 +253,15 @@ describe("Graph Traversal", () => {
       const graph = getObservableGraph(inv);
       const fromEdge = graph.edges.find((e) => e.type === "from");
       expect(fromEdge).toBeDefined();
-      expect(fromEdge?.source).toBe("obs:email-message:msg1");
-      expect(fromEdge?.target).toBe("obs:email-addr:sender@example.com");
+      expect(fromEdge?.source).toBe("obs:file:msg1");
+      expect(fromEdge?.target).toBe("obs:email:sender@example.com");
     });
   });
 
   describe("findSourceObservables", () => {
     it("finds observables with no incoming relationships", () => {
       const sources = findSourceObservables(inv);
-      // email-message and file-hash are sources
+      // file and hash are sources
       expect(sources.length).toBeGreaterThanOrEqual(2);
       const values = sources.map((o) => o.value);
       expect(values).toContain("msg1");
@@ -272,7 +272,7 @@ describe("Graph Traversal", () => {
   describe("findOrphanObservables", () => {
     it("finds observables with no relationships", () => {
       const orphans = findOrphanObservables(inv);
-      // file-hash has no relationships
+      // hash has no relationships
       expect(orphans).toHaveLength(1);
       expect(orphans[0].value).toBe("abc123");
     });
@@ -290,7 +290,7 @@ describe("Graph Traversal", () => {
   describe("areConnected", () => {
     it("returns true for directly connected", () => {
       expect(
-        areConnected(inv, "obs:email-message:msg1", "obs:ipv4-addr:192.168.1.1")
+        areConnected(inv, "obs:file:msg1", "obs:ipv4:192.168.1.1")
       ).toBe(true);
     });
 
@@ -298,21 +298,21 @@ describe("Graph Traversal", () => {
       expect(
         areConnected(
           inv,
-          "obs:email-message:msg1",
-          "obs:domain-name:example.com"
+          "obs:file:msg1",
+          "obs:domain:example.com"
         )
       ).toBe(true);
     });
 
     it("returns false for disconnected", () => {
       expect(
-        areConnected(inv, "obs:file-hash:abc123", "obs:email-message:msg1")
+        areConnected(inv, "obs:hash:abc123", "obs:file:msg1")
       ).toBe(false);
     });
 
     it("returns true for same node", () => {
       expect(
-        areConnected(inv, "obs:email-message:msg1", "obs:email-message:msg1")
+        areConnected(inv, "obs:file:msg1", "obs:file:msg1")
       ).toBe(true);
     });
   });
@@ -321,32 +321,32 @@ describe("Graph Traversal", () => {
     it("finds direct path", () => {
       const path = findPath(
         inv,
-        "obs:email-message:msg1",
-        "obs:ipv4-addr:192.168.1.1"
+        "obs:file:msg1",
+        "obs:ipv4:192.168.1.1"
       );
       expect(path).toEqual([
-        "obs:email-message:msg1",
-        "obs:ipv4-addr:192.168.1.1",
+        "obs:file:msg1",
+        "obs:ipv4:192.168.1.1",
       ]);
     });
 
     it("finds transitive path", () => {
       const path = findPath(
         inv,
-        "obs:email-message:msg1",
-        "obs:domain-name:example.com"
+        "obs:file:msg1",
+        "obs:domain:example.com"
       );
       expect(path).not.toBeNull();
       expect(path?.length).toBe(3);
-      expect(path?.[0]).toBe("obs:email-message:msg1");
-      expect(path?.[path.length - 1]).toBe("obs:domain-name:example.com");
+      expect(path?.[0]).toBe("obs:file:msg1");
+      expect(path?.[path.length - 1]).toBe("obs:domain:example.com");
     });
 
     it("returns null for no path", () => {
       const path = findPath(
         inv,
-        "obs:file-hash:abc123",
-        "obs:email-message:msg1"
+        "obs:hash:abc123",
+        "obs:file:msg1"
       );
       expect(path).toBeNull();
     });
@@ -354,23 +354,23 @@ describe("Graph Traversal", () => {
     it("returns single node for same source/target", () => {
       const path = findPath(
         inv,
-        "obs:email-message:msg1",
-        "obs:email-message:msg1"
+        "obs:file:msg1",
+        "obs:file:msg1"
       );
-      expect(path).toEqual(["obs:email-message:msg1"]);
+      expect(path).toEqual(["obs:file:msg1"]);
     });
   });
 
   describe("getReachableObservables", () => {
     it("returns all reachable from start", () => {
-      const reachable = getReachableObservables(inv, "obs:email-message:msg1");
+      const reachable = getReachableObservables(inv, "obs:file:msg1");
       expect(reachable).toHaveLength(4); // msg1 + sender + ip + domain
     });
 
     it("respects max depth", () => {
       const reachable = getReachableObservables(
         inv,
-        "obs:email-message:msg1",
+        "obs:file:msg1",
         1
       );
       expect(reachable).toHaveLength(3); // msg1 + sender + ip (depth 1)
@@ -399,7 +399,7 @@ describe("Graph Traversal", () => {
     it("returns outbound and inbound relationships", () => {
       const rels = getRelationshipsForObservable(
         inv,
-        "obs:email-addr:sender@example.com"
+        "obs:email:sender@example.com"
       );
       expect(rels.outbound).toHaveLength(1);
       expect(rels.inbound).toHaveLength(1);

--- a/js/packages/cyvest-js/tests/keys-levels.test.ts
+++ b/js/packages/cyvest-js/tests/keys-levels.test.ts
@@ -27,20 +27,20 @@ import {
 describe("Key Generation", () => {
   describe("generateObservableKey", () => {
     it("generates correct observable key", () => {
-      expect(generateObservableKey("ipv4-addr", "192.168.1.1")).toBe(
-        "obs:ipv4-addr:192.168.1.1"
+      expect(generateObservableKey("ipv4", "192.168.1.1")).toBe(
+        "obs:ipv4:192.168.1.1"
       );
     });
 
     it("normalizes to lowercase", () => {
       expect(generateObservableKey("IPV4-ADDR", "192.168.1.1")).toBe(
-        "obs:ipv4-addr:192.168.1.1"
+        "obs:ipv4:192.168.1.1"
       );
     });
 
     it("trims whitespace", () => {
-      expect(generateObservableKey("  ipv4-addr  ", "  192.168.1.1  ")).toBe(
-        "obs:ipv4-addr:192.168.1.1"
+      expect(generateObservableKey("  ipv4  ", "  192.168.1.1  ")).toBe(
+        "obs:ipv4:192.168.1.1"
       );
     });
   });
@@ -56,8 +56,8 @@ describe("Key Generation", () => {
   describe("generateThreatIntelKey", () => {
     it("generates correct threat intel key", () => {
       expect(
-        generateThreatIntelKey("virustotal", "obs:ipv4-addr:192.168.1.1")
-      ).toBe("ti:virustotal:obs:ipv4-addr:192.168.1.1");
+        generateThreatIntelKey("virustotal", "obs:ipv4:192.168.1.1")
+      ).toBe("ti:virustotal:obs:ipv4:192.168.1.1");
     });
   });
 
@@ -88,7 +88,7 @@ describe("Key Generation", () => {
 
   describe("parseKeyType", () => {
     it("parses observable key type", () => {
-      expect(parseKeyType("obs:ipv4-addr:192.168.1.1")).toBe("obs");
+      expect(parseKeyType("obs:ipv4:192.168.1.1")).toBe("obs");
     });
 
     it("parses check key type", () => {
@@ -115,13 +115,13 @@ describe("Key Generation", () => {
 
   describe("validateKey", () => {
     it("validates correct keys", () => {
-      expect(validateKey("obs:ipv4-addr:192.168.1.1")).toBe(true);
+      expect(validateKey("obs:ipv4:192.168.1.1")).toBe(true);
       expect(validateKey("chk:sender:email")).toBe(true);
     });
 
     it("validates key type", () => {
-      expect(validateKey("obs:ipv4-addr:192.168.1.1", "obs")).toBe(true);
-      expect(validateKey("obs:ipv4-addr:192.168.1.1", "chk")).toBe(false);
+      expect(validateKey("obs:ipv4:192.168.1.1", "obs")).toBe(true);
+      expect(validateKey("obs:ipv4:192.168.1.1", "chk")).toBe(false);
     });
 
     it("rejects invalid keys", () => {
@@ -133,8 +133,8 @@ describe("Key Generation", () => {
 
   describe("parseObservableKey", () => {
     it("parses observable key components", () => {
-      expect(parseObservableKey("obs:ipv4-addr:192.168.1.1")).toEqual({
-        type: "ipv4-addr",
+      expect(parseObservableKey("obs:ipv4:192.168.1.1")).toEqual({
+        type: "ipv4",
         value: "192.168.1.1",
       });
     });
@@ -162,10 +162,10 @@ describe("Key Generation", () => {
   describe("parseThreatIntelKey", () => {
     it("parses threat intel key components", () => {
       expect(
-        parseThreatIntelKey("ti:virustotal:obs:ipv4-addr:192.168.1.1")
+        parseThreatIntelKey("ti:virustotal:obs:ipv4:192.168.1.1")
       ).toEqual({
         source: "virustotal",
-        observableKey: "obs:ipv4-addr:192.168.1.1",
+        observableKey: "obs:ipv4:192.168.1.1",
       });
     });
   });

--- a/js/packages/cyvest-vis/README.md
+++ b/js/packages/cyvest-vis/README.md
@@ -108,7 +108,7 @@ Access icon components for custom UIs:
 import { getObservableIcon, getInvestigationIcon, GlobeIcon, MailIcon } from "@cyvest/cyvest-vis";
 
 // Get icon by observable type
-const Icon = getObservableIcon("ipv4-addr"); // Returns GlobeIcon
+const Icon = getObservableIcon("ipv4"); // Returns GlobeIcon
 <Icon size={24} color="#3b82f6" />
 
 // Or use icons directly

--- a/js/packages/cyvest-vis/src/components/Icons.tsx
+++ b/js/packages/cyvest-vis/src/components/Icons.tsx
@@ -652,46 +652,21 @@ export const OBSERVABLE_ICON_MAP: Record<
   string,
   React.FC<IconProps>
 > = {
-  // Network
-  "ipv4-addr": GlobeIcon,
-  "ipv6-addr": GlobeIcon,
-  "domain-name": DomainIcon,
+  // Network (canonical Python enum values)
+  ipv4: GlobeIcon,
+  ipv6: GlobeIcon,
+  domain: DomainIcon,
   url: LinkIcon,
-  "autonomous-system": WorldIcon,
-  "mac-addr": WifiIcon,
+
+  // Hash
+  hash: HashIcon,
 
   // Email
-  "email-addr": MailIcon,
-  "email-message": EnvelopeIcon,
+  email: MailIcon,
 
   // File
   file: FileIcon,
-  "file-hash": HashIcon,
-  "file:hash:md5": HashIcon,
-  "file:hash:sha1": HashIcon,
-  "file:hash:sha256": HashIcon,
-
-  // User/Identity
-  user: UserIcon,
-  "user-account": UserIcon,
-  identity: IdCardIcon,
-
-  // Process/System
-  process: GearIcon,
-  software: AppIcon,
-  "windows-registry-key": RegistryIcon,
-
-  // Threat Intelligence
-  "threat-actor": ThreatActorIcon,
-  malware: BugIcon,
-  "attack-pattern": SwordIcon,
-  campaign: TargetIcon,
-  indicator: AlertIcon,
-
-  // Artifacts
   artifact: FlaskIcon,
-  certificate: CertificateIcon,
-  "x509-certificate": CertificateIcon,
 
   // Default
   unknown: QuestionIcon,

--- a/js/packages/cyvest-vis/src/types.ts
+++ b/js/packages/cyvest-vis/src/types.ts
@@ -23,7 +23,7 @@ export interface ObservableNodeData extends Record<string, unknown> {
   label: string;
   /** Full observable value */
   fullValue: string;
-  /** Observable type (e.g., "domain-name", "ipv4-addr") */
+  /** Observable type (e.g., "domain", "ipv4") */
   observableType: string;
   /** Security level */
   level: Level;

--- a/js/packages/cyvest-vis/tests/observables.test.ts
+++ b/js/packages/cyvest-vis/tests/observables.test.ts
@@ -11,12 +11,12 @@ import {
 describe("observables utils", () => {
   it("returns shapes based on root flag (all non-root nodes are circles)", () => {
     // All non-root nodes are now circles for a cleaner design
-    expect(getObservableShape("domain-name", false)).toBe("circle");
-    expect(getObservableShape("ipv6-addr", false)).toBe("circle");
+    expect(getObservableShape("domain", false)).toBe("circle");
+    expect(getObservableShape("ipv6", false)).toBe("circle");
     expect(getObservableShape("anything-else", false)).toBe("circle");
     // Root nodes get a rectangle (pill shape)
     expect(getObservableShape("anything-else", true)).toBe("rectangle");
-    expect(getObservableShape("domain-name", true)).toBe("rectangle");
+    expect(getObservableShape("domain", true)).toBe("rectangle");
   });
 
   it("truncates long labels in the middle by default", () => {


### PR DESCRIPTION
- Updated observable types from "ipv4-addr" to "ipv4", "domain-name" to "domain", and "email-addr" to "email" across various files including documentation, JavaScript code, and tests.
- Adjusted key generation functions to reflect the new observable types.
- Modified icon mapping in the visualization package to use the updated observable types.
- Ensured all related tests were updated to match the new observable type definitions and keys.