### PR TITLE
feat(extract): Add observable extraction module

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,10 @@ cyvest extract report.txt -t url -t ip -t hash
 # Output as JSON
 cyvest extract report.txt -f json -o extracted.json
 
+# Markdown output for LLM consumption
+cyvest extract report.txt --format markdown --title "Threat IOCs"
+cyvest extract report.txt --format markdown-table --defang-output
+
 # Fetch from URL and extract
 cyvest extract --from-url https://example.com/ioc-feed.txt
 
@@ -543,13 +547,28 @@ cyvest extract -R < defanged_iocs.txt
 **Programmatic usage:**
 
 ```python
-from cyvest.extract import extract_all, extract_from_url, refang, defang
+from cyvest.extract import (
+    extract_all,
+    extract_from_url,
+    refang,
+    defang,
+    observables_to_markdown,
+    observables_to_markdown_table,
+)
 
 # Extract from text
 text = "Check IP 192[.]168[.]1[.]1 and hxxps://evil[.]com"
 observables = extract_all(text)
 for obs in observables:
-    print(f"{obs.obs_type.value}: {obs.value} (defanged: {obs.defanged})")
+    print(f"{obs.obs_type.value}: {obs.value} (count: {obs.count})")
+
+# Generate markdown for LLM consumption
+md = observables_to_markdown(observables, title="Extracted IOCs", group_by_type=True)
+print(md)
+
+# Generate compact markdown table
+table = observables_to_markdown_table(observables, defang_values=True)
+print(table)
 
 # Extract from URL
 observables = extract_from_url("https://example.com/ioc-feed.txt")

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - 🎨 **Rich Console Output**: Beautiful terminal displays with the Rich library
 - 🧩 **Fluent helpers**: Convenient API with method chaining for rapid development
 - 🔬 **Investigation Comparison**: Compare investigations with tolerance rules and visual diff output
+- 🔎 **Observable Extraction**: Extract IOCs (IPs, URLs, domains, emails, hashes) from text, markdown, or web pages with defang/refang support
 
 ## Installation
 
@@ -490,8 +491,72 @@ cyvest merge inv1.json inv2.json -o merged.json -f rich --stats
 # Generate an interactive visualization (requires visualization extra)
 cyvest visualize investigation.json --min-level SUSPICIOUS --group-by-type
 
+# Extract observables (IOCs) from text
+echo "Check IP 192.168.1.1 and https://evil.com" | cyvest extract
+cyvest extract report.txt -t url -t ip -o iocs.txt
+cyvest extract --from-url https://example.com/indicators.txt -f json
+
 # Output the JSON Schema describing serialized investigations and generate types
 uv run cyvest schema -o ./schema/cyvest.schema.json && pnpm -C js/packages/cyvest-js run generate:types
+```
+
+### Observable Extraction
+
+Extract cyber observables (IOCs) from raw text, markdown, or web pages:
+
+```bash
+# From stdin (pipe text)
+echo "Malicious IP: 192[.]168[.]1[.]1, URL: hxxps://evil[.]com/malware" | cyvest extract
+
+# From file
+cyvest extract threat_report.txt
+
+# Filter by type
+cyvest extract report.txt -t url -t ip -t hash
+
+# Output as JSON
+cyvest extract report.txt -f json -o extracted.json
+
+# Fetch from URL and extract
+cyvest extract --from-url https://example.com/ioc-feed.txt
+
+# Keep defanged format (don't refang)
+cyvest extract -R < defanged_iocs.txt
+```
+
+**Supported observable types:**
+
+| Type | Description | Examples |
+|------|-------------|----------|
+| `url` | URLs with various schemes | http, https, ftp, sftp, tcp, udp |
+| `ip` / `ipv4` / `ipv6` | IP addresses | 192.168.1.1, 2001:db8::1 |
+| `email` | Email addresses | user@example.com |
+| `hash` | Cryptographic hashes | MD5, SHA1, SHA256, SHA512 |
+| `domain` | Domain names | example.com |
+
+**Defanged indicator support:**
+
+- URLs: `hxxp://`, `hxxps://`, `[.]`, `[/]`
+- IPs: `192[.]168[.]1[.]1`, `10(dot)0(dot)0(dot)1`
+- Emails: `user[@]example.com`, `user at example.com`
+
+**Programmatic usage:**
+
+```python
+from cyvest.extract import extract_all, extract_from_url, refang, defang
+
+# Extract from text
+text = "Check IP 192[.]168[.]1[.]1 and hxxps://evil[.]com"
+observables = extract_all(text)
+for obs in observables:
+    print(f"{obs.obs_type.value}: {obs.value} (defanged: {obs.defanged})")
+
+# Extract from URL
+observables = extract_from_url("https://example.com/ioc-feed.txt")
+
+# Refang/defang utilities
+safe_text = defang("https://malware.com")  # -> hxxps://malware[.]com
+original = refang("hxxps://malware[.]com")  # -> https://malware.com
 ```
 
 ## Development

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ Build, score, and narrate cybersecurity investigations with a single fluent Pyth
 | **Fluent helpers** | Builder-style methods with deterministic keys and safe merges | `cyvest.cyvest`, [Quick Start](getting-started/quickstart.md#using-the-fluent-api) |
 | **Shared context** | Thread-safe fragments that can reconcile into a single story | `cyvest.shared.SharedInvestigationContext`, [Guide](shared-investigation-context.md) |
 | **Comparison** | Compare investigations with tolerance rules for regression testing | `cyvest.compare`, [Guide](comparing-investigations.md) |
+| **Observable extraction** | Extract IOCs from text, markdown, or URLs with defang/refang support | `cyvest.extract`, [Guide](observable-extraction.md) |
 | **Reporting** | Export JSON, Markdown, or render rich terminal summaries | `cyvest.io_serialization`, `cyvest.io_rich`, [Quick Start](getting-started/quickstart.md#exporting-results) |
 
 ---
@@ -91,6 +92,7 @@ Cyvest (facade + fluent proxies)
 | Understand observables vs. checks | [Core Concepts](getting-started/concepts.md#investigation-structure) |
 | Share state across threads | [Shared Investigation Context](shared-investigation-context.md) |
 | Compare investigations or regression test | [Comparing Investigations](comparing-investigations.md) |
+| Extract IOCs from text or URLs | [Observable Extraction](observable-extraction.md) |
 | Extend scoring or fluent helpers | [Contributing](contributing.md#architecture-overview) |
 | Embed results in other tools | [Quick Start → Exporting Results](getting-started/quickstart.md#exporting-results) |
 

--- a/docs/observable-extraction.md
+++ b/docs/observable-extraction.md
@@ -11,8 +11,9 @@ The `cyvest.extract` module provides utilities to identify and extract indicator
 - **Multiple observable types**: URLs, IP addresses (IPv4/IPv6), email addresses, cryptographic hashes, and domain names
 - **Defanged indicators**: Automatic recognition and refanging of common defang patterns (`hxxp://`, `[.]`, `[@]`, etc.)
 - **Encoded URLs**: Hex-encoded, URL-encoded, and base64-encoded URLs
-- **Deduplication**: Extracted observables are automatically deduplicated by value
+- **Deduplication with counting**: Extracted observables are automatically deduplicated by value and occurrence counts are tracked
 - **Web fetching**: Extract observables directly from web pages
+- **Markdown output**: Generate markdown lists or tables for LLM consumption with defang support
 
 ---
 
@@ -48,8 +49,12 @@ cyvest extract -R < defanged_iocs.txt
 | `-t, --types` | Types to extract: `url`, `ip`, `ipv4`, `ipv6`, `email`, `hash`, `domain`, `all` (default: `all`) |
 | `-r/-R, --refang/--no-refang` | Refang extracted observables (default: enabled) |
 | `-o, --output` | Output file (defaults to stdout) |
-| `-f, --format` | Output format: `text` or `json` (default: `text`) |
+| `-f, --format` | Output format: `text`, `json`, `markdown`, or `markdown-table` (default: `text`) |
 | `--from-url` | Fetch content from URL and extract observables |
+| `--title` | Title for markdown output (rendered as `## Title`) |
+| `--group-by-type` | Group observables by type in markdown list output |
+| `--include-original` | Include original text in markdown output |
+| `--defang-output` | Defang values in markdown output for safe sharing |
 
 ### Output Formats
 
@@ -71,16 +76,54 @@ domain  malware.io
     "obs_type": "url",
     "value": "https://evil.com/malware",
     "original": "hxxps://evil[.]com/malware",
-    "defanged": true
+    "defanged": true,
+    "count": 1
   },
   {
     "obs_type": "ipv4",
     "value": "192.168.1.1",
     "original": "192[.]168[.]1[.]1",
-    "defanged": true
+    "defanged": true,
+    "count": 3
   }
 ]
 ```
+
+**Markdown list format** (`--format markdown`): Human-readable list for LLM consumption:
+
+```bash
+cyvest extract report.txt --format markdown --title "Threat IOCs" --group-by-type
+```
+
+```markdown
+## Threat IOCs
+
+### URL
+
+- URL: `https://evil.com/malware`
+  - Defanged: Yes
+
+### IPV4
+
+- IPV4: `192.168.1.1`
+  - Defanged: Yes
+  - Count: 3
+```
+
+**Markdown table format** (`--format markdown-table`): Compact table view:
+
+```bash
+cyvest extract report.txt --format markdown-table --defang-output
+```
+
+```markdown
+| Type | Value | Count | Defanged |
+|------|-------|-------|----------|
+| URL | `hxxps://evil[.]com/malware` | 1 | ✓ |
+| IPV4 | `192[.]168[.]1[.]1` | 3 | ✓ |
+```
+
+> **Note:** The Count column only appears when any observable has count > 1.
 
 ---
 
@@ -273,7 +316,94 @@ obs.obs_type   # ObservableType enum (URL, IPV4, IPV6, EMAIL, HASH, DOMAIN)
 obs.value      # Normalized (refanged) value
 obs.original   # Original matched text
 obs.defanged   # Boolean indicating if original was defanged
+obs.count      # Number of occurrences in the source text
 ```
+
+### Markdown Serialization
+
+Each observable can be serialized to markdown for LLM consumption:
+
+```python
+# Single observable
+md = obs.to_markdown()
+md = obs.to_markdown(include_original=True, defang_value=True)
+```
+
+---
+
+## Markdown Output Functions
+
+### List Format
+
+Generate a markdown list of observables:
+
+```python
+from cyvest.extract import extract_all, observables_to_markdown
+
+text = "IP: 192.168.1.1, URL: https://evil.com"
+observables = extract_all(text)
+
+# Basic list
+md = observables_to_markdown(observables)
+
+# With options
+md = observables_to_markdown(
+    observables,
+    title="Extracted IOCs",        # Add ## title header
+    group_by_type=True,            # Group by observable type with ### sub-headers
+    include_original=True,         # Include original text if different
+    defang_values=True,            # Defang values for safe sharing
+)
+print(md)
+```
+
+Output:
+```markdown
+## Extracted IOCs
+
+### IPV4
+
+- IPV4: `192[.]168[.]1[.]1`
+  - Defanged: Yes
+
+### URL
+
+- URL: `hxxps://evil[.]com`
+  - Defanged: Yes
+```
+
+### Table Format
+
+Generate a compact markdown table:
+
+```python
+from cyvest.extract import extract_all, observables_to_markdown_table
+
+observables = extract_all(text)
+
+# Basic table
+md = observables_to_markdown_table(observables)
+
+# With options
+md = observables_to_markdown_table(
+    observables,
+    title="IOC Summary",           # Add ## title header
+    defang_values=True,            # Defang values for safe sharing
+)
+print(md)
+```
+
+Output:
+```markdown
+## IOC Summary
+
+| Type | Value | Defanged |
+|------|-------|----------|
+| IPV4 | `192[.]168[.]1[.]1` | ✓ |
+| URL | `hxxps://evil[.]com` | ✓ |
+```
+
+> **Tip:** The table automatically adds a Count column when any observable appears multiple times.
 
 ---
 

--- a/docs/observable-extraction.md
+++ b/docs/observable-extraction.md
@@ -1,0 +1,310 @@
+# Observable Extraction
+
+Extract cyber observables (IOCs) from raw text, markdown, or web pages with automatic defang/refang support.
+
+---
+
+## Overview
+
+The `cyvest.extract` module provides utilities to identify and extract indicators of compromise (IOCs) from unstructured text. It supports:
+
+- **Multiple observable types**: URLs, IP addresses (IPv4/IPv6), email addresses, cryptographic hashes, and domain names
+- **Defanged indicators**: Automatic recognition and refanging of common defang patterns (`hxxp://`, `[.]`, `[@]`, etc.)
+- **Encoded URLs**: Hex-encoded, URL-encoded, and base64-encoded URLs
+- **Deduplication**: Extracted observables are automatically deduplicated by value
+- **Web fetching**: Extract observables directly from web pages
+
+---
+
+## CLI Usage
+
+The `cyvest extract` command provides a convenient way to extract observables from the command line:
+
+```bash
+# From stdin
+echo "Check IP 192.168.1.1 and https://evil.com" | cyvest extract
+
+# From file
+cyvest extract threat_report.txt
+
+# Filter by type (can specify multiple)
+cyvest extract report.txt -t url -t ip -t hash
+
+# Output as JSON
+cyvest extract report.txt -f json -o extracted.json
+
+# Fetch from URL and extract
+cyvest extract --from-url https://example.com/ioc-feed.txt
+
+# Keep defanged format (don't refang)
+cyvest extract -R < defanged_iocs.txt
+```
+
+### Command Options
+
+| Option | Description |
+|--------|-------------|
+| `INPUT` | Input file (defaults to stdin if not specified) |
+| `-t, --types` | Types to extract: `url`, `ip`, `ipv4`, `ipv6`, `email`, `hash`, `domain`, `all` (default: `all`) |
+| `-r/-R, --refang/--no-refang` | Refang extracted observables (default: enabled) |
+| `-o, --output` | Output file (defaults to stdout) |
+| `-f, --format` | Output format: `text` or `json` (default: `text`) |
+| `--from-url` | Fetch content from URL and extract observables |
+
+### Output Formats
+
+**Text format** (default): Tab-separated type and value, one per line:
+
+```
+url     https://evil.com/malware
+ipv4    192.168.1.1
+email   admin@evil.com
+hash    d41d8cd98f00b204e9800998ecf8427e
+domain  malware.io
+```
+
+**JSON format**: Array of observable objects with metadata:
+
+```json
+[
+  {
+    "obs_type": "url",
+    "value": "https://evil.com/malware",
+    "original": "hxxps://evil[.]com/malware",
+    "defanged": true
+  },
+  {
+    "obs_type": "ipv4",
+    "value": "192.168.1.1",
+    "original": "192[.]168[.]1[.]1",
+    "defanged": true
+  }
+]
+```
+
+---
+
+## Programmatic Usage
+
+### Basic Extraction
+
+```python
+from cyvest.extract import extract_all, extract_urls, extract_ips, extract_emails, extract_hashes, extract_domains
+from cyvest.model_enums import ObservableType
+
+# Extract all observable types
+text = """
+Threat Report:
+- C2 Server: hxxps://evil[.]domain[.]com/c2
+- IP Address: 192[.]168[.]1[.]1
+- Contact: admin[@]evil.com
+- Malware hash: d41d8cd98f00b204e9800998ecf8427e
+"""
+
+observables = extract_all(text)
+for obs in observables:
+    print(f"{obs.obs_type.value}: {obs.value} (defanged: {obs.defanged})")
+```
+
+Output:
+```
+url: https://evil.domain.com/c2 (defanged: True)
+ipv4: 192.168.1.1 (defanged: True)
+email: admin@evil.com (defanged: True)
+hash: d41d8cd98f00b204e9800998ecf8427e (defanged: False)
+domain: evil.com (defanged: True)
+```
+
+### Filter by Type
+
+```python
+from cyvest.extract import extract_all
+from cyvest.model_enums import ObservableType
+
+# Extract only URLs and IPs
+observables = extract_all(
+    text,
+    types={ObservableType.URL, ObservableType.IPV4, ObservableType.IPV6}
+)
+```
+
+### Individual Extractors
+
+Use specific extractors for fine-grained control:
+
+```python
+from cyvest.extract import extract_urls, extract_ips, extract_emails, extract_hashes, extract_domains
+
+# Extract URLs (returns iterator)
+for url in extract_urls(text):
+    print(f"URL: {url.value}")
+
+# Extract IPs (both IPv4 and IPv6)
+for ip in extract_ips(text):
+    print(f"IP ({ip.obs_type.value}): {ip.value}")
+
+# Extract emails
+for email in extract_emails(text):
+    print(f"Email: {email.value}")
+
+# Extract hashes (MD5, SHA1, SHA256, SHA512)
+for hash_obs in extract_hashes(text):
+    print(f"Hash: {hash_obs.value}")
+
+# Extract domains (excludes domains in URLs)
+for domain in extract_domains(text):
+    print(f"Domain: {domain.value}")
+```
+
+### Extract from URL
+
+Fetch content from a web page and extract observables:
+
+```python
+from cyvest.extract import extract_from_url
+
+# Fetch and extract
+observables = extract_from_url("https://example.com/ioc-feed.txt")
+
+# With type filtering
+from cyvest.model_enums import ObservableType
+observables = extract_from_url(
+    "https://example.com/ioc-feed.txt",
+    types={ObservableType.IPV4},
+    timeout=60
+)
+```
+
+---
+
+## Defang/Refang Utilities
+
+### Refanging
+
+Convert defanged indicators back to their original format:
+
+```python
+from cyvest.extract import refang
+
+# URLs
+refang("hxxps://evil[.]com")  # -> "https://evil.com"
+refang("hxxp://malware(.)site[/]payload")  # -> "http://malware.site/payload"
+
+# IPs
+refang("192[.]168[.]1[.]1")  # -> "192.168.1.1"
+refang("10[dot]0[dot]0[dot]1")  # -> "10.0.0.1"
+
+# Emails
+refang("admin[@]evil[.]com")  # -> "admin@evil.com"
+refang("user at example.com")  # -> "user@example.com"
+```
+
+### Defanging
+
+Convert indicators to safe, non-clickable format:
+
+```python
+from cyvest.extract import defang
+
+defang("https://malware.com/payload")  # -> "hxxps://malware[.]com[/]payload"
+defang("user@evil.com")  # -> "user[@]evil[.]com"
+```
+
+---
+
+## Supported Patterns
+
+### URL Schemes
+
+| Scheme | Description |
+|--------|-------------|
+| `http`, `https` | Standard web URLs |
+| `ftp`, `ftps`, `sftp` | File transfer protocols |
+| `tcp`, `udp` | Network protocols |
+
+**Defanged variants**: `hxxp://`, `hxxps://`, `fxp://`, `[:]//`, `:\[//\]`
+
+### IP Addresses
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| IPv4 | Standard dotted notation | `192.168.1.1` |
+| IPv4 defanged | Bracket/paren dots | `192[.]168[.]1[.]1`, `10(dot)0(dot)0(dot)1` |
+| IPv6 | Full and compressed | `2001:db8::1`, `::1` |
+
+### Email Addresses
+
+| Pattern | Example |
+|---------|---------|
+| Standard | `user@example.com` |
+| Bracket @ | `user[@]example.com` |
+| Paren @ | `user(@)example.com` |
+| Word "at" | `user at example.com` |
+| Combined | `user[@]example[.]com` |
+
+### Hashes
+
+| Type | Length | Example |
+|------|--------|---------|
+| MD5 | 32 hex chars | `d41d8cd98f00b204e9800998ecf8427e` |
+| SHA1 | 40 hex chars | `da39a3ee5e6b4b0d3255bfef95601890afd80709` |
+| SHA256 | 64 hex chars | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` |
+| SHA512 | 128 hex chars | `cf83e1357eefb8bdf1542850d66d8007...` |
+
+### Encoded URLs
+
+| Encoding | Description |
+|----------|-------------|
+| Hex | `68747470733a2f2f...` (hex-encoded URL) |
+| URL-encoded | `https://example.com/path%20with%20spaces` |
+| Base64 | `aHR0cHM6Ly9leGFtcGxlLmNvbQ==` |
+
+---
+
+## ExtractedObservable Model
+
+Each extracted observable is returned as an `ExtractedObservable` Pydantic model:
+
+```python
+from cyvest.extract import ExtractedObservable
+
+# Fields
+obs.obs_type   # ObservableType enum (URL, IPV4, IPV6, EMAIL, HASH, DOMAIN)
+obs.value      # Normalized (refanged) value
+obs.original   # Original matched text
+obs.defanged   # Boolean indicating if original was defanged
+```
+
+---
+
+## Integration with Cyvest
+
+Combine extraction with investigation building:
+
+```python
+from cyvest import Cyvest
+from cyvest.extract import extract_all
+
+# Extract observables from threat report
+text = open("threat_report.txt").read()
+extracted = extract_all(text)
+
+# Build investigation from extracted IOCs
+cv = Cyvest(root_data={"source": "threat_report.txt"})
+
+for obs in extracted:
+    cv.observable(obs.obs_type, obs.value, internal=False)
+
+cv.display_summary()
+cv.io_save_json("investigation.json")
+```
+
+---
+
+## Best Practices
+
+1. **Use type filtering** when you know what you're looking for to reduce false positives
+2. **Keep refanging enabled** (default) for normalized, searchable values
+3. **Check the `defanged` flag** to identify indicators that were obfuscated in the source
+4. **Use `extract_from_url`** with caution - set appropriate timeouts and consider rate limiting
+5. **Validate extracted hashes** against known-good patterns if precision is critical

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - Concepts: getting-started/concepts.md
   - Shared Investigation Context: shared-investigation-context.md
   - Comparing Investigations: comparing-investigations.md
+  - Observable Extraction: observable-extraction.md
   - JavaScript Packages: js-packages.md
   - Contributing: contributing.md
 

--- a/src/cyvest/cli.py
+++ b/src/cyvest/cli.py
@@ -18,7 +18,13 @@ from rich.console import Console
 
 from cyvest import __version__
 from cyvest.compare import ExpectedResult, compare_investigations
-from cyvest.extract import ExtractedObservable, extract_all, extract_from_url
+from cyvest.extract import (
+    ExtractedObservable,
+    extract_all,
+    extract_from_url,
+    observables_to_markdown,
+    observables_to_markdown_table,
+)
 from cyvest.io_rich import display_check_query, display_diff, display_observable_query, display_threat_intel_query
 from cyvest.io_schema import get_investigation_schema
 from cyvest.io_serialization import load_investigation_json
@@ -513,7 +519,15 @@ def _parse_extract_types(types: tuple[str, ...]) -> set[ObservableType] | None:
     return result if result else None
 
 
-def _format_observables(observables: list[ExtractedObservable], output_format: str) -> str:
+def _format_observables(
+    observables: list[ExtractedObservable],
+    output_format: str,
+    *,
+    group_by_type: bool = False,
+    include_original: bool = False,
+    defang_output: bool = False,
+    title: str | None = None,
+) -> str:
     """Format extracted observables for output."""
     import json as json_module
 
@@ -522,6 +536,20 @@ def _format_observables(observables: list[ExtractedObservable], output_format: s
             [obs.model_dump(mode="json") for obs in observables],
             indent=2,
             ensure_ascii=False,
+        )
+    elif output_format == "markdown":
+        return observables_to_markdown(
+            observables,
+            include_original=include_original,
+            group_by_type=group_by_type,
+            title=title,
+            defang_values=defang_output,
+        )
+    elif output_format == "markdown-table":
+        return observables_to_markdown_table(
+            observables,
+            title=title,
+            defang_values=defang_output,
         )
     else:
         # Text format: one per line, with type prefix
@@ -560,16 +588,40 @@ def _format_observables(observables: list[ExtractedObservable], output_format: s
     "-f",
     "--format",
     "output_format",
-    type=click.Choice(["text", "json"], case_sensitive=False),
+    type=click.Choice(["text", "json", "markdown", "markdown-table"], case_sensitive=False),
     default="text",
     show_default=True,
-    help="Output format.",
+    help="Output format. Use 'markdown' or 'markdown-table' for LLM-friendly output.",
 )
 @click.option(
     "--from-url",
     "from_url",
     type=str,
     help="Fetch content from URL and extract observables (ignores INPUT argument).",
+)
+@click.option(
+    "--group-by-type",
+    is_flag=True,
+    default=False,
+    help="Group observables by type in markdown output.",
+)
+@click.option(
+    "--include-original",
+    is_flag=True,
+    default=False,
+    help="Include original (defanged) text in markdown output.",
+)
+@click.option(
+    "--defang-output",
+    is_flag=True,
+    default=False,
+    help="Defang values in output for safe sharing (markdown formats only).",
+)
+@click.option(
+    "--title",
+    type=str,
+    default=None,
+    help="Title header for markdown output.",
 )
 def extract(
     input,
@@ -578,6 +630,10 @@ def extract(
     output,
     output_format: str,
     from_url: str | None,
+    group_by_type: bool,
+    include_original: bool,
+    defang_output: bool,
+    title: str | None,
 ) -> None:
     """
     Extract observables (IOCs) from text input.
@@ -600,6 +656,8 @@ def extract(
         cyvest extract report.txt -t url -t email
         cyvest extract -t ip --format json < input.txt
         cyvest extract --from-url https://example.com/iocs.txt -o extracted.txt
+        cyvest extract report.txt --format markdown --group-by-type --title "IOCs"
+        cyvest extract report.txt --format markdown-table --defang-output
     """
     observable_types = _parse_extract_types(types)
 
@@ -627,10 +685,24 @@ def extract(
 
     logger.info(f"[green]✓ Extracted {len(observables)} observable(s)[/green]")
 
-    formatted = _format_observables(observables, output_format)
-    output.write(formatted)
-    if not formatted.endswith("\n"):
-        output.write("\n")
+    formatted = _format_observables(
+        observables,
+        output_format,
+        group_by_type=group_by_type,
+        include_original=include_original,
+        defang_output=defang_output,
+        title=title,
+    )
+
+    # Use Rich Markdown rendering for markdown formats when outputting to stdout
+    if output.name == "<stdout>" and output_format in ("markdown", "markdown-table"):
+        from rich.markdown import Markdown
+
+        logger.rich("INFO", Markdown(formatted), prefix=False)
+    else:
+        output.write(formatted)
+        if not formatted.endswith("\n"):
+            output.write("\n")
 
 
 def main() -> None:

--- a/src/cyvest/cli.py
+++ b/src/cyvest/cli.py
@@ -18,11 +18,13 @@ from rich.console import Console
 
 from cyvest import __version__
 from cyvest.compare import ExpectedResult, compare_investigations
+from cyvest.extract import ExtractedObservable, extract_all, extract_from_url
 from cyvest.io_rich import display_check_query, display_diff, display_observable_query, display_threat_intel_query
 from cyvest.io_schema import get_investigation_schema
 from cyvest.io_serialization import load_investigation_json
 from cyvest.io_visualization import VisualizationDependencyMissingError
 from cyvest.keys import parse_key_type
+from cyvest.model_enums import ObservableType
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 console = Console()
@@ -476,6 +478,159 @@ def query(input: Path, key: str, depth: int) -> None:
             display_threat_intel_query(cv, key, rich_print)
     except KeyError as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+# =============================================================================
+# Extract Command
+# =============================================================================
+
+_EXTRACT_TYPE_CHOICES = ["url", "ip", "ipv4", "ipv6", "email", "hash", "domain", "all"]
+
+
+def _parse_extract_types(types: tuple[str, ...]) -> set[ObservableType] | None:
+    """Parse extract type choices into ObservableType set."""
+    if "all" in types or not types:
+        return None  # None means all types
+
+    result: set[ObservableType] = set()
+    for t in types:
+        t_lower = t.lower()
+        if t_lower == "ip":
+            result.add(ObservableType.IPV4)
+            result.add(ObservableType.IPV6)
+        elif t_lower == "ipv4":
+            result.add(ObservableType.IPV4)
+        elif t_lower == "ipv6":
+            result.add(ObservableType.IPV6)
+        elif t_lower == "url":
+            result.add(ObservableType.URL)
+        elif t_lower == "email":
+            result.add(ObservableType.EMAIL)
+        elif t_lower == "hash":
+            result.add(ObservableType.HASH)
+        elif t_lower == "domain":
+            result.add(ObservableType.DOMAIN)
+    return result if result else None
+
+
+def _format_observables(observables: list[ExtractedObservable], output_format: str) -> str:
+    """Format extracted observables for output."""
+    import json as json_module
+
+    if output_format == "json":
+        return json_module.dumps(
+            [obs.model_dump(mode="json") for obs in observables],
+            indent=2,
+            ensure_ascii=False,
+        )
+    else:
+        # Text format: one per line, with type prefix
+        lines = []
+        for obs in observables:
+            lines.append(f"{obs.obs_type.value}\t{obs.value}")
+        return "\n".join(lines)
+
+
+@cli.command()
+@click.argument("input", type=click.File("r", encoding="utf-8"), default="-", required=False)
+@click.option(
+    "-t",
+    "--types",
+    multiple=True,
+    type=click.Choice(_EXTRACT_TYPE_CHOICES, case_sensitive=False),
+    default=["all"],
+    show_default=True,
+    help="Types of observables to extract. Can be specified multiple times.",
+)
+@click.option(
+    "-r/-R",
+    "--refang/--no-refang",
+    default=True,
+    show_default=True,
+    help="Refang extracted observables (convert hxxp to http, [.] to ., etc.).",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.File("w", encoding="utf-8"),
+    default="-",
+    help="Output file (defaults to stdout).",
+)
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "--from-url",
+    "from_url",
+    type=str,
+    help="Fetch content from URL and extract observables (ignores INPUT argument).",
+)
+def extract(
+    input,
+    types: tuple[str, ...],
+    refang: bool,
+    output,
+    output_format: str,
+    from_url: str | None,
+) -> None:
+    """
+    Extract observables (IOCs) from text input.
+
+    Reads from stdin by default, or from a file if INPUT is specified.
+    Use --from-url to fetch and extract from a web page.
+
+    Supported observable types:
+    - url: URLs (http, https, ftp, sftp, tcp, udp) including encoded
+    - ip/ipv4/ipv6: IP addresses
+    - email: Email addresses
+    - hash: MD5, SHA1, SHA256, SHA512 hashes
+    - domain: Domain names
+
+    Supports defanged indicators (hxxp://, [.], [@], etc.) with automatic refanging.
+
+    \b
+    Examples:
+        cat report.txt | cyvest extract
+        cyvest extract report.txt -t url -t email
+        cyvest extract -t ip --format json < input.txt
+        cyvest extract --from-url https://example.com/iocs.txt -o extracted.txt
+    """
+    observable_types = _parse_extract_types(types)
+
+    try:
+        if from_url:
+            logger.info(f"[cyan]Fetching content from: {from_url}[/cyan]")
+            observables = extract_from_url(
+                from_url,
+                types=observable_types,
+                refang_output=refang,
+            )
+        else:
+            text = input.read()
+            observables = extract_all(
+                text,
+                types=observable_types,
+                refang_output=refang,
+            )
+    except Exception as exc:
+        raise click.ClickException(f"Extraction failed: {exc}") from exc
+
+    if not observables:
+        logger.info("[yellow]No observables found.[/yellow]")
+        return
+
+    logger.info(f"[green]✓ Extracted {len(observables)} observable(s)[/green]")
+
+    formatted = _format_observables(observables, output_format)
+    output.write(formatted)
+    if not formatted.endswith("\n"):
+        output.write("\n")
 
 
 def main() -> None:

--- a/src/cyvest/extract.py
+++ b/src/cyvest/extract.py
@@ -35,6 +35,46 @@ class ExtractedObservable(BaseModel):
     value: str = Field(..., description="Normalized (refanged) value")
     original: str = Field(..., description="Original matched text")
     defanged: bool = Field(default=False, description="Whether the original was defanged")
+    count: int = Field(default=1, description="Number of times this observable was seen")
+
+    def __str__(self) -> str:
+        """Return a simple string representation for debugging."""
+        if self.count > 1:
+            return f"{self.obs_type.value}:{self.value} (x{self.count})"
+        return f"{self.obs_type.value}:{self.value}"
+
+    def to_markdown(
+        self,
+        *,
+        include_original: bool = False,
+        defang_value: bool = False,
+    ) -> str:
+        """
+        Generate markdown representation of this extracted observable.
+
+        Useful for providing structured data to LLM models.
+
+        Args:
+            include_original: Include original (pre-refanged) text if different from value.
+            defang_value: Defang the value for safe sharing.
+
+        Returns:
+            Markdown formatted string as a list item.
+        """
+        # Use defang function defined later in this module
+        display_value = defang(self.value) if defang_value else self.value
+        lines = [f"- {self.obs_type.value.upper()}: `{display_value}`"]
+
+        if self.defanged:
+            lines.append("  - Defanged: Yes")
+
+        if self.count > 1:
+            lines.append(f"  - Count: {self.count}")
+
+        if include_original and self.original != self.value:
+            lines.append(f"  - Original: `{self.original}`")
+
+        return "\n".join(lines)
 
 
 # =============================================================================
@@ -262,8 +302,6 @@ def extract_urls(text: str, refang_output: bool = True) -> Iterator[ExtractedObs
     Yields:
         ExtractedObservable for each URL found.
     """
-    seen: set[str] = set()
-
     # Extract standard and defanged URLs
     for match in _URL_PATTERN.finditer(text):
         original = match.group(0)
@@ -276,22 +314,19 @@ def extract_urls(text: str, refang_output: bool = True) -> Iterator[ExtractedObs
         # URL decode the value
         value = _decode_url_encoded(value)
 
-        if value not in seen:
-            seen.add(value)
-            yield ExtractedObservable(
-                obs_type=ObservableType.URL,
-                value=value,
-                original=original,
-                defanged=defanged,
-            )
+        yield ExtractedObservable(
+            obs_type=ObservableType.URL,
+            value=value,
+            original=original,
+            defanged=defanged,
+        )
 
     # Extract hex-encoded URLs
     hex_pattern = re.compile(r"\b([0-9a-fA-F]{14,})\b")
     for match in hex_pattern.finditer(text):
         hex_str = match.group(1)
         decoded = _decode_hex_url(hex_str)
-        if decoded and decoded not in seen:
-            seen.add(decoded)
+        if decoded:
             yield ExtractedObservable(
                 obs_type=ObservableType.URL,
                 value=decoded,
@@ -303,8 +338,7 @@ def extract_urls(text: str, refang_output: bool = True) -> Iterator[ExtractedObs
     for match in _BASE64_PATTERN.finditer(text):
         b64_str = match.group(0)
         decoded = _decode_base64_url(b64_str)
-        if decoded and decoded not in seen:
-            seen.add(decoded)
+        if decoded:
             yield ExtractedObservable(
                 obs_type=ObservableType.URL,
                 value=decoded,
@@ -377,16 +411,13 @@ def extract_ipv4(text: str, refang_output: bool = True) -> Iterator[ExtractedObs
     Yields:
         ExtractedObservable for each valid IPv4 found.
     """
-    seen: set[str] = set()
-
     for match in _IPV4_PATTERN.finditer(text):
         original = match.group(0)
         defanged = _is_defanged(original)
         value = refang(original) if refang_output else original
 
         # Validate the IP
-        if _validate_ipv4(value) and value not in seen:
-            seen.add(value)
+        if _validate_ipv4(value):
             yield ExtractedObservable(
                 obs_type=ObservableType.IPV4,
                 value=value,
@@ -405,14 +436,11 @@ def extract_ipv6(text: str) -> Iterator[ExtractedObservable]:
     Yields:
         ExtractedObservable for each valid IPv6 found.
     """
-    seen: set[str] = set()
-
     for match in _IPV6_PATTERN.finditer(text):
         original = match.group(1)
 
         # Validate the IP
-        if _validate_ipv6(original) and original not in seen:
-            seen.add(original)
+        if _validate_ipv6(original):
             yield ExtractedObservable(
                 obs_type=ObservableType.IPV6,
                 value=original,
@@ -475,22 +503,18 @@ def extract_emails(text: str, refang_output: bool = True) -> Iterator[ExtractedO
     Yields:
         ExtractedObservable for each email found.
     """
-    seen: set[str] = set()
-
     # Match standard @ variants
     for match in _EMAIL_PATTERN.finditer(text):
         original = match.group(0)
         defanged = _is_defanged(original)
         value = refang(original) if refang_output else original
 
-        if value not in seen:
-            seen.add(value)
-            yield ExtractedObservable(
-                obs_type=ObservableType.EMAIL,
-                value=value,
-                original=original,
-                defanged=defanged,
-            )
+        yield ExtractedObservable(
+            obs_type=ObservableType.EMAIL,
+            value=value,
+            original=original,
+            defanged=defanged,
+        )
 
     # Match " at " format (word-based)
     for match in _EMAIL_PATTERN_WORD_AT.finditer(text):
@@ -498,14 +522,12 @@ def extract_emails(text: str, refang_output: bool = True) -> Iterator[ExtractedO
         defanged = True  # " at " format is always defanged
         value = refang(original) if refang_output else original
 
-        if value not in seen:
-            seen.add(value)
-            yield ExtractedObservable(
-                obs_type=ObservableType.EMAIL,
-                value=value,
-                original=original,
-                defanged=defanged,
-            )
+        yield ExtractedObservable(
+            obs_type=ObservableType.EMAIL,
+            value=value,
+            original=original,
+            defanged=defanged,
+        )
 
 
 # =============================================================================
@@ -542,22 +564,21 @@ def extract_hashes(text: str) -> Iterator[ExtractedObservable]:
         for match in pattern.finditer(text):
             hash_value = match.group(1).lower()
 
-            if hash_value not in seen:
-                # Check it's not a substring of an already-found longer hash
-                is_substring = False
-                for existing in seen:
-                    if hash_value in existing:
-                        is_substring = True
-                        break
+            # Check it's not a substring of an already-found longer hash
+            is_substring = False
+            for existing in seen:
+                if hash_value in existing:
+                    is_substring = True
+                    break
 
-                if not is_substring:
-                    seen.add(hash_value)
-                    yield ExtractedObservable(
-                        obs_type=ObservableType.HASH,
-                        value=hash_value,
-                        original=match.group(1),
-                        defanged=False,
-                    )
+            if not is_substring:
+                seen.add(hash_value)
+                yield ExtractedObservable(
+                    obs_type=ObservableType.HASH,
+                    value=hash_value,
+                    original=match.group(1),
+                    defanged=False,
+                )
 
 
 # =============================================================================
@@ -600,8 +621,6 @@ def extract_domains(text: str, refang_output: bool = True) -> Iterator[Extracted
     Yields:
         ExtractedObservable for each domain found.
     """
-    seen: set[str] = set()
-
     # First, find all URLs to exclude their domains
     url_domains: set[str] = set()
     for url_obs in extract_urls(text, refang_output=True):
@@ -621,14 +640,12 @@ def extract_domains(text: str, refang_output: bool = True) -> Iterator[Extracted
         if value in url_domains:
             continue
 
-        if value not in seen:
-            seen.add(value)
-            yield ExtractedObservable(
-                obs_type=ObservableType.DOMAIN,
-                value=value,
-                original=original,
-                defanged=defanged,
-            )
+        yield ExtractedObservable(
+            obs_type=ObservableType.DOMAIN,
+            value=value,
+            original=original,
+            defanged=defanged,
+        )
 
 
 # =============================================================================
@@ -650,7 +667,7 @@ def extract_all(
         refang_output: Whether to refang extracted observables.
 
     Returns:
-        Deduplicated list of extracted observables.
+        Deduplicated list of extracted observables with occurrence counts.
     """
     if types is None:
         types = {
@@ -662,50 +679,55 @@ def extract_all(
             ObservableType.DOMAIN,
         }
 
-    results: list[ExtractedObservable] = []
-    seen: set[tuple[ObservableType, str]] = set()
+    # Track counts per observable
+    counts: dict[tuple[ObservableType, str], int] = {}
+    # Store first occurrence of each observable (for original/defanged info)
+    first_seen: dict[tuple[ObservableType, str], ExtractedObservable] = {}
+
+    def _process_obs(obs: ExtractedObservable) -> None:
+        key = (obs.obs_type, obs.value)
+        if key in counts:
+            counts[key] += 1
+        else:
+            counts[key] = 1
+            first_seen[key] = obs
 
     if ObservableType.URL in types:
         for obs in extract_urls(text, refang_output):
-            key = (obs.obs_type, obs.value)
-            if key not in seen:
-                seen.add(key)
-                results.append(obs)
+            _process_obs(obs)
 
     if ObservableType.IPV4 in types:
         for obs in extract_ipv4(text, refang_output):
-            key = (obs.obs_type, obs.value)
-            if key not in seen:
-                seen.add(key)
-                results.append(obs)
+            _process_obs(obs)
 
     if ObservableType.IPV6 in types:
         for obs in extract_ipv6(text):
-            key = (obs.obs_type, obs.value)
-            if key not in seen:
-                seen.add(key)
-                results.append(obs)
+            _process_obs(obs)
 
     if ObservableType.EMAIL in types:
         for obs in extract_emails(text, refang_output):
-            key = (obs.obs_type, obs.value)
-            if key not in seen:
-                seen.add(key)
-                results.append(obs)
+            _process_obs(obs)
 
     if ObservableType.HASH in types:
         for obs in extract_hashes(text):
-            key = (obs.obs_type, obs.value)
-            if key not in seen:
-                seen.add(key)
-                results.append(obs)
+            _process_obs(obs)
 
     if ObservableType.DOMAIN in types:
         for obs in extract_domains(text, refang_output):
-            key = (obs.obs_type, obs.value)
-            if key not in seen:
-                seen.add(key)
-                results.append(obs)
+            _process_obs(obs)
+
+    # Build results with counts
+    results: list[ExtractedObservable] = []
+    for key, obs in first_seen.items():
+        results.append(
+            ExtractedObservable(
+                obs_type=obs.obs_type,
+                value=obs.value,
+                original=obs.original,
+                defanged=obs.defanged,
+                count=counts[key],
+            )
+        )
 
     return results
 
@@ -756,3 +778,140 @@ def extract_from_url(
             text = response.read().decode("utf-8", errors="replace")
 
     return extract_all(text, types=types, refang_output=refang_output)
+
+
+# =============================================================================
+# Markdown Serialization
+# =============================================================================
+
+
+def observables_to_markdown(
+    observables: list[ExtractedObservable],
+    *,
+    include_original: bool = False,
+    group_by_type: bool = False,
+    title: str | None = None,
+    defang_values: bool = False,
+) -> str:
+    """
+    Generate markdown report for a list of extracted observables.
+
+    Useful for providing structured data to LLM models.
+
+    Args:
+        observables: List of extracted observables.
+        include_original: Include original text for each observable.
+        group_by_type: Group observables by type with sub-headers.
+        title: Optional title header (rendered as ## Title).
+        defang_values: Defang all values for safe sharing.
+
+    Returns:
+        Markdown formatted string.
+
+    Example:
+        >>> obs = extract_all("Contact admin@example.com or visit https://example.com")
+        >>> print(observables_to_markdown(obs, title="Extracted IOCs"))
+        ## Extracted IOCs
+
+        - **URL:** `https://example.com`
+        - **EMAIL:** `admin@example.com`
+    """
+    if not observables:
+        if title:
+            return f"## {title}\n\nNo observables found."
+        return "No observables found."
+
+    lines: list[str] = []
+
+    if title:
+        lines.append(f"## {title}")
+        lines.append("")
+
+    if group_by_type:
+        from collections import defaultdict
+
+        by_type: dict[ObservableType, list[ExtractedObservable]] = defaultdict(list)
+        for obs in observables:
+            by_type[obs.obs_type].append(obs)
+
+        for obs_type in ObservableType:
+            if obs_type in by_type:
+                lines.append(f"### {obs_type.value.upper()}")
+                lines.append("")
+                for obs in by_type[obs_type]:
+                    lines.append(
+                        obs.to_markdown(
+                            include_original=include_original,
+                            defang_value=defang_values,
+                        )
+                    )
+                lines.append("")
+    else:
+        for obs in observables:
+            lines.append(
+                obs.to_markdown(
+                    include_original=include_original,
+                    defang_value=defang_values,
+                )
+            )
+
+    return "\n".join(lines).rstrip()
+
+
+def observables_to_markdown_table(
+    observables: list[ExtractedObservable],
+    *,
+    title: str | None = None,
+    defang_values: bool = False,
+) -> str:
+    """
+    Generate a compact markdown table of extracted observables.
+
+    Useful for quick summaries when providing data to LLM models.
+
+    Args:
+        observables: List of extracted observables.
+        title: Optional title header (rendered as ## Title).
+        defang_values: Defang all values for safe sharing.
+
+    Returns:
+        Markdown table formatted string.
+
+    Example:
+        >>> obs = extract_all("IP: 192.168.1.1, Hash: d41d8cd98f00b204e9800998ecf8427e")
+        >>> print(observables_to_markdown_table(obs))
+        | Type | Value | Defanged |
+        |------|-------|----------|
+        | IPV4 | `192.168.1.1` |  |
+        | HASH | `d41d8cd98f00b204e9800998ecf8427e` |  |
+    """
+    if not observables:
+        if title:
+            return f"## {title}\n\nNo observables found."
+        return "No observables found."
+
+    lines: list[str] = []
+
+    if title:
+        lines.append(f"## {title}")
+        lines.append("")
+
+    # Check if any observable has count > 1
+    show_count = any(obs.count > 1 for obs in observables)
+
+    if show_count:
+        lines.append("| Type | Value | Count | Defanged |")
+        lines.append("|------|-------|-------|----------|")
+    else:
+        lines.append("| Type | Value | Defanged |")
+        lines.append("|------|-------|----------|")
+
+    for obs in observables:
+        display_value = defang(obs.value) if defang_values else obs.value
+        defanged_mark = "✓" if obs.defanged else ""
+        if show_count:
+            lines.append(f"| {obs.obs_type.value.upper()} | `{display_value}` | {obs.count} | {defanged_mark} |")
+        else:
+            lines.append(f"| {obs.obs_type.value.upper()} | `{display_value}` | {defanged_mark} |")
+
+    return "\n".join(lines)

--- a/src/cyvest/extract.py
+++ b/src/cyvest/extract.py
@@ -1,0 +1,758 @@
+"""
+Observable extraction module for Cyvest.
+
+Provides functions to extract cyber observables (IPs, URLs, domains, emails, hashes)
+from raw text, markdown, and web pages. Supports defanged indicators (hxxp://, [.], [@], etc.)
+with automatic refanging.
+
+Inspired by IOCExtract patterns but implemented using stdlib only.
+"""
+
+from __future__ import annotations
+
+import base64
+import ipaddress
+import re
+import urllib.parse
+import urllib.request
+from collections.abc import Iterator
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cyvest.model_enums import ObservableType
+
+# =============================================================================
+# Pydantic Model
+# =============================================================================
+
+
+class ExtractedObservable(BaseModel):
+    """Extracted observable with metadata."""
+
+    model_config = ConfigDict(frozen=True)
+
+    obs_type: ObservableType = Field(..., description="Type of the observable")
+    value: str = Field(..., description="Normalized (refanged) value")
+    original: str = Field(..., description="Original matched text")
+    defanged: bool = Field(default=False, description="Whether the original was defanged")
+
+
+# =============================================================================
+# Defang / Refang Utilities
+# =============================================================================
+
+# Patterns for defanged indicators
+_DEFANG_DOT_PATTERNS = [
+    (r"\[\.\]", "."),
+    (r"\(\.\)", "."),
+    (r"\{\.\}", "."),
+    (r"\[dot\]", "."),
+    (r"\(dot\)", "."),
+    (r"\{dot\}", "."),
+    (r"\\.", "."),
+]
+
+_DEFANG_AT_PATTERNS = [
+    (r"\[@\]", "@"),
+    (r"\(@\)", "@"),
+    (r"\{@\}", "@"),
+    (r"\[at\]", "@"),
+    (r"\(at\)", "@"),
+    (r"\{at\}", "@"),
+    (r"\s+at\s+", "@"),  # " at " -> "@" (removes surrounding spaces)
+]
+
+_DEFANG_SCHEME_PATTERNS = [
+    (r"hxxps?", lambda m: m.group(0).replace("xx", "tt")),
+    (r"fxp", "ftp"),
+    (r"\[:\]//", "://"),
+    (r":\[//\]", "://"),
+    (r":\\\\", "://"),
+    (r"\[:\/\/\]", "://"),
+]
+
+_DEFANG_SLASH_PATTERNS = [
+    (r"\[/\]", "/"),
+    (r"\(/\)", "/"),
+]
+
+
+def refang(text: str) -> str:
+    """
+    Convert defanged indicators to standard format.
+
+    Handles common defang patterns like:
+    - hxxp:// -> http://
+    - [.] or (.) or [dot] -> .
+    - [@] or (at) or " at " -> @
+    - [/] -> /
+
+    Args:
+        text: Text containing potentially defanged indicators.
+
+    Returns:
+        Text with indicators refanged.
+    """
+    result = text
+
+    # Refang schemes first
+    for pattern, replacement in _DEFANG_SCHEME_PATTERNS:
+        if callable(replacement):
+            result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+        else:
+            result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+
+    # Refang dots
+    for pattern, replacement in _DEFANG_DOT_PATTERNS:
+        result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+
+    # Refang at symbols
+    for pattern, replacement in _DEFANG_AT_PATTERNS:
+        result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+
+    # Refang slashes
+    for pattern, replacement in _DEFANG_SLASH_PATTERNS:
+        result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+
+    return result
+
+
+def defang(text: str) -> str:
+    """
+    Convert indicators to defanged format for safe sharing.
+
+    Applies common defanging:
+    - http:// -> hxxp://
+    - https:// -> hxxps://
+    - . -> [.]
+    - @ -> [@]
+
+    Args:
+        text: Text containing indicators to defang.
+
+    Returns:
+        Text with indicators defanged.
+    """
+    result = text
+
+    # Defang schemes
+    result = re.sub(r"https://", "hxxps://", result, flags=re.IGNORECASE)
+    result = re.sub(r"http://", "hxxp://", result, flags=re.IGNORECASE)
+
+    # Defang dots (but not in scheme)
+    # We need to be careful not to double-defang
+    if "hxxp" not in result.lower():
+        result = result.replace(".", "[.]")
+    else:
+        # Split by scheme, defang the rest
+        parts = re.split(r"(hxxps?://)", result, flags=re.IGNORECASE)
+        defanged_parts = []
+        for part in parts:
+            if re.match(r"hxxps?://", part, re.IGNORECASE):
+                defanged_parts.append(part)
+            else:
+                defanged_parts.append(part.replace(".", "[.]"))
+        result = "".join(defanged_parts)
+
+    # Defang @ in emails
+    result = result.replace("@", "[@]")
+
+    return result
+
+
+def _is_defanged(text: str) -> bool:
+    """Check if text contains defanged patterns."""
+    defang_indicators = [
+        r"\[\.\]",
+        r"\(\.\)",
+        r"\[dot\]",
+        r"\(dot\)",
+        r"\[@\]",
+        r"\(@\)",
+        r"\[at\]",
+        r"\(at\)",
+        r"\s+at\s+",
+        r"hxxps?://",
+        r"\[:\]//",
+        r"\[/\]",
+    ]
+    for pattern in defang_indicators:
+        if re.search(pattern, text, re.IGNORECASE):
+            return True
+    return False
+
+
+# =============================================================================
+# URL Patterns and Extraction
+# =============================================================================
+
+# Supported URL schemes
+_URL_SCHEMES = r"(?:https?|ftp|ftps|sftp|tcp|udp)"
+_DEFANGED_SCHEMES = r"(?:hxxps?|fxp)"
+
+# URL pattern - matches both normal and defanged URLs
+# The rest part allows defanged characters like [.], [/], etc.
+_URL_PATTERN = re.compile(
+    r"(?P<scheme>" + _URL_SCHEMES + r"|" + _DEFANGED_SCHEMES + r")"
+    r"(?P<sep>://|\[:\]//|:\[//\]|:\\\\|\[:\/\/\])"
+    r"(?P<rest>(?:[^\s\"'<>]|\[\.\]|\[/\]|\[dot\])+)",
+    re.IGNORECASE,
+)
+
+# Hex-encoded URL pattern (e.g., 68747470733a2f2f... for https://)
+_HEX_URL_PREFIXES = {
+    "68747470733a2f2f": "https://",  # https://
+    "687474703a2f2f": "http://",  # http://
+    "6674703a2f2f": "ftp://",  # ftp://
+}
+
+# Base64 URL pattern
+_BASE64_PATTERN = re.compile(r"[A-Za-z0-9+/]{20,}={0,2}")
+
+
+def _decode_hex_url(hex_string: str) -> str | None:
+    """Try to decode a hex-encoded URL."""
+    try:
+        decoded = bytes.fromhex(hex_string).decode("utf-8", errors="strict")
+        # Check if it looks like a URL
+        if re.match(r"^" + _URL_SCHEMES + r"://", decoded, re.IGNORECASE):
+            return decoded
+    except (ValueError, UnicodeDecodeError):
+        pass
+    return None
+
+
+def _decode_base64_url(b64_string: str) -> str | None:
+    """Try to decode a base64-encoded URL."""
+    try:
+        # Add padding if needed
+        padded = b64_string + "=" * (4 - len(b64_string) % 4)
+        decoded = base64.b64decode(padded).decode("utf-8", errors="strict")
+        # Check if it looks like a URL
+        if re.match(r"^" + _URL_SCHEMES + r"://", decoded, re.IGNORECASE):
+            return decoded
+    except (ValueError, UnicodeDecodeError, base64.binascii.Error):
+        pass
+    return None
+
+
+def _decode_url_encoded(text: str) -> str:
+    """Decode URL-encoded text."""
+    try:
+        return urllib.parse.unquote(text)
+    except Exception:
+        return text
+
+
+def extract_urls(text: str, refang_output: bool = True) -> Iterator[ExtractedObservable]:
+    """
+    Extract URLs from text.
+
+    Supports:
+    - Standard URLs (http, https, ftp, ftps, sftp, tcp, udp)
+    - Defanged URLs (hxxp, hxxps, [.], etc.)
+    - Hex-encoded URLs
+    - URL-encoded URLs
+    - Base64-encoded URLs
+
+    Args:
+        text: Text to extract URLs from.
+        refang_output: Whether to refang extracted URLs.
+
+    Yields:
+        ExtractedObservable for each URL found.
+    """
+    seen: set[str] = set()
+
+    # Extract standard and defanged URLs
+    for match in _URL_PATTERN.finditer(text):
+        original = match.group(0)
+        # Clean up trailing punctuation
+        original = re.sub(r"[.,;:!?)\"']+$", "", original)
+
+        defanged = _is_defanged(original)
+        value = refang(original) if refang_output else original
+
+        # URL decode the value
+        value = _decode_url_encoded(value)
+
+        if value not in seen:
+            seen.add(value)
+            yield ExtractedObservable(
+                obs_type=ObservableType.URL,
+                value=value,
+                original=original,
+                defanged=defanged,
+            )
+
+    # Extract hex-encoded URLs
+    hex_pattern = re.compile(r"\b([0-9a-fA-F]{14,})\b")
+    for match in hex_pattern.finditer(text):
+        hex_str = match.group(1)
+        decoded = _decode_hex_url(hex_str)
+        if decoded and decoded not in seen:
+            seen.add(decoded)
+            yield ExtractedObservable(
+                obs_type=ObservableType.URL,
+                value=decoded,
+                original=hex_str,
+                defanged=False,
+            )
+
+    # Extract base64-encoded URLs
+    for match in _BASE64_PATTERN.finditer(text):
+        b64_str = match.group(0)
+        decoded = _decode_base64_url(b64_str)
+        if decoded and decoded not in seen:
+            seen.add(decoded)
+            yield ExtractedObservable(
+                obs_type=ObservableType.URL,
+                value=decoded,
+                original=b64_str,
+                defanged=False,
+            )
+
+
+# =============================================================================
+# IP Address Extraction
+# =============================================================================
+
+# IPv4 pattern (including defanged)
+_IPV4_OCTET = r"(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+_IPV4_SEP = r"(?:\.|\[\.\]|\(\.\)|\[dot\]|\(dot\))"
+_IPV4_PATTERN = re.compile(
+    rf"\b{_IPV4_OCTET}{_IPV4_SEP}{_IPV4_OCTET}{_IPV4_SEP}{_IPV4_OCTET}{_IPV4_SEP}{_IPV4_OCTET}\b",
+    re.IGNORECASE,
+)
+
+# IPv6 pattern (simplified - relies on ipaddress module for validation)
+_IPV6_PATTERN = re.compile(
+    r"(?:^|[^\w:])("
+    # Full form
+    r"(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|"
+    # Compressed form
+    r"(?:[0-9a-fA-F]{1,4}:){1,7}:|"
+    r"(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|"
+    r"(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|"
+    r"(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|"
+    r"(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|"
+    r"(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|"
+    r"[0-9a-fA-F]{1,4}:(?::[0-9a-fA-F]{1,4}){1,6}|"
+    r":(?::[0-9a-fA-F]{1,4}){1,7}|"
+    r"::(?:[fF]{4}:)?(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|"
+    r"(?:[0-9a-fA-F]{1,4}:){1,4}:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+    r")(?:[^\w:]|$)",
+    re.IGNORECASE,
+)
+
+
+def _validate_ipv4(ip_str: str) -> bool:
+    """Validate an IPv4 address using ipaddress module."""
+    try:
+        ipaddress.IPv4Address(ip_str)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
+
+def _validate_ipv6(ip_str: str) -> bool:
+    """Validate an IPv6 address using ipaddress module."""
+    try:
+        ipaddress.IPv6Address(ip_str)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
+
+def extract_ipv4(text: str, refang_output: bool = True) -> Iterator[ExtractedObservable]:
+    """
+    Extract IPv4 addresses from text.
+
+    Supports defanged formats like 192[.]168[.]1[.]1.
+
+    Args:
+        text: Text to extract IPs from.
+        refang_output: Whether to refang extracted IPs.
+
+    Yields:
+        ExtractedObservable for each valid IPv4 found.
+    """
+    seen: set[str] = set()
+
+    for match in _IPV4_PATTERN.finditer(text):
+        original = match.group(0)
+        defanged = _is_defanged(original)
+        value = refang(original) if refang_output else original
+
+        # Validate the IP
+        if _validate_ipv4(value) and value not in seen:
+            seen.add(value)
+            yield ExtractedObservable(
+                obs_type=ObservableType.IPV4,
+                value=value,
+                original=original,
+                defanged=defanged,
+            )
+
+
+def extract_ipv6(text: str) -> Iterator[ExtractedObservable]:
+    """
+    Extract IPv6 addresses from text.
+
+    Args:
+        text: Text to extract IPs from.
+
+    Yields:
+        ExtractedObservable for each valid IPv6 found.
+    """
+    seen: set[str] = set()
+
+    for match in _IPV6_PATTERN.finditer(text):
+        original = match.group(1)
+
+        # Validate the IP
+        if _validate_ipv6(original) and original not in seen:
+            seen.add(original)
+            yield ExtractedObservable(
+                obs_type=ObservableType.IPV6,
+                value=original,
+                original=original,
+                defanged=False,
+            )
+
+
+def extract_ips(text: str, refang_output: bool = True) -> Iterator[ExtractedObservable]:
+    """
+    Extract all IP addresses (IPv4 and IPv6) from text.
+
+    Args:
+        text: Text to extract IPs from.
+        refang_output: Whether to refang extracted IPs.
+
+    Yields:
+        ExtractedObservable for each valid IP found.
+    """
+    yield from extract_ipv4(text, refang_output)
+    yield from extract_ipv6(text)
+
+
+# =============================================================================
+# Email Extraction
+# =============================================================================
+
+# Email pattern with defanged support
+_EMAIL_LOCAL_PART = r"[a-zA-Z0-9._%+-]+"
+_EMAIL_AT = r"(?:@|\[@\]|\(@\)|\{@\}|\[at\]|\(at\)|\{at\})"
+_EMAIL_AT_WORD = r"\s+at\s+"  # " at " with spaces
+_EMAIL_DOMAIN_PART = r"[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?"
+_EMAIL_DOMAIN_SEP = r"(?:\.|\[\.\]|\(\.\)|\[dot\]|\(dot\))"
+
+# Two patterns: one for standard @ variants, one for " at " format
+_EMAIL_PATTERN = re.compile(
+    rf"\b({_EMAIL_LOCAL_PART}){_EMAIL_AT}({_EMAIL_DOMAIN_PART}(?:{_EMAIL_DOMAIN_SEP}{_EMAIL_DOMAIN_PART})+)\b",
+    re.IGNORECASE,
+)
+
+_EMAIL_PATTERN_WORD_AT = re.compile(
+    rf"\b({_EMAIL_LOCAL_PART}){_EMAIL_AT_WORD}({_EMAIL_DOMAIN_PART}(?:{_EMAIL_DOMAIN_SEP}{_EMAIL_DOMAIN_PART})+)\b",
+    re.IGNORECASE,
+)
+
+
+def extract_emails(text: str, refang_output: bool = True) -> Iterator[ExtractedObservable]:
+    """
+    Extract email addresses from text.
+
+    Supports defanged formats like:
+    - user[@]example[.]com
+    - user(at)example(dot)com
+    - user at example dot com
+
+    Args:
+        text: Text to extract emails from.
+        refang_output: Whether to refang extracted emails.
+
+    Yields:
+        ExtractedObservable for each email found.
+    """
+    seen: set[str] = set()
+
+    # Match standard @ variants
+    for match in _EMAIL_PATTERN.finditer(text):
+        original = match.group(0)
+        defanged = _is_defanged(original)
+        value = refang(original) if refang_output else original
+
+        if value not in seen:
+            seen.add(value)
+            yield ExtractedObservable(
+                obs_type=ObservableType.EMAIL,
+                value=value,
+                original=original,
+                defanged=defanged,
+            )
+
+    # Match " at " format (word-based)
+    for match in _EMAIL_PATTERN_WORD_AT.finditer(text):
+        original = match.group(0)
+        defanged = True  # " at " format is always defanged
+        value = refang(original) if refang_output else original
+
+        if value not in seen:
+            seen.add(value)
+            yield ExtractedObservable(
+                obs_type=ObservableType.EMAIL,
+                value=value,
+                original=original,
+                defanged=defanged,
+            )
+
+
+# =============================================================================
+# Hash Extraction
+# =============================================================================
+
+# Hash patterns by length
+_MD5_PATTERN = re.compile(r"(?:^|[^a-fA-F0-9])([a-fA-F0-9]{32})(?:$|[^a-fA-F0-9])")
+_SHA1_PATTERN = re.compile(r"(?:^|[^a-fA-F0-9])([a-fA-F0-9]{40})(?:$|[^a-fA-F0-9])")
+_SHA256_PATTERN = re.compile(r"(?:^|[^a-fA-F0-9])([a-fA-F0-9]{64})(?:$|[^a-fA-F0-9])")
+_SHA512_PATTERN = re.compile(r"(?:^|[^a-fA-F0-9])([a-fA-F0-9]{128})(?:$|[^a-fA-F0-9])")
+
+
+def extract_hashes(text: str) -> Iterator[ExtractedObservable]:
+    """
+    Extract cryptographic hashes from text.
+
+    Supports:
+    - MD5 (32 hex characters)
+    - SHA1 (40 hex characters)
+    - SHA256 (64 hex characters)
+    - SHA512 (128 hex characters)
+
+    Args:
+        text: Text to extract hashes from.
+
+    Yields:
+        ExtractedObservable for each hash found.
+    """
+    seen: set[str] = set()
+
+    # Extract in order from longest to shortest to avoid substring matches
+    for pattern in [_SHA512_PATTERN, _SHA256_PATTERN, _SHA1_PATTERN, _MD5_PATTERN]:
+        for match in pattern.finditer(text):
+            hash_value = match.group(1).lower()
+
+            if hash_value not in seen:
+                # Check it's not a substring of an already-found longer hash
+                is_substring = False
+                for existing in seen:
+                    if hash_value in existing:
+                        is_substring = True
+                        break
+
+                if not is_substring:
+                    seen.add(hash_value)
+                    yield ExtractedObservable(
+                        obs_type=ObservableType.HASH,
+                        value=hash_value,
+                        original=match.group(1),
+                        defanged=False,
+                    )
+
+
+# =============================================================================
+# Domain Extraction
+# =============================================================================
+
+# TLD list (common TLDs - not exhaustive but covers most cases)
+_COMMON_TLDS = (
+    r"com|org|net|edu|gov|mil|int|"
+    r"co|io|ai|app|dev|cloud|"
+    r"uk|us|ca|au|de|fr|jp|cn|ru|br|in|"
+    r"info|biz|name|pro|museum|"
+    r"online|site|store|tech|xyz|"
+    r"eu|asia|africa"
+)
+
+_DOMAIN_LABEL = r"[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?"
+_DOMAIN_SEP = r"(?:\.|\[\.\]|\(\.\)|\[dot\]|\(dot\))"
+
+# Domain pattern - must end with a known TLD
+_DOMAIN_PATTERN = re.compile(
+    rf"\b({_DOMAIN_LABEL}(?:{_DOMAIN_SEP}{_DOMAIN_LABEL})*{_DOMAIN_SEP}(?:{_COMMON_TLDS}))\b",
+    re.IGNORECASE,
+)
+
+
+def extract_domains(text: str, refang_output: bool = True) -> Iterator[ExtractedObservable]:
+    """
+    Extract domain names from text.
+
+    Supports defanged formats like example[.]com.
+
+    Note: This extracts standalone domains, not domains within URLs.
+    Use extract_urls() for URLs.
+
+    Args:
+        text: Text to extract domains from.
+        refang_output: Whether to refang extracted domains.
+
+    Yields:
+        ExtractedObservable for each domain found.
+    """
+    seen: set[str] = set()
+
+    # First, find all URLs to exclude their domains
+    url_domains: set[str] = set()
+    for url_obs in extract_urls(text, refang_output=True):
+        try:
+            parsed = urllib.parse.urlparse(url_obs.value)
+            if parsed.netloc:
+                url_domains.add(parsed.netloc.lower())
+        except Exception:
+            pass
+
+    for match in _DOMAIN_PATTERN.finditer(text):
+        original = match.group(1)
+        defanged = _is_defanged(original)
+        value = refang(original).lower() if refang_output else original.lower()
+
+        # Skip if this domain is part of a URL
+        if value in url_domains:
+            continue
+
+        if value not in seen:
+            seen.add(value)
+            yield ExtractedObservable(
+                obs_type=ObservableType.DOMAIN,
+                value=value,
+                original=original,
+                defanged=defanged,
+            )
+
+
+# =============================================================================
+# Combined Extraction
+# =============================================================================
+
+
+def extract_all(
+    text: str,
+    types: set[ObservableType] | None = None,
+    refang_output: bool = True,
+) -> list[ExtractedObservable]:
+    """
+    Extract all observables from text.
+
+    Args:
+        text: Text to extract observables from.
+        types: Optional set of types to extract. If None, extracts all types.
+        refang_output: Whether to refang extracted observables.
+
+    Returns:
+        Deduplicated list of extracted observables.
+    """
+    if types is None:
+        types = {
+            ObservableType.URL,
+            ObservableType.IPV4,
+            ObservableType.IPV6,
+            ObservableType.EMAIL,
+            ObservableType.HASH,
+            ObservableType.DOMAIN,
+        }
+
+    results: list[ExtractedObservable] = []
+    seen: set[tuple[ObservableType, str]] = set()
+
+    if ObservableType.URL in types:
+        for obs in extract_urls(text, refang_output):
+            key = (obs.obs_type, obs.value)
+            if key not in seen:
+                seen.add(key)
+                results.append(obs)
+
+    if ObservableType.IPV4 in types:
+        for obs in extract_ipv4(text, refang_output):
+            key = (obs.obs_type, obs.value)
+            if key not in seen:
+                seen.add(key)
+                results.append(obs)
+
+    if ObservableType.IPV6 in types:
+        for obs in extract_ipv6(text):
+            key = (obs.obs_type, obs.value)
+            if key not in seen:
+                seen.add(key)
+                results.append(obs)
+
+    if ObservableType.EMAIL in types:
+        for obs in extract_emails(text, refang_output):
+            key = (obs.obs_type, obs.value)
+            if key not in seen:
+                seen.add(key)
+                results.append(obs)
+
+    if ObservableType.HASH in types:
+        for obs in extract_hashes(text):
+            key = (obs.obs_type, obs.value)
+            if key not in seen:
+                seen.add(key)
+                results.append(obs)
+
+    if ObservableType.DOMAIN in types:
+        for obs in extract_domains(text, refang_output):
+            key = (obs.obs_type, obs.value)
+            if key not in seen:
+                seen.add(key)
+                results.append(obs)
+
+    return results
+
+
+# =============================================================================
+# URL Fetching
+# =============================================================================
+
+
+def extract_from_url(
+    url: str,
+    types: set[ObservableType] | None = None,
+    refang_output: bool = True,
+    timeout: int = 30,
+) -> list[ExtractedObservable]:
+    """
+    Fetch content from a URL and extract observables.
+
+    Args:
+        url: URL to fetch content from.
+        types: Optional set of types to extract. If None, extracts all types.
+        refang_output: Whether to refang extracted observables.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Deduplicated list of extracted observables.
+
+    Raises:
+        URLError: If the URL cannot be fetched.
+        HTTPError: If the server returns an error response.
+    """
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Mozilla/5.0 (compatible; Cyvest/1.0; +https://github.com/PakitoSec/cyvest)"},
+    )
+
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        content_type = response.headers.get("Content-Type", "")
+        charset = "utf-8"
+
+        # Try to extract charset from Content-Type
+        if "charset=" in content_type:
+            charset = content_type.split("charset=")[-1].split(";")[0].strip()
+
+        try:
+            text = response.read().decode(charset)
+        except (UnicodeDecodeError, LookupError):
+            text = response.read().decode("utf-8", errors="replace")
+
+    return extract_all(text, types=types, refang_output=refang_output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -362,3 +362,131 @@ def test_cli_query_not_found(tmp_path: Path) -> None:
     result = runner.invoke(cli, ["query", str(sample), "-k", "chk:nonexistent"])
     assert result.exit_code != 0
     assert "not found" in result.output
+
+
+# =============================================================================
+# Extract Command Markdown Format Tests
+# =============================================================================
+
+
+class TestExtractMarkdownFormat:
+    """Tests for extract command markdown output formats."""
+
+    def test_extract_format_markdown(self, tmp_path: Path) -> None:
+        """Extract command outputs markdown format."""
+        runner = CliRunner()
+        input_text = "Visit https://example.com or email admin@test.org"
+        output_file = tmp_path / "output.md"
+
+        result = runner.invoke(cli, ["extract", "--format", "markdown", "-o", str(output_file)], input=input_text)
+        assert result.exit_code == 0
+        content = output_file.read_text()
+        assert "- URL" in content
+        assert "- EMAIL" in content
+
+    def test_extract_format_markdown_table(self, tmp_path: Path) -> None:
+        """Extract command outputs markdown table format."""
+        runner = CliRunner()
+        input_text = "IP: 192.168.1.1"
+        output_file = tmp_path / "output.md"
+
+        result = runner.invoke(cli, ["extract", "--format", "markdown-table", "-o", str(output_file)], input=input_text)
+        assert result.exit_code == 0
+        content = output_file.read_text()
+        assert "| Type | Value | Defanged |" in content
+        assert "| IPV4 |" in content
+
+    def test_extract_markdown_with_title(self, tmp_path: Path) -> None:
+        """Extract command adds title header to markdown output."""
+        runner = CliRunner()
+        input_text = "https://example.com"
+        output_file = tmp_path / "output.md"
+
+        result = runner.invoke(
+            cli,
+            ["extract", "--format", "markdown", "--title", "Threat IOCs", "-o", str(output_file)],
+            input=input_text,
+        )
+        assert result.exit_code == 0
+        content = output_file.read_text()
+        assert "## Threat IOCs" in content
+
+    def test_extract_markdown_group_by_type(self, tmp_path: Path) -> None:
+        """Extract command groups by type in markdown output."""
+        runner = CliRunner()
+        input_text = "URL: https://a.com Email: test@example.com IP: 1.2.3.4"
+        output_file = tmp_path / "output.md"
+
+        result = runner.invoke(
+            cli,
+            ["extract", "--format", "markdown", "--group-by-type", "-o", str(output_file)],
+            input=input_text,
+        )
+        assert result.exit_code == 0
+        content = output_file.read_text()
+        # Should have type headers
+        assert "### IPV4" in content or "### URL" in content
+
+    def test_extract_markdown_include_original(self, tmp_path: Path) -> None:
+        """Extract command includes original text in markdown output."""
+        runner = CliRunner()
+        input_text = "Malicious: hxxps://evil[.]com"
+        output_file = tmp_path / "output.md"
+
+        result = runner.invoke(
+            cli,
+            ["extract", "--format", "markdown", "--include-original", "-o", str(output_file)],
+            input=input_text,
+        )
+        assert result.exit_code == 0
+        content = output_file.read_text()
+        assert "Original:" in content
+        assert "hxxps://evil[.]com" in content
+
+    def test_extract_markdown_defang_output(self, tmp_path: Path) -> None:
+        """Extract command defangs values in markdown output."""
+        runner = CliRunner()
+        input_text = "https://malware.com/payload"
+        output_file = tmp_path / "output.md"
+
+        result = runner.invoke(
+            cli,
+            ["extract", "--format", "markdown", "--defang-output", "-o", str(output_file)],
+            input=input_text,
+        )
+        assert result.exit_code == 0
+        content = output_file.read_text()
+        assert "hxxps://" in content
+        assert "[.]" in content
+
+    def test_extract_markdown_table_defang_output(self, tmp_path: Path) -> None:
+        """Extract command defangs values in markdown table output."""
+        runner = CliRunner()
+        input_text = "admin@malware.com"
+        output_file = tmp_path / "output.md"
+
+        result = runner.invoke(
+            cli,
+            ["extract", "--format", "markdown-table", "--defang-output", "-o", str(output_file)],
+            input=input_text,
+        )
+        assert result.exit_code == 0
+        content = output_file.read_text()
+        assert "[@]" in content
+        assert "[.]" in content
+
+    def test_extract_markdown_table_with_title(self, tmp_path: Path) -> None:
+        """Extract command adds title header to markdown table output."""
+        runner = CliRunner()
+        input_text = "192.168.1.1"
+        output_file = tmp_path / "output.md"
+
+        result = runner.invoke(
+            cli,
+            ["extract", "--format", "markdown-table", "--title", "Network IOCs", "-o", str(output_file)],
+            input=input_text,
+        )
+        assert result.exit_code == 0
+        content = output_file.read_text()
+        assert "## Network IOCs" in content
+        assert "| Type | Value | Defanged |" in content

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 
 from cyvest.cli import cli
 from cyvest.extract import (
+    ExtractedObservable,
     defang,
     extract_all,
     extract_domains,
@@ -22,6 +23,8 @@ from cyvest.extract import (
     extract_ipv4,
     extract_ipv6,
     extract_urls,
+    observables_to_markdown,
+    observables_to_markdown_table,
     refang,
 )
 from cyvest.model_enums import ObservableType
@@ -198,9 +201,14 @@ class TestExtractUrls:
         assert len(urls) == 2
 
     def test_extract_urls_deduplicates(self):
+        # Deduplication happens in extract_all, not in extract_urls
         text = "Visit http://example.com and http://example.com again"
         urls = list(extract_urls(text))
-        assert len(urls) == 1
+        assert len(urls) == 2  # extract_urls yields all matches
+        # extract_all deduplicates and counts
+        all_obs = extract_all(text, types={ObservableType.URL})
+        assert len(all_obs) == 1
+        assert all_obs[0].count == 2
 
     def test_extract_no_refang(self):
         text = "C2: hxxps://evil[.]com"
@@ -274,9 +282,14 @@ class TestExtractIPs:
         assert len(ips) == 2
 
     def test_extract_ips_deduplicates(self):
+        # Deduplication happens in extract_all, not in extract_ips
         text = "IP 8.8.8.8 and again 8.8.8.8"
         ips = list(extract_ips(text))
-        assert len(ips) == 1
+        assert len(ips) == 2  # extract_ips yields all matches
+        # extract_all deduplicates and counts
+        all_obs = extract_all(text, types={ObservableType.IPV4})
+        assert len(all_obs) == 1
+        assert all_obs[0].count == 2
 
 
 # =============================================================================
@@ -332,9 +345,14 @@ class TestExtractEmails:
         assert emails[0].value == "user+tag@example.com"
 
     def test_extract_emails_deduplicates(self):
+        # Deduplication happens in extract_all, not in extract_emails
         text = "Contact user@test.com or user@test.com"
         emails = list(extract_emails(text))
-        assert len(emails) == 1
+        assert len(emails) == 2  # extract_emails yields all matches
+        # extract_all deduplicates and counts
+        all_obs = extract_all(text, types={ObservableType.EMAIL})
+        assert len(all_obs) == 1
+        assert all_obs[0].count == 2
 
 
 # =============================================================================
@@ -442,9 +460,14 @@ class TestExtractDomains:
         assert all(d.value != "example.com" for d in domains)
 
     def test_extract_domains_deduplicates(self):
+        # Deduplication happens in extract_all, not in extract_domains
         text = "Check example.com and example.com"
         domains = list(extract_domains(text))
-        assert len(domains) == 1
+        assert len(domains) == 2  # extract_domains yields all matches
+        # extract_all deduplicates and counts
+        all_obs = extract_all(text, types={ObservableType.DOMAIN})
+        assert len(all_obs) == 1
+        assert all_obs[0].count == 2
 
 
 # =============================================================================
@@ -724,3 +747,354 @@ class TestEdgeCases:
         hashes = list(extract_hashes(text))
         # Should not extract as any hash type since it's too long
         assert len(hashes) <= 2  # At most SHA512 (128) extracted
+
+
+# =============================================================================
+# Markdown Serialization Tests
+# =============================================================================
+
+
+class TestExtractedObservableStr:
+    """Tests for ExtractedObservable.__str__ method."""
+
+    def test_str_url(self):
+        obs = ExtractedObservable(
+            obs_type=ObservableType.URL,
+            value="https://example.com",
+            original="https://example.com",
+            defanged=False,
+        )
+        assert str(obs) == "url:https://example.com"
+
+    def test_str_email(self):
+        obs = ExtractedObservable(
+            obs_type=ObservableType.EMAIL,
+            value="admin@example.com",
+            original="admin@example.com",
+            defanged=False,
+        )
+        assert str(obs) == "email:admin@example.com"
+
+    def test_str_ipv4(self):
+        obs = ExtractedObservable(
+            obs_type=ObservableType.IPV4,
+            value="192.168.1.1",
+            original="192[.]168[.]1[.]1",
+            defanged=True,
+        )
+        assert str(obs) == "ipv4:192.168.1.1"
+
+
+class TestExtractedObservableToMarkdown:
+    """Tests for ExtractedObservable.to_markdown method."""
+
+    def test_to_markdown_basic(self):
+        obs = ExtractedObservable(
+            obs_type=ObservableType.URL,
+            value="https://example.com",
+            original="https://example.com",
+            defanged=False,
+        )
+        md = obs.to_markdown()
+        assert md == "- URL: `https://example.com`"
+
+    def test_to_markdown_with_defanged_flag(self):
+        obs = ExtractedObservable(
+            obs_type=ObservableType.IPV4,
+            value="192.168.1.1",
+            original="192[.]168[.]1[.]1",
+            defanged=True,
+        )
+        md = obs.to_markdown()
+        assert "- IPV4: `192.168.1.1`" in md
+        assert "Defanged: Yes" in md
+
+    def test_to_markdown_include_original(self):
+        obs = ExtractedObservable(
+            obs_type=ObservableType.URL,
+            value="https://example.com",
+            original="hxxps://example[.]com",
+            defanged=True,
+        )
+        md = obs.to_markdown(include_original=True)
+        assert "- URL: `https://example.com`" in md
+        assert "Original: `hxxps://example[.]com`" in md
+
+    def test_to_markdown_include_original_same_value(self):
+        """Original should not be shown if it equals value."""
+        obs = ExtractedObservable(
+            obs_type=ObservableType.URL,
+            value="https://example.com",
+            original="https://example.com",
+            defanged=False,
+        )
+        md = obs.to_markdown(include_original=True)
+        assert "Original:" not in md
+
+    def test_to_markdown_defang_value(self):
+        obs = ExtractedObservable(
+            obs_type=ObservableType.URL,
+            value="https://example.com",
+            original="https://example.com",
+            defanged=False,
+        )
+        md = obs.to_markdown(defang_value=True)
+        assert "hxxps://" in md
+        assert "[.]" in md
+
+
+class TestObservablesToMarkdown:
+    """Tests for observables_to_markdown function."""
+
+    def test_empty_list(self):
+        md = observables_to_markdown([])
+        assert md == "No observables found."
+
+    def test_empty_list_with_title(self):
+        md = observables_to_markdown([], title="IOCs")
+        assert "## IOCs" in md
+        assert "No observables found." in md
+
+    def test_basic_list(self):
+        obs = [
+            ExtractedObservable(
+                obs_type=ObservableType.URL,
+                value="https://example.com",
+                original="https://example.com",
+                defanged=False,
+            ),
+            ExtractedObservable(
+                obs_type=ObservableType.IPV4,
+                value="192.168.1.1",
+                original="192.168.1.1",
+                defanged=False,
+            ),
+        ]
+        md = observables_to_markdown(obs)
+        assert "- URL: `https://example.com`" in md
+        assert "- IPV4: `192.168.1.1`" in md
+
+    def test_with_title(self):
+        obs = [
+            ExtractedObservable(
+                obs_type=ObservableType.DOMAIN,
+                value="example.com",
+                original="example.com",
+                defanged=False,
+            ),
+        ]
+        md = observables_to_markdown(obs, title="Extracted Domains")
+        assert md.startswith("## Extracted Domains")
+
+    def test_group_by_type(self):
+        obs = [
+            ExtractedObservable(
+                obs_type=ObservableType.URL,
+                value="https://a.com",
+                original="https://a.com",
+                defanged=False,
+            ),
+            ExtractedObservable(
+                obs_type=ObservableType.IPV4,
+                value="1.2.3.4",
+                original="1.2.3.4",
+                defanged=False,
+            ),
+            ExtractedObservable(
+                obs_type=ObservableType.URL,
+                value="https://b.com",
+                original="https://b.com",
+                defanged=False,
+            ),
+        ]
+        md = observables_to_markdown(obs, group_by_type=True)
+        assert "### URL" in md
+        assert "### IPV4" in md
+        # IPV4 comes before URL in ObservableType enum order
+        ipv4_section_start = md.find("### IPV4")
+        url_section_start = md.find("### URL")
+        assert ipv4_section_start < url_section_start
+
+    def test_defang_values(self):
+        obs = [
+            ExtractedObservable(
+                obs_type=ObservableType.URL,
+                value="https://malware.com/payload",
+                original="https://malware.com/payload",
+                defanged=False,
+            ),
+        ]
+        md = observables_to_markdown(obs, defang_values=True)
+        assert "hxxps://" in md
+        assert "[.]" in md
+
+
+class TestObservablesToMarkdownTable:
+    """Tests for observables_to_markdown_table function."""
+
+    def test_empty_list(self):
+        md = observables_to_markdown_table([])
+        assert md == "No observables found."
+
+    def test_empty_list_with_title(self):
+        md = observables_to_markdown_table([], title="IOCs")
+        assert "## IOCs" in md
+        assert "No observables found." in md
+
+    def test_basic_table(self):
+        obs = [
+            ExtractedObservable(
+                obs_type=ObservableType.URL,
+                value="https://example.com",
+                original="https://example.com",
+                defanged=False,
+            ),
+            ExtractedObservable(
+                obs_type=ObservableType.IPV4,
+                value="192.168.1.1",
+                original="192[.]168[.]1[.]1",
+                defanged=True,
+            ),
+        ]
+        md = observables_to_markdown_table(obs)
+        assert "| Type | Value | Defanged |" in md
+        assert "|------|-------|----------|" in md
+        assert "| URL | `https://example.com` |  |" in md
+        assert "| IPV4 | `192.168.1.1` | ✓ |" in md
+
+    def test_with_title(self):
+        obs = [
+            ExtractedObservable(
+                obs_type=ObservableType.HASH,
+                value="d41d8cd98f00b204e9800998ecf8427e",
+                original="d41d8cd98f00b204e9800998ecf8427e",
+                defanged=False,
+            ),
+        ]
+        md = observables_to_markdown_table(obs, title="File Hashes")
+        assert md.startswith("## File Hashes")
+
+    def test_defang_values(self):
+        obs = [
+            ExtractedObservable(
+                obs_type=ObservableType.EMAIL,
+                value="evil@malware.com",
+                original="evil@malware.com",
+                defanged=False,
+            ),
+        ]
+        md = observables_to_markdown_table(obs, defang_values=True)
+        assert "[@]" in md
+        assert "[.]" in md
+
+
+class TestMarkdownIntegration:
+    """Integration tests for markdown serialization with extract functions."""
+
+    def test_extract_and_serialize_to_markdown(self):
+        text = """
+        Malicious IP: 192[.]168[.]1[.]100
+        C2 server: hxxps://evil[.]com/callback
+        Contact: admin[@]evil[.]com
+        """
+        obs = extract_all(text)
+        md = observables_to_markdown(obs, title="Threat IOCs", group_by_type=True)
+        assert "## Threat IOCs" in md
+        assert "192.168.1.100" in md
+        assert "https://evil.com/callback" in md
+        assert "admin@evil.com" in md
+
+    def test_extract_and_serialize_to_table(self):
+        text = "Visit https://example.com or contact user@example.com"
+        obs = extract_all(text)
+        md = observables_to_markdown_table(obs)
+        assert "| URL |" in md
+        assert "| EMAIL |" in md
+
+
+class TestOccurrenceCounting:
+    """Tests for occurrence counting functionality."""
+
+    def test_count_duplicate_ips(self):
+        text = "IP: 192.168.1.1 and again 192.168.1.1 and 192.168.1.1"
+        obs = extract_all(text)
+        assert len(obs) == 1
+        assert obs[0].value == "192.168.1.1"
+        assert obs[0].count == 3
+
+    def test_count_single_occurrence(self):
+        text = "IP: 192.168.1.1"
+        obs = extract_all(text)
+        assert len(obs) == 1
+        assert obs[0].count == 1
+
+    def test_count_multiple_types(self):
+        text = """
+        192.168.1.1 192.168.1.1
+        https://example.com https://example.com https://example.com
+        test@example.com
+        """
+        obs = extract_all(text)
+        ip_obs = [o for o in obs if o.obs_type == ObservableType.IPV4][0]
+        url_obs = [o for o in obs if o.obs_type == ObservableType.URL][0]
+        email_obs = [o for o in obs if o.obs_type == ObservableType.EMAIL][0]
+
+        assert ip_obs.count == 2
+        assert url_obs.count == 3
+        assert email_obs.count == 1
+
+    def test_str_with_count(self):
+        obs = ExtractedObservable(
+            obs_type=ObservableType.IPV4,
+            value="192.168.1.1",
+            original="192.168.1.1",
+            defanged=False,
+            count=5,
+        )
+        assert "(x5)" in str(obs)
+
+    def test_to_markdown_with_count(self):
+        obs = ExtractedObservable(
+            obs_type=ObservableType.IPV4,
+            value="192.168.1.1",
+            original="192.168.1.1",
+            defanged=False,
+            count=3,
+        )
+        md = obs.to_markdown()
+        assert "Count: 3" in md
+
+    def test_table_with_count_column(self):
+        obs = [
+            ExtractedObservable(
+                obs_type=ObservableType.IPV4,
+                value="192.168.1.1",
+                original="192.168.1.1",
+                defanged=False,
+                count=3,
+            ),
+            ExtractedObservable(
+                obs_type=ObservableType.URL,
+                value="https://example.com",
+                original="https://example.com",
+                defanged=False,
+                count=1,
+            ),
+        ]
+        md = observables_to_markdown_table(obs)
+        assert "| Count |" in md
+        assert "| 3 |" in md
+        assert "| 1 |" in md
+
+    def test_table_without_count_column_when_all_one(self):
+        obs = [
+            ExtractedObservable(
+                obs_type=ObservableType.IPV4,
+                value="192.168.1.1",
+                original="192.168.1.1",
+                defanged=False,
+                count=1,
+            ),
+        ]
+        md = observables_to_markdown_table(obs)
+        assert "| Count |" not in md

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,726 @@
+"""
+Tests for the observable extraction module.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cyvest.cli import cli
+from cyvest.extract import (
+    defang,
+    extract_all,
+    extract_domains,
+    extract_emails,
+    extract_from_url,
+    extract_hashes,
+    extract_ips,
+    extract_ipv4,
+    extract_ipv6,
+    extract_urls,
+    refang,
+)
+from cyvest.model_enums import ObservableType
+
+# =============================================================================
+# Refang / Defang Tests
+# =============================================================================
+
+
+class TestRefang:
+    """Tests for the refang function."""
+
+    def test_refang_hxxp(self):
+        assert refang("hxxp://example.com") == "http://example.com"
+
+    def test_refang_hxxps(self):
+        assert refang("hxxps://example.com") == "https://example.com"
+
+    def test_refang_bracket_dot(self):
+        assert refang("example[.]com") == "example.com"
+
+    def test_refang_paren_dot(self):
+        assert refang("example(.)com") == "example.com"
+
+    def test_refang_word_dot(self):
+        assert refang("example[dot]com") == "example.com"
+
+    def test_refang_bracket_at(self):
+        assert refang("user[@]example.com") == "user@example.com"
+
+    def test_refang_paren_at(self):
+        assert refang("user(@)example.com") == "user@example.com"
+
+    def test_refang_word_at(self):
+        assert refang("user at example.com") == "user@example.com"
+
+    def test_refang_bracket_slash(self):
+        assert refang("http://example.com[/]path") == "http://example.com/path"
+
+    def test_refang_combined(self):
+        """Test multiple defang patterns in one string."""
+        text = "hxxps://evil[.]domain[.]com[/]malware"
+        assert refang(text) == "https://evil.domain.com/malware"
+
+    def test_refang_email_combined(self):
+        text = "user[@]example[.]com"
+        assert refang(text) == "user@example.com"
+
+    def test_refang_preserves_normal_text(self):
+        text = "This is normal text without any defanged indicators."
+        assert refang(text) == text
+
+
+class TestDefang:
+    """Tests for the defang function."""
+
+    def test_defang_http(self):
+        assert "hxxp://" in defang("http://example.com")
+
+    def test_defang_https(self):
+        assert "hxxps://" in defang("https://example.com")
+
+    def test_defang_dots(self):
+        result = defang("example.com")
+        assert "[.]" in result
+
+    def test_defang_at(self):
+        result = defang("user@example.com")
+        assert "[@]" in result
+
+    def test_defang_url_combined(self):
+        result = defang("https://malware.evil.com/payload")
+        assert "hxxps://" in result
+        assert "[.]" in result
+
+
+# =============================================================================
+# URL Extraction Tests
+# =============================================================================
+
+
+class TestExtractUrls:
+    """Tests for URL extraction."""
+
+    def test_extract_http_url(self):
+        text = "Visit http://example.com for more info"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert urls[0].value == "http://example.com"
+        assert urls[0].obs_type == ObservableType.URL
+
+    def test_extract_https_url(self):
+        text = "Visit https://example.com/path?query=1"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert urls[0].value == "https://example.com/path?query=1"
+
+    def test_extract_ftp_url(self):
+        text = "Download from ftp://files.example.com/file.zip"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert urls[0].value == "ftp://files.example.com/file.zip"
+
+    def test_extract_sftp_url(self):
+        text = "Connect to sftp://secure.example.com"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert "sftp://" in urls[0].value
+
+    def test_extract_ftps_url(self):
+        text = "Connect to ftps://secure.example.com"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert "ftps://" in urls[0].value
+
+    def test_extract_tcp_url(self):
+        text = "Connect to tcp://192.168.1.1:8080"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert "tcp://" in urls[0].value
+
+    def test_extract_udp_url(self):
+        text = "Send to udp://192.168.1.1:53"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert "udp://" in urls[0].value
+
+    def test_extract_defanged_hxxp(self):
+        text = "Malicious: hxxp://evil.com/malware"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert urls[0].value == "http://evil.com/malware"
+        assert urls[0].defanged is True
+
+    def test_extract_defanged_hxxps(self):
+        text = "Malicious: hxxps://evil.com"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert urls[0].value == "https://evil.com"
+        assert urls[0].defanged is True
+
+    def test_extract_defanged_brackets(self):
+        text = "C2: hxxps://evil[.]domain[.]com[/]c2"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert urls[0].value == "https://evil.domain.com/c2"
+        assert urls[0].defanged is True
+
+    def test_extract_url_encoded(self):
+        text = "URL: https://example.com/path%20with%20spaces"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert "path with spaces" in urls[0].value
+
+    def test_extract_hex_encoded_url(self):
+        # "https://evil.com" in hex
+        hex_url = "68747470733a2f2f6576696c2e636f6d"
+        text = f"Encoded C2: {hex_url}"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert urls[0].value == "https://evil.com"
+
+    def test_extract_base64_encoded_url(self):
+        # "https://evil.com" in base64
+        b64_url = base64.b64encode(b"https://evil.com").decode()
+        text = f"Encoded: {b64_url}"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+        assert urls[0].value == "https://evil.com"
+
+    def test_extract_multiple_urls(self):
+        text = "Visit http://a.com and https://b.com"
+        urls = list(extract_urls(text))
+        assert len(urls) == 2
+
+    def test_extract_urls_deduplicates(self):
+        text = "Visit http://example.com and http://example.com again"
+        urls = list(extract_urls(text))
+        assert len(urls) == 1
+
+    def test_extract_no_refang(self):
+        text = "C2: hxxps://evil[.]com"
+        urls = list(extract_urls(text, refang_output=False))
+        assert len(urls) == 1
+        assert "hxxps" in urls[0].value
+        assert "[.]" in urls[0].value
+
+
+# =============================================================================
+# IP Extraction Tests
+# =============================================================================
+
+
+class TestExtractIPs:
+    """Tests for IP address extraction."""
+
+    def test_extract_ipv4(self):
+        text = "Server IP: 192.168.1.1"
+        ips = list(extract_ipv4(text))
+        assert len(ips) == 1
+        assert ips[0].value == "192.168.1.1"
+        assert ips[0].obs_type == ObservableType.IPV4
+
+    def test_extract_ipv4_defanged_brackets(self):
+        text = "C2 IP: 192[.]168[.]1[.]1"
+        ips = list(extract_ipv4(text))
+        assert len(ips) == 1
+        assert ips[0].value == "192.168.1.1"
+        assert ips[0].defanged is True
+
+    def test_extract_ipv4_defanged_parens(self):
+        text = "C2 IP: 10(.)0(.)0(.)1"
+        ips = list(extract_ipv4(text))
+        assert len(ips) == 1
+        assert ips[0].value == "10.0.0.1"
+
+    def test_extract_ipv4_defanged_dot_word(self):
+        text = "C2 IP: 10[dot]0[dot]0[dot]1"
+        ips = list(extract_ipv4(text))
+        assert len(ips) == 1
+        assert ips[0].value == "10.0.0.1"
+
+    def test_extract_ipv4_validates(self):
+        """Invalid IPs should not be extracted."""
+        text = "Invalid: 999.999.999.999"
+        ips = list(extract_ipv4(text))
+        assert len(ips) == 0
+
+    def test_extract_ipv6_full(self):
+        text = "IPv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        ips = list(extract_ipv6(text))
+        assert len(ips) == 1
+        assert ips[0].obs_type == ObservableType.IPV6
+
+    def test_extract_ipv6_compressed(self):
+        text = "IPv6: 2001:db8::1"
+        ips = list(extract_ipv6(text))
+        assert len(ips) == 1
+        assert ips[0].obs_type == ObservableType.IPV6
+
+    def test_extract_ipv6_loopback(self):
+        text = "Loopback: ::1"
+        ips = list(extract_ipv6(text))
+        assert len(ips) == 1
+        assert ips[0].value == "::1"
+
+    def test_extract_ips_combined(self):
+        text = "IPv4: 8.8.8.8, IPv6: 2001:db8::1"
+        ips = list(extract_ips(text))
+        assert len(ips) == 2
+
+    def test_extract_ips_deduplicates(self):
+        text = "IP 8.8.8.8 and again 8.8.8.8"
+        ips = list(extract_ips(text))
+        assert len(ips) == 1
+
+
+# =============================================================================
+# Email Extraction Tests
+# =============================================================================
+
+
+class TestExtractEmails:
+    """Tests for email extraction."""
+
+    def test_extract_email_standard(self):
+        text = "Contact: user@example.com"
+        emails = list(extract_emails(text))
+        assert len(emails) == 1
+        assert emails[0].value == "user@example.com"
+        assert emails[0].obs_type == ObservableType.EMAIL
+
+    def test_extract_email_defanged_bracket_at(self):
+        text = "Email: user[@]example.com"
+        emails = list(extract_emails(text))
+        assert len(emails) == 1
+        assert emails[0].value == "user@example.com"
+        assert emails[0].defanged is True
+
+    def test_extract_email_defanged_paren_at(self):
+        text = "Email: user(@)example.com"
+        emails = list(extract_emails(text))
+        assert len(emails) == 1
+        assert emails[0].value == "user@example.com"
+
+    def test_extract_email_defanged_word_at(self):
+        text = "Email: user at example.com"
+        emails = list(extract_emails(text))
+        assert len(emails) == 1
+        assert emails[0].value == "user@example.com"
+
+    def test_extract_email_defanged_combined(self):
+        text = "Phishing: admin[@]evil[.]com"
+        emails = list(extract_emails(text))
+        assert len(emails) == 1
+        assert emails[0].value == "admin@evil.com"
+
+    def test_extract_email_with_dots_in_local(self):
+        text = "Email: first.last@example.com"
+        emails = list(extract_emails(text))
+        assert len(emails) == 1
+        assert emails[0].value == "first.last@example.com"
+
+    def test_extract_email_with_plus(self):
+        text = "Email: user+tag@example.com"
+        emails = list(extract_emails(text))
+        assert len(emails) == 1
+        assert emails[0].value == "user+tag@example.com"
+
+    def test_extract_emails_deduplicates(self):
+        text = "Contact user@test.com or user@test.com"
+        emails = list(extract_emails(text))
+        assert len(emails) == 1
+
+
+# =============================================================================
+# Hash Extraction Tests
+# =============================================================================
+
+
+class TestExtractHashes:
+    """Tests for hash extraction."""
+
+    def test_extract_md5(self):
+        md5 = "d41d8cd98f00b204e9800998ecf8427e"
+        text = f"MD5: {md5}"
+        hashes = list(extract_hashes(text))
+        assert len(hashes) == 1
+        assert hashes[0].value == md5
+        assert hashes[0].obs_type == ObservableType.HASH
+
+    def test_extract_sha1(self):
+        sha1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        text = f"SHA1: {sha1}"
+        hashes = list(extract_hashes(text))
+        assert len(hashes) == 1
+        assert hashes[0].value == sha1
+
+    def test_extract_sha256(self):
+        sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        text = f"SHA256: {sha256}"
+        hashes = list(extract_hashes(text))
+        assert len(hashes) == 1
+        assert hashes[0].value == sha256
+
+    def test_extract_sha512(self):
+        sha512 = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"  # noqa: E501
+        text = f"SHA512: {sha512}"
+        hashes = list(extract_hashes(text))
+        assert len(hashes) == 1
+        assert hashes[0].value == sha512
+
+    def test_extract_multiple_hashes(self):
+        md5 = "d41d8cd98f00b204e9800998ecf8427e"
+        sha1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        text = f"MD5: {md5}\nSHA1: {sha1}"
+        hashes = list(extract_hashes(text))
+        assert len(hashes) == 2
+
+    def test_extract_hash_case_insensitive(self):
+        md5_upper = "D41D8CD98F00B204E9800998ECF8427E"
+        text = f"MD5: {md5_upper}"
+        hashes = list(extract_hashes(text))
+        assert len(hashes) == 1
+        assert hashes[0].value == md5_upper.lower()
+
+    def test_extract_hashes_deduplicates(self):
+        md5 = "d41d8cd98f00b204e9800998ecf8427e"
+        text = f"Hash: {md5} and again {md5}"
+        hashes = list(extract_hashes(text))
+        assert len(hashes) == 1
+
+    def test_extract_hash_ignores_non_hex(self):
+        """Strings with non-hex characters should not be extracted."""
+        text = "Not a hash: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+        hashes = list(extract_hashes(text))
+        assert len(hashes) == 0
+
+
+# =============================================================================
+# Domain Extraction Tests
+# =============================================================================
+
+
+class TestExtractDomains:
+    """Tests for domain extraction."""
+
+    def test_extract_domain(self):
+        text = "Lookup example.com for more info"
+        domains = list(extract_domains(text))
+        assert len(domains) == 1
+        assert domains[0].value == "example.com"
+        assert domains[0].obs_type == ObservableType.DOMAIN
+
+    def test_extract_domain_defanged(self):
+        text = "C2 domain: evil[.]com"
+        domains = list(extract_domains(text))
+        assert len(domains) == 1
+        assert domains[0].value == "evil.com"
+        assert domains[0].defanged is True
+
+    def test_extract_subdomain(self):
+        text = "Server: api.subdomain.example.com"
+        domains = list(extract_domains(text))
+        assert len(domains) == 1
+        assert domains[0].value == "api.subdomain.example.com"
+
+    def test_extract_domain_various_tlds(self):
+        text = "Domains: test.io, test.dev, test.co.uk"
+        domains = list(extract_domains(text))
+        assert len(domains) >= 2
+
+    def test_extract_domain_excludes_url_domains(self):
+        """Domains within URLs should not be extracted separately."""
+        text = "Visit https://example.com for info"
+        domains = list(extract_domains(text))
+        # example.com should not appear as it's part of a URL
+        assert all(d.value != "example.com" for d in domains)
+
+    def test_extract_domains_deduplicates(self):
+        text = "Check example.com and example.com"
+        domains = list(extract_domains(text))
+        assert len(domains) == 1
+
+
+# =============================================================================
+# Combined Extraction Tests
+# =============================================================================
+
+
+class TestExtractAll:
+    """Tests for the combined extract_all function."""
+
+    def test_extract_all_types(self):
+        text = """
+        URL: https://example.com
+        IP: 192.168.1.1
+        Email: user@test.com
+        Hash: d41d8cd98f00b204e9800998ecf8427e
+        Domain: malware.io
+        """
+        observables = extract_all(text)
+        types = {obs.obs_type for obs in observables}
+        assert ObservableType.URL in types
+        assert ObservableType.IPV4 in types
+        assert ObservableType.EMAIL in types
+        assert ObservableType.HASH in types
+        assert ObservableType.DOMAIN in types
+
+    def test_extract_all_filters_by_type(self):
+        text = """
+        URL: https://example.com
+        IP: 192.168.1.1
+        Email: user@test.com
+        """
+        observables = extract_all(text, types={ObservableType.URL})
+        assert len(observables) == 1
+        assert observables[0].obs_type == ObservableType.URL
+
+    def test_extract_all_deduplicates(self):
+        text = "IP: 8.8.8.8 and again 8.8.8.8"
+        observables = extract_all(text)
+        assert len(observables) == 1
+
+    def test_extract_all_defanged(self):
+        text = "C2: hxxps://evil[.]com, IP: 10[.]0[.]0[.]1"
+        observables = extract_all(text)
+        assert len(observables) >= 2
+        for obs in observables:
+            if obs.obs_type == ObservableType.URL:
+                assert obs.value == "https://evil.com"
+            if obs.obs_type == ObservableType.IPV4:
+                assert obs.value == "10.0.0.1"
+
+
+# =============================================================================
+# URL Fetching Tests
+# =============================================================================
+
+
+class TestExtractFromUrl:
+    """Tests for extract_from_url function."""
+
+    @patch("cyvest.extract.urllib.request.urlopen")
+    def test_extract_from_url_success(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"IP: 192.168.1.1\nURL: https://example.com"
+        mock_response.headers.get.return_value = "text/plain; charset=utf-8"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        observables = extract_from_url("https://ioc-feed.example.com/list.txt")
+
+        assert len(observables) >= 2
+        types = {obs.obs_type for obs in observables}
+        assert ObservableType.IPV4 in types
+        assert ObservableType.URL in types
+
+    @patch("cyvest.extract.urllib.request.urlopen")
+    def test_extract_from_url_filters_types(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"IP: 192.168.1.1\nURL: https://example.com"
+        mock_response.headers.get.return_value = "text/plain"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        observables = extract_from_url(
+            "https://ioc-feed.example.com/list.txt",
+            types={ObservableType.IPV4},
+        )
+
+        assert len(observables) == 1
+        assert observables[0].obs_type == ObservableType.IPV4
+
+
+# =============================================================================
+# CLI Tests
+# =============================================================================
+
+
+class TestExtractCLI:
+    """Tests for the extract CLI command."""
+
+    def test_cli_extract_from_stdin(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["extract"],
+            input="IP: 192.168.1.1\nURL: https://example.com\n",
+        )
+        assert result.exit_code == 0
+        assert "192.168.1.1" in result.output
+        assert "example.com" in result.output
+
+    def test_cli_extract_specific_types(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["extract", "-t", "ip"],
+            input="IP: 192.168.1.1\nURL: https://example.com\n",
+        )
+        assert result.exit_code == 0
+        assert "192.168.1.1" in result.output
+        # URL should not be in output since we only asked for IPs
+        # (but it may appear in logs, so we check the data lines)
+        lines = [line for line in result.output.split("\n") if "\t" in line]
+        assert all("ipv4" in line or "ipv6" in line for line in lines)
+
+    def test_cli_extract_json_format(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["extract", "-f", "json"],
+            input="IP: 192.168.1.1\n",
+        )
+        assert result.exit_code == 0
+        # Find the JSON array in the output
+        output_lines = result.output.split("\n")
+        json_start = None
+        for i, line in enumerate(output_lines):
+            if line.strip().startswith("["):
+                json_start = i
+                break
+        if json_start is not None:
+            json_text = "\n".join(output_lines[json_start:])
+            data = json.loads(json_text)
+            assert len(data) >= 1
+            assert data[0]["obs_type"] == "ipv4"
+
+    def test_cli_extract_no_refang(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["extract", "-R"],  # --no-refang
+            input="IP: 192[.]168[.]1[.]1\n",
+        )
+        assert result.exit_code == 0
+
+    def test_cli_extract_from_file(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("IP: 8.8.8.8\nDomain: google.com\n")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["extract", str(test_file)])
+        assert result.exit_code == 0
+        assert "8.8.8.8" in result.output
+
+    def test_cli_extract_output_to_file(self, tmp_path):
+        output_file = tmp_path / "output.txt"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["extract", "-o", str(output_file)],
+            input="IP: 10.0.0.1\n",
+        )
+        assert result.exit_code == 0
+        assert output_file.exists()
+        content = output_file.read_text()
+        assert "10.0.0.1" in content
+
+    def test_cli_extract_no_observables(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["extract"],
+            input="No observables here.\n",
+        )
+        assert result.exit_code == 0
+
+    @patch("cyvest.extract.urllib.request.urlopen")
+    def test_cli_extract_from_url(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"IP: 1.2.3.4"
+        mock_response.headers.get.return_value = "text/plain"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["extract", "--from-url", "https://example.com/iocs.txt"],
+        )
+        assert result.exit_code == 0
+        assert "1.2.3.4" in result.output
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Edge case tests."""
+
+    def test_empty_input(self):
+        observables = extract_all("")
+        assert observables == []
+
+    def test_whitespace_only(self):
+        observables = extract_all("   \n\t  \n  ")
+        assert observables == []
+
+    def test_markdown_with_observables(self):
+        """Test that observables are extracted from markdown."""
+        text = """
+        # Threat Report
+
+        ## Indicators of Compromise
+
+        | Type | Value |
+        |------|-------|
+        | IP | 192.168.1.1 |
+        | URL | https://evil.com/malware |
+
+        Contact: analyst@security.com
+        """
+        observables = extract_all(text)
+        types = {obs.obs_type for obs in observables}
+        assert ObservableType.IPV4 in types
+        assert ObservableType.URL in types
+        assert ObservableType.EMAIL in types
+
+    def test_json_with_observables(self):
+        """Test extraction from JSON-like content."""
+        text = '{"ip": "10.0.0.1", "url": "https://c2.evil.com"}'
+        observables = extract_all(text)
+        assert len(observables) >= 2
+
+    def test_mixed_defanged_and_normal(self):
+        text = """
+        Normal: https://good.com
+        Defanged: hxxps://bad[.]com
+        """
+        observables = extract_all(text)
+        urls = [o for o in observables if o.obs_type == ObservableType.URL]
+        assert len(urls) == 2
+        values = {u.value for u in urls}
+        assert "https://good.com" in values
+        assert "https://bad.com" in values
+
+    def test_ip_in_url_not_duplicated(self):
+        """IPs that appear in URLs should be extracted as part of the URL."""
+        text = "Connect to http://192.168.1.1:8080/api"
+        observables = extract_all(text)
+        urls = [o for o in observables if o.obs_type == ObservableType.URL]
+        ips = [o for o in observables if o.obs_type == ObservableType.IPV4]
+        assert len(urls) == 1
+        # IP may or may not be extracted separately - both are valid
+        assert len(ips) <= 1
+
+    def test_very_long_hash_not_false_positive(self):
+        """Ensure we don't extract substrings of longer hex strings."""
+        # A 256-char hex string should not produce multiple hash matches
+        long_hex = "a" * 256
+        text = f"Long hex: {long_hex}"
+        hashes = list(extract_hashes(text))
+        # Should not extract as any hash type since it's too long
+        assert len(hashes) <= 2  # At most SHA512 (128) extracted


### PR DESCRIPTION
- Implement tests for refang and defang functions to ensure proper handling of defanged URLs and email addresses.
- Create tests for URL extraction covering various protocols, defanged URLs, and encoded formats.
- Add tests for IP address extraction, including IPv4 and IPv6, with defanged variations.
- Implement email extraction tests to validate standard and defanged formats.
- Add hash extraction tests for MD5, SHA1, SHA256, and SHA512, including case insensitivity and deduplication.
- Create domain extraction tests to validate standard domains and defanged formats.
- Implement combined extraction tests to ensure all observable types are extracted correctly.
- Add tests for extracting observables from URLs and CLI commands.
- Include edge case tests for empty input, whitespace, and mixed content formats.