### PR TITLE
fix(cli): accept pydantic statistics models

### DIFF
--- a/src/cyvest/cli.py
+++ b/src/cyvest/cli.py
@@ -8,12 +8,14 @@ and generating simple reports from serialized investigations.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 import click
 from logurich import get_logger
 from logurich.opt_click import click_logger_params
+from pydantic import BaseModel
 from rich.console import Console
 
 from cyvest import __version__
@@ -43,13 +45,23 @@ def _load_investigation(input_path: Path) -> dict[str, Any]:
         return json.load(handle)
 
 
-def _print_stats_overview(stats: dict[str, Any]) -> None:
+def _statistics_as_dict(stats: Mapping[str, Any] | BaseModel | None) -> dict[str, Any]:
+    """Return statistics as a plain dictionary for CLI rendering."""
+    if stats is None:
+        return {}
+    if isinstance(stats, BaseModel):
+        return stats.model_dump(mode="json")
+    return dict(stats)
+
+
+def _print_stats_overview(stats: Mapping[str, Any] | BaseModel | None) -> None:
     """Render a lightweight overview of statistics."""
-    if not stats:
+    stats_data = _statistics_as_dict(stats)
+    if not stats_data:
         logger.info("  No statistics available.")
         return
 
-    for key, value in stats.items():
+    for key, value in stats_data.items():
         if isinstance(value, dict):
             continue
         logger.info("  %s: %s", key, value)
@@ -57,7 +69,7 @@ def _print_stats_overview(stats: dict[str, Any]) -> None:
 
 def _write_markdown(data: dict[str, Any], output_path: Path) -> None:
     """Write a basic Markdown report derived from serialized data."""
-    stats = data.get("stats", {})
+    stats = _statistics_as_dict(data.get("stats", {}))
     score_value = data.get("score", None)
     try:
         score_display = "N/A" if score_value is None else f"{float(score_value):.2f}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,17 @@ def test_cli_stats_detailed(tmp_path: Path) -> None:
     assert result.exit_code == 0
 
 
+def test_cli_stats_overview_accepts_statistics_schema(tmp_path: Path) -> None:
+    """CLI 'stats' overview accepts the Pydantic statistics model returned by Cyvest."""
+    sample = _write_sample(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["stats", str(sample)])
+
+    assert result.exit_code == 0
+    assert result.exception is None
+
+
 def test_cli_export_writes_files(tmp_path: Path) -> None:
     """CLI 'export' command writes both JSON and Markdown outputs."""
     sample = _write_sample(tmp_path)


### PR DESCRIPTION
## Summary
- normalize CLI statistics inputs from mappings or Pydantic `BaseModel` instances before rendering output
- reuse the normalized statistics data for both the stats overview and Markdown export paths
- add CLI coverage for the stats overview flow when Cyvest returns the statistics schema model

## Testing
- updated `tests/test_cli.py` to cover the `cli stats` overview with the Pydantic-backed sample