### PR TITLE
Add observable canonicalisation resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,36 @@ process.relate_to(executable, cv.REL.RELATED_TO)
 with the same value and can be related explicitly. A process image path is modeled as `FILE/path`, not as a
 `PROCESS` subtype.
 
+You can also canonicalise identities at creation time with instance-local observable resolvers. Resolvers receive a
+source `ObservableAlias` and may return a canonical `ObservableIdentity`; Cyvest creates or merges the canonical
+observable and stores the source identity as an alias with counts.
+
+```python
+from cyvest import ObservableAlias, ObservableIdentity, ObservableResolver
+
+def resolve_user(alias: ObservableAlias) -> ObservableIdentity | None:
+    if alias.value.lower() != "alice@example.com":
+        return None
+    return ObservableIdentity(
+        obs_type=cv.OBS.USER,
+        subtype=cv.SUB.USER_UID,
+        namespace="okta",
+        value="123",
+    )
+
+cv.observable_resolver_register(
+    ObservableResolver(
+        name="okta-user-id",
+        source_types={(cv.OBS.USER, cv.SUB.USER_EMAIL)},
+        resolve=resolve_user,
+    )
+)
+
+user = cv.observable_create(cv.OBS.USER, "alice@example.com", subtype=cv.SUB.USER_EMAIL)
+assert user.subtype == cv.SUB.USER_UID
+assert user.aliases[0].subtype == cv.SUB.USER_EMAIL
+```
+
 ### Findings
 
 Findings represent verification steps in your investigation:

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -86,6 +86,87 @@ Use the facade namespace for autocomplete:
 obs = cv.observable(cv.OBS.URL, "https://example.com")
 ```
 
+### Observable canonicalisation
+
+Some raw identifiers describe the same real-world entity. For example, `USER/email alice@example.com` and
+`USER/username/windows alice` might both refer to the canonical Okta user `USER/uid/okta 123`.
+
+Register an instance-local resolver when you want `observable_create()` to resolve source identities before creating
+the observable:
+
+```python
+from cyvest import Cyvest, ObservableAlias, ObservableIdentity, ObservableResolver
+
+cv = Cyvest()
+
+def resolve_user_to_okta(alias: ObservableAlias) -> ObservableIdentity | None:
+    lookup = {
+        ("email", None, "alice@example.com"): "123",
+        ("username", "windows", "alice"): "123",
+    }
+    subtype = alias.subtype.value if hasattr(alias.subtype, "value") else alias.subtype
+    okta_uid = lookup.get((subtype, alias.namespace, alias.value.lower()))
+    if okta_uid is None:
+        return None
+
+    return ObservableIdentity(
+        obs_type=cv.OBS.USER,
+        subtype=cv.SUB.USER_UID,
+        namespace="okta",
+        value=okta_uid,
+    )
+
+cv.observable_resolver_register(
+    ObservableResolver(
+        name="okta-user-id",
+        source_types={
+            (cv.OBS.USER, cv.SUB.USER_EMAIL),
+            (cv.OBS.USER, cv.SUB.USER_USERNAME),
+        },
+        resolve=resolve_user_to_okta,
+    )
+)
+
+email = cv.observable_create(cv.OBS.USER, "alice@example.com", subtype=cv.SUB.USER_EMAIL)
+username = cv.observable_create(
+    cv.OBS.USER,
+    "alice",
+    subtype=cv.SUB.USER_USERNAME,
+    namespace="windows",
+)
+
+assert email.key == username.key
+assert email.subtype == cv.SUB.USER_UID
+assert email.namespace == "okta"
+assert email.value == "123"
+assert email.occurrence_count == 2
+```
+
+Resolvers are evaluated in registration order and the first non-`None` `ObservableIdentity` wins. Returning `None`
+means "not resolved", so Cyvest creates the source observable normally. Resolver exceptions are not swallowed.
+
+The source identities are stored on the canonical observable as typed aliases:
+
+```python
+for alias in email.aliases:
+    print(alias.obs_type, alias.subtype, alias.namespace, alias.value, alias.count)
+```
+
+`ObservableIdentity` is the canonical identity returned by a resolver. `ObservableAlias` is the source identity
+stored on the canonical observable, with a `count` for repeated occurrences. The canonical `Observable` also tracks
+`occurrence_count`, which is merged across repeated creations and investigation merges.
+
+Resolver registration is per `Cyvest` instance:
+
+```python
+cv.observable_resolver_get_all()
+cv.observable_resolver_unregister("okta-user-id")
+cv.observable_resolver_clear()
+```
+
+For async lookups, register `aresolve=` and use `await cv.observable_acreate(...)`. If a matching async resolver is
+registered, synchronous `observable_create()` raises a clear error instead of blocking the event loop.
+
 ### Findings
 
 **Findings** represent verification steps in your investigation:

--- a/js/packages/cyvest-app/src/investigations/cyvest_email.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_email.json
@@ -60,13 +60,15 @@
           }
         ]
       },
-      "score": 10.0,
+      "score": 10,
       "level": "MALICIOUS",
       "threat_intels": [],
       "relationships": [],
       "key": "obs:artifact:root",
       "finding_links": [],
-      "score_display": "10.00"
+      "score_display": "10.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:email:noreply@dmalicious.com": {
       "type": "email",
@@ -77,7 +79,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 5.0,
+      "score": 5,
       "level": "MALICIOUS",
       "threat_intels": [
         "ti:vt:obs:email:noreply@dmalicious.com",
@@ -100,7 +102,9 @@
         "fnd:from",
         "fnd:from-proofpoint"
       ],
-      "score_display": "5.00"
+      "score_display": "5.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:domain:dmalicious.com": {
       "type": "domain",
@@ -111,7 +115,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 2.0,
+      "score": 2,
       "level": "NOTABLE",
       "threat_intels": [
         "ti:vt:obs:domain:dmalicious.com"
@@ -125,7 +129,9 @@
       ],
       "key": "obs:domain:dmalicious.com",
       "finding_links": [],
-      "score_display": "2.00"
+      "score_display": "2.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:ipv4:8.1.2.3": {
       "type": "ipv4",
@@ -136,7 +142,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 2.0,
+      "score": 2,
       "level": "NOTABLE",
       "threat_intels": [
         "ti:abuseipdb:obs:ipv4:8.1.2.3"
@@ -144,7 +150,9 @@
       "relationships": [],
       "key": "obs:ipv4:8.1.2.3",
       "finding_links": [],
-      "score_display": "2.00"
+      "score_display": "2.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:email:user@company.com": {
       "type": "email",
@@ -155,7 +163,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 0.0,
+      "score": 0,
       "level": "INFO",
       "threat_intels": [],
       "relationships": [
@@ -169,7 +177,9 @@
       "finding_links": [
         "fnd:receiver"
       ],
-      "score_display": "0.00"
+      "score_display": "0.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:url:https://virus.com/payload.exe": {
       "type": "url",
@@ -180,7 +190,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 5.0,
+      "score": 5,
       "level": "MALICIOUS",
       "threat_intels": [
         "ti:vt:obs:url:https://virus.com/payload.exe"
@@ -196,7 +206,9 @@
       "finding_links": [
         "fnd:body-url-https://virus.com/payload.exe"
       ],
-      "score_display": "5.00"
+      "score_display": "5.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:domain:virus.com": {
       "type": "domain",
@@ -207,7 +219,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 5.0,
+      "score": 5,
       "level": "MALICIOUS",
       "threat_intels": [
         "ti:vt:obs:domain:virus.com"
@@ -223,7 +235,9 @@
       "finding_links": [
         "fnd:body-domain-virus.com"
       ],
-      "score_display": "5.00"
+      "score_display": "5.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:url:https://virus.com/about": {
       "type": "url",
@@ -234,7 +248,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 3.0,
+      "score": 3,
       "level": "SUSPICIOUS",
       "threat_intels": [
         "ti:vt:obs:url:https://virus.com/about"
@@ -250,7 +264,9 @@
       "finding_links": [
         "fnd:body-url-https://virus.com/about"
       ],
-      "score_display": "3.00"
+      "score_display": "3.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:url:https://domain.com/ok/toto": {
       "type": "url",
@@ -261,7 +277,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": -1.0,
+      "score": -1,
       "level": "TRUSTED",
       "threat_intels": [
         "ti:vt:obs:url:https://domain.com/ok/toto"
@@ -277,7 +293,9 @@
       "finding_links": [
         "fnd:body-url-https://domain.com/ok/toto"
       ],
-      "score_display": "-1.00"
+      "score_display": "-1.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:domain:domain.com": {
       "type": "domain",
@@ -288,7 +306,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 0.0,
+      "score": 0,
       "level": "INFO",
       "threat_intels": [
         "ti:vt:obs:domain:domain.com"
@@ -304,7 +322,9 @@
       "finding_links": [
         "fnd:body-domain-domain.com"
       ],
-      "score_display": "0.00"
+      "score_display": "0.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:file:body/html": {
       "type": "file",
@@ -315,7 +335,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 5.0,
+      "score": 5,
       "level": "MALICIOUS",
       "threat_intels": [],
       "relationships": [
@@ -327,7 +347,9 @@
       ],
       "key": "obs:file:body/html",
       "finding_links": [],
-      "score_display": "5.00"
+      "score_display": "5.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:file:invoice.pdf": {
       "type": "file",
@@ -338,7 +360,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 10.0,
+      "score": 10,
       "level": "MALICIOUS",
       "threat_intels": [
         "ti:malwarebazaar:obs:file:invoice.pdf"
@@ -359,7 +381,9 @@
       "finding_links": [
         "fnd:attachment-invoice.pdf"
       ],
-      "score_display": "10.00"
+      "score_display": "10.00",
+      "aliases": [],
+      "occurrence_count": 1
     },
     "obs:hash:md5:d41d8cd98f00b204e9800998ecf8427e": {
       "type": "hash",
@@ -370,7 +394,7 @@
       "whitelisted": false,
       "comment": "",
       "extra": {},
-      "score": 10.0,
+      "score": 10,
       "level": "MALICIOUS",
       "threat_intels": [
         "ti:vt:obs:hash:md5:d41d8cd98f00b204e9800998ecf8427e"
@@ -378,7 +402,9 @@
       "relationships": [],
       "key": "obs:hash:md5:d41d8cd98f00b204e9800998ecf8427e",
       "finding_links": [],
-      "score_display": "10.00"
+      "score_display": "10.00",
+      "aliases": [],
+      "occurrence_count": 1
     }
   },
   "findings": {
@@ -387,7 +413,7 @@
       "description": "test email vt 10",
       "comment": "> ok boys",
       "extra": {},
-      "score": 2.0,
+      "score": 2,
       "level": "NOTABLE",
       "origin_investigation_id": "fragment-emailfrom",
       "observable_links": [
@@ -405,7 +431,7 @@
       "description": "test email vt 10",
       "comment": "> ok boys",
       "extra": {},
-      "score": 5.0,
+      "score": 5,
       "level": "MALICIOUS",
       "origin_investigation_id": "fragment-emailfrombis",
       "observable_links": [
@@ -441,7 +467,7 @@
       "description": "URL analysis https://virus.com/payload.exe",
       "comment": "> score: 5",
       "extra": {},
-      "score": 5.0,
+      "score": 5,
       "level": "MALICIOUS",
       "origin_investigation_id": "fragment-bodiesurltask",
       "observable_links": [
@@ -459,7 +485,7 @@
       "description": "URL analysis https://virus.com/about",
       "comment": "> score: 3",
       "extra": {},
-      "score": 3.0,
+      "score": 3,
       "level": "SUSPICIOUS",
       "origin_investigation_id": "fragment-bodiesurltask",
       "observable_links": [
@@ -477,7 +503,7 @@
       "description": "URL analysis https://domain.com/ok/toto",
       "comment": "> score: -1",
       "extra": {},
-      "score": 0.0,
+      "score": 0,
       "level": "INFO",
       "origin_investigation_id": "fragment-bodiesurltask",
       "observable_links": [
@@ -495,7 +521,7 @@
       "description": "Domain analysis virus.com",
       "comment": "> score: 3",
       "extra": {},
-      "score": 5.0,
+      "score": 5,
       "level": "MALICIOUS",
       "origin_investigation_id": "fragment-bodiesdomaintask",
       "observable_links": [
@@ -513,7 +539,7 @@
       "description": "Domain analysis domain.com",
       "comment": "> score: 0",
       "extra": {},
-      "score": 0.0,
+      "score": 0,
       "level": "INFO",
       "origin_investigation_id": "fragment-bodiesdomaintask",
       "observable_links": [
@@ -531,7 +557,7 @@
       "description": "File: invoice.pdf (1024 bytes)",
       "comment": "> MD5: d41d8cd98f00b204e9800998ecf8427e\n> SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n> Threat score: 10",
       "extra": {},
-      "score": 10.0,
+      "score": 10,
       "level": "MALICIOUS",
       "origin_investigation_id": "fragment-attachmenttask",
       "observable_links": [
@@ -549,7 +575,7 @@
       "description": "Aggregated Email Risk Assessment",
       "comment": "> **Aggregated Risk Assessment**\n> Total risk score: 6.0\n> Indicators analyzed: 2\n>\n> **Risk Factors:**\n> - Suspicious URLs detected (max score: 5)\n> - Malicious attachment detected (score: 10)\n>\n> **Component Analysis:**\n> - Header findings: 2\n> - URL findings: 3\n> - Attachment findings: 2\n",
       "extra": {},
-      "score": 6.0,
+      "score": 6,
       "level": "MALICIOUS",
       "origin_investigation_id": "fragment-aggregatedrisktask",
       "observable_links": [],
@@ -562,7 +588,7 @@
       "description": "AI Analysis",
       "comment": "",
       "extra": {},
-      "score": 0.0,
+      "score": 0,
       "level": "MALICIOUS",
       "origin_investigation_id": "fragment-ai",
       "observable_links": [],
@@ -578,7 +604,7 @@
       "observable_key": "obs:domain:dmalicious.com",
       "comment": "",
       "extra": {},
-      "score": 1.0,
+      "score": 1,
       "level": "NOTABLE",
       "taxonomies": [],
       "key": "ti:vt:obs:domain:dmalicious.com",
@@ -589,7 +615,7 @@
       "observable_key": "obs:ipv4:8.1.2.3",
       "comment": "",
       "extra": {},
-      "score": 2.0,
+      "score": 2,
       "level": "NOTABLE",
       "taxonomies": [],
       "key": "ti:abuseipdb:obs:ipv4:8.1.2.3",
@@ -600,7 +626,7 @@
       "observable_key": "obs:email:noreply@dmalicious.com",
       "comment": "> test",
       "extra": {},
-      "score": 0.0,
+      "score": 0,
       "level": "INFO",
       "taxonomies": [],
       "key": "ti:vt:obs:email:noreply@dmalicious.com",
@@ -611,7 +637,7 @@
       "observable_key": "obs:email:noreply@dmalicious.com",
       "comment": "> test",
       "extra": {},
-      "score": 5.0,
+      "score": 5,
       "level": "MALICIOUS",
       "taxonomies": [],
       "key": "ti:proofpoint:obs:email:noreply@dmalicious.com",
@@ -622,7 +648,7 @@
       "observable_key": "obs:url:https://virus.com/payload.exe",
       "comment": "",
       "extra": {},
-      "score": 5.0,
+      "score": 5,
       "level": "MALICIOUS",
       "taxonomies": [],
       "key": "ti:vt:obs:url:https://virus.com/payload.exe",
@@ -633,7 +659,7 @@
       "observable_key": "obs:url:https://virus.com/about",
       "comment": "",
       "extra": {},
-      "score": 3.0,
+      "score": 3,
       "level": "SUSPICIOUS",
       "taxonomies": [],
       "key": "ti:vt:obs:url:https://virus.com/about",
@@ -644,7 +670,7 @@
       "observable_key": "obs:url:https://domain.com/ok/toto",
       "comment": "",
       "extra": {},
-      "score": -1.0,
+      "score": -1,
       "level": "TRUSTED",
       "taxonomies": [],
       "key": "ti:vt:obs:url:https://domain.com/ok/toto",
@@ -655,7 +681,7 @@
       "observable_key": "obs:domain:virus.com",
       "comment": "",
       "extra": {},
-      "score": 3.0,
+      "score": 3,
       "level": "SUSPICIOUS",
       "taxonomies": [],
       "key": "ti:vt:obs:domain:virus.com",
@@ -666,7 +692,7 @@
       "observable_key": "obs:domain:domain.com",
       "comment": "",
       "extra": {},
-      "score": 0.0,
+      "score": 0,
       "level": "INFO",
       "taxonomies": [],
       "key": "ti:vt:obs:domain:domain.com",
@@ -677,7 +703,7 @@
       "observable_key": "obs:hash:md5:d41d8cd98f00b204e9800998ecf8427e",
       "comment": "MD5 hash analysis",
       "extra": {},
-      "score": 10.0,
+      "score": 10,
       "level": "MALICIOUS",
       "taxonomies": [],
       "key": "ti:vt:obs:hash:md5:d41d8cd98f00b204e9800998ecf8427e",
@@ -688,7 +714,7 @@
       "observable_key": "obs:file:invoice.pdf",
       "comment": "Known malware: invoice.pdf",
       "extra": {},
-      "score": 10.0,
+      "score": 10,
       "level": "MALICIOUS",
       "taxonomies": [],
       "key": "ti:malwarebazaar:obs:file:invoice.pdf",
@@ -725,7 +751,7 @@
       "description": "",
       "findings": [],
       "key": "tag:bodies",
-      "direct_score": 0.0,
+      "direct_score": 0,
       "direct_level": "INFO"
     },
     "tag:bodies:urls": {
@@ -737,7 +763,7 @@
         "fnd:body-url-https://domain.com/ok/toto"
       ],
       "key": "tag:bodies:urls",
-      "direct_score": 8.0,
+      "direct_score": 8,
       "direct_level": "MALICIOUS"
     },
     "tag:bodies:domains": {
@@ -748,7 +774,7 @@
         "fnd:body-domain-domain.com"
       ],
       "key": "tag:bodies:domains",
-      "direct_score": 5.0,
+      "direct_score": 5,
       "direct_level": "MALICIOUS"
     },
     "tag:attachments": {
@@ -758,7 +784,7 @@
         "fnd:attachment-invoice.pdf"
       ],
       "key": "tag:attachments",
-      "direct_score": 10.0,
+      "direct_score": 10,
       "direct_level": "MALICIOUS"
     },
     "tag:risk_assessment": {
@@ -768,7 +794,7 @@
         "fnd:email_risk_aggregated"
       ],
       "key": "tag:risk_assessment",
-      "direct_score": 6.0,
+      "direct_score": 6,
       "direct_level": "MALICIOUS"
     },
     "tag:risk_assessment:ai": {
@@ -778,7 +804,7 @@
         "fnd:ai"
       ],
       "key": "tag:risk_assessment:ai",
-      "direct_score": 0.0,
+      "direct_score": 0,
       "direct_level": "INFO"
     }
   },

--- a/js/packages/cyvest-app/src/investigations/cyvest_visual.json
+++ b/js/packages/cyvest-app/src/investigations/cyvest_visual.json
@@ -19,6 +19,8 @@
       "extra": {},
       "score": 0.0,
       "level": "INFO",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [],
       "relationships": [
         {
@@ -57,6 +59,8 @@
       "extra": {},
       "score": 9.0,
       "level": "MALICIOUS",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:virustotal:obs:domain:evil-phishing.com",
         "ti:alienvault otx:obs:domain:evil-phishing.com"
@@ -79,6 +83,8 @@
       "extra": {},
       "score": 9.5,
       "level": "MALICIOUS",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:abuseipdb:obs:ipv4:185.220.101.50"
       ],
@@ -106,6 +112,8 @@
       "extra": {},
       "score": 4.5,
       "level": "SUSPICIOUS",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:virustotal:obs:domain:sketchy-site.net"
       ],
@@ -131,6 +139,8 @@
       "extra": {},
       "score": 3.0,
       "level": "SUSPICIOUS",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:shodan:obs:ipv4:192.168.100.5"
       ],
@@ -150,6 +160,8 @@
       "extra": {},
       "score": 8.0,
       "level": "MALICIOUS",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:emailrep:obs:email:attacker@evil-phishing.com"
       ],
@@ -177,6 +189,8 @@
       "extra": {},
       "score": -1.0,
       "level": "TRUSTED",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:internal whitelist:obs:email:victim@company.com"
       ],
@@ -198,6 +212,8 @@
       "extra": {},
       "score": 10.0,
       "level": "MALICIOUS",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:email gateway:obs:artifact:phishing email - invoice #12345"
       ],
@@ -240,6 +256,8 @@
       "extra": {},
       "score": 10.0,
       "level": "MALICIOUS",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:urlhaus:obs:url:https://evil-phishing.com/login"
       ],
@@ -267,6 +285,8 @@
       "extra": {},
       "score": 9.0,
       "level": "MALICIOUS",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:urlhaus:obs:url:https://evil-phishing.com/verify"
       ],
@@ -294,6 +314,8 @@
       "extra": {},
       "score": 10.0,
       "level": "MALICIOUS",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:virustotal:obs:file:invoice.exe"
       ],
@@ -326,6 +348,8 @@
       "extra": {},
       "score": -2.0,
       "level": "TRUSTED",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:internal whitelist:obs:domain:google.com"
       ],
@@ -345,6 +369,8 @@
       "extra": {},
       "score": 2.0,
       "level": "NOTABLE",
+      "aliases": [],
+      "occurrence_count": 1,
       "threat_intels": [
         "ti:passive dns:obs:domain:new-service.cloud"
       ],

--- a/js/packages/cyvest-js/src/types.generated.ts
+++ b/js/packages/cyvest-js/src/types.generated.ts
@@ -26,6 +26,9 @@ export type ObjectType = string | null;
 export type ObjectKey = string | null;
 export type Subtype = string | null;
 export type Namespace = string | null;
+export type Subtype1 = string | null;
+export type Namespace1 = string | null;
+export type Aliases = ObservableAlias[];
 export type ThreatIntels = string[];
 /**
  * Direction of a relationship between observables.
@@ -150,6 +153,8 @@ export interface Observable {
   extra: Extra;
   score: number;
   level: Level;
+  aliases: Aliases;
+  occurrence_count?: number;
   threat_intels: ThreatIntels;
   relationships: Relationships;
   key: string;
@@ -158,6 +163,17 @@ export interface Observable {
   [k: string]: unknown;
 }
 export interface Extra {
+  [k: string]: unknown;
+}
+/**
+ * Source observable identity attached to a canonical observable.
+ */
+export interface ObservableAlias {
+  type: string;
+  subtype?: Subtype1;
+  namespace?: Namespace1;
+  value: string;
+  count?: number;
   [k: string]: unknown;
 }
 /**

--- a/schema/cyvest.schema.json
+++ b/schema/cyvest.schema.json
@@ -432,6 +432,19 @@
         "level": {
           "$ref": "#/$defs/Level"
         },
+        "aliases": {
+          "items": {
+            "$ref": "#/$defs/ObservableAlias"
+          },
+          "title": "Aliases",
+          "type": "array"
+        },
+        "occurrence_count": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Occurrence Count",
+          "type": "integer"
+        },
         "threat_intels": {
           "items": {
             "type": "string"
@@ -474,6 +487,7 @@
         "extra",
         "score",
         "level",
+        "aliases",
         "threat_intels",
         "relationships",
         "key",
@@ -481,6 +495,54 @@
         "score_display"
       ],
       "title": "Observable",
+      "type": "object"
+    },
+    "ObservableAlias": {
+      "description": "Source observable identity attached to a canonical observable.",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "type": "string"
+        },
+        "subtype": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Subtype"
+        },
+        "namespace": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Namespace"
+        },
+        "value": {
+          "title": "Value",
+          "type": "string"
+        },
+        "count": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "title": "ObservableAlias",
       "type": "object"
     },
     "ObservableLink": {

--- a/src/cyvest/__init__.py
+++ b/src/cyvest/__init__.py
@@ -15,9 +15,21 @@ from cyvest.compare import (
 )
 from cyvest.cyvest import Cyvest
 from cyvest.levels import Level
-from cyvest.model import Enrichment, Evidence, Finding, InvestigationWhitelist, Observable, Tag, Taxonomy, ThreatIntel
+from cyvest.model import (
+    Enrichment,
+    Evidence,
+    Finding,
+    InvestigationWhitelist,
+    Observable,
+    ObservableAlias,
+    ObservableIdentity,
+    Tag,
+    Taxonomy,
+    ThreatIntel,
+)
 from cyvest.model_enums import ObservableSubtype, ObservableType, RelationshipDirection, RelationshipType
 from cyvest.proxies import EnrichmentProxy, EvidenceProxy, FindingProxy, ObservableProxy, TagProxy, ThreatIntelProxy
+from cyvest.resolvers import ObservableResolver
 
 __version__ = "6.0.0"
 
@@ -44,6 +56,9 @@ __all__ = [
     "Finding",
     "Evidence",
     "Observable",
+    "ObservableAlias",
+    "ObservableIdentity",
+    "ObservableResolver",
     "ThreatIntel",
     "Taxonomy",
     # Comparison module

--- a/src/cyvest/cyvest.py
+++ b/src/cyvest/cyvest.py
@@ -41,7 +41,18 @@ from cyvest.io_serialization import (
 )
 from cyvest.io_visualization import generate_network_graph
 from cyvest.levels import Level
-from cyvest.model import Enrichment, Evidence, Finding, Observable, Tag, Taxonomy, ThreatIntel, round_score_decimal
+from cyvest.model import (
+    Enrichment,
+    Evidence,
+    Finding,
+    Observable,
+    ObservableAlias,
+    ObservableIdentity,
+    Tag,
+    Taxonomy,
+    ThreatIntel,
+    round_score_decimal,
+)
 from cyvest.model_enums import (
     ObservableSubtype,
     ObservableType,
@@ -51,6 +62,7 @@ from cyvest.model_enums import (
 )
 from cyvest.model_schema import InvestigationSchema, StatisticsSchema
 from cyvest.proxies import EnrichmentProxy, EvidenceProxy, FindingProxy, ObservableProxy, TagProxy, ThreatIntelProxy
+from cyvest.resolvers import ObservableResolver
 from cyvest.score import ScoreMode
 
 if TYPE_CHECKING:
@@ -99,6 +111,7 @@ class Cyvest:
             investigation_name=investigation_name,
             investigation_id=investigation_id,
         )
+        self._observable_resolvers: list[ObservableResolver] = []
 
     # Internal helpers
 
@@ -229,6 +242,150 @@ class Cyvest:
 
     # Observable methods
 
+    @staticmethod
+    def _normalized_source_type(
+        obs_type: ObservableType | str,
+        subtype: ObservableSubtype | str | None,
+    ) -> tuple[str, str | None]:
+        normalized_type = obs_type.value if isinstance(obs_type, ObservableType) else str(obs_type).strip().lower()
+        normalized_subtype = subtype.value if isinstance(subtype, ObservableSubtype) else subtype
+        if isinstance(normalized_subtype, str):
+            normalized_subtype = normalized_subtype.strip().lower()
+        return normalized_type, normalized_subtype
+
+    @classmethod
+    def _resolver_applies(cls, resolver: ObservableResolver, alias: ObservableAlias) -> bool:
+        alias_source_type = cls._normalized_source_type(alias.obs_type, alias.subtype)
+        return any(
+            cls._normalized_source_type(obs_type, subtype) == alias_source_type
+            for obs_type, subtype in resolver.source_types
+        )
+
+    @staticmethod
+    def _observable_kwargs_from_identity(
+        identity: ObservableIdentity,
+        *,
+        internal: bool,
+        whitelisted: bool,
+        comment: str,
+        extra: dict[str, Any],
+        score: Decimal | float | None,
+        level: Level | None,
+        aliases: list[ObservableAlias] | None = None,
+    ) -> dict[str, Any]:
+        obs_kwargs: dict[str, Any] = {
+            "obs_type": identity.obs_type,
+            "subtype": identity.subtype,
+            "namespace": identity.namespace,
+            "value": identity.value,
+            "internal": internal,
+            "whitelisted": whitelisted,
+            "comment": comment,
+            "extra": extra,
+            "aliases": aliases or [],
+        }
+        if score is not None:
+            obs_kwargs["score"] = Decimal(str(score))
+        if level is not None:
+            obs_kwargs["level"] = level
+        return obs_kwargs
+
+    def observable_resolver_register(self, resolver: ObservableResolver, *, replace: bool = False) -> None:
+        """Register an instance-local observable identity resolver."""
+        if not isinstance(resolver, ObservableResolver):
+            raise TypeError("resolver must be an ObservableResolver.")
+        existing_idx = next(
+            (idx for idx, item in enumerate(self._observable_resolvers) if item.name == resolver.name),
+            None,
+        )
+        if existing_idx is not None:
+            if not replace:
+                raise ValueError(f"Observable resolver '{resolver.name}' is already registered.")
+            self._observable_resolvers[existing_idx] = resolver
+            return
+        self._observable_resolvers.append(resolver)
+
+    def observable_resolver_unregister(self, name: str) -> bool:
+        """Unregister an observable identity resolver by name."""
+        normalized_name = name.strip()
+        for idx, resolver in enumerate(self._observable_resolvers):
+            if resolver.name == normalized_name:
+                del self._observable_resolvers[idx]
+                return True
+        return False
+
+    def observable_resolver_clear(self) -> None:
+        """Remove all instance-local observable identity resolvers."""
+        self._observable_resolvers.clear()
+
+    def observable_resolver_get_all(self) -> tuple[ObservableResolver, ...]:
+        """Return registered observable identity resolvers in evaluation order."""
+        return tuple(self._observable_resolvers)
+
+    def _resolve_observable_identity_sync(self, alias: ObservableAlias) -> ObservableIdentity | None:
+        for resolver in self._observable_resolvers:
+            if self._resolver_applies(resolver, alias) and resolver.aresolve is not None:
+                raise RuntimeError(
+                    f"Observable resolver '{resolver.name}' is async; use 'await cv.observable_acreate(...)'."
+                )
+        for resolver in self._observable_resolvers:
+            if not self._resolver_applies(resolver, alias):
+                continue
+            if resolver.resolve is None:
+                continue
+            resolved = resolver.resolve(alias)
+            if resolved is not None:
+                return ObservableIdentity.model_validate(resolved)
+        return None
+
+    async def _resolve_observable_identity_async(self, alias: ObservableAlias) -> ObservableIdentity | None:
+        for resolver in self._observable_resolvers:
+            if not self._resolver_applies(resolver, alias):
+                continue
+            resolved: ObservableIdentity | None = None
+            if resolver.resolve is not None:
+                resolved = resolver.resolve(alias)
+            elif resolver.aresolve is not None:
+                resolved = await resolver.aresolve(alias)
+            if resolved is not None:
+                return ObservableIdentity.model_validate(resolved)
+        return None
+
+    def _observable_create_from_resolved_identity(
+        self,
+        *,
+        alias: ObservableAlias,
+        identity: ObservableIdentity | None,
+        internal: bool,
+        whitelisted: bool,
+        comment: str,
+        extra: dict[str, Any] | None,
+        score: Decimal | float | None,
+        level: Level | None,
+    ) -> ObservableProxy:
+        source_identity = ObservableIdentity(
+            obs_type=alias.obs_type,
+            subtype=alias.subtype,
+            namespace=alias.namespace,
+            value=alias.value,
+        )
+        canonical_identity = identity or source_identity
+        aliases = [alias] if identity is not None else []
+        obs = Observable(
+            **self._observable_kwargs_from_identity(
+                canonical_identity,
+                internal=internal,
+                whitelisted=whitelisted,
+                comment=comment,
+                extra=extra or {},
+                score=score,
+                level=level,
+                aliases=aliases,
+            )
+        )
+        obs_result, _ = self._investigation.add_observable(obs)
+        return self._observable_proxy(obs_result)
+
     def observable_create(
         self,
         obs_type: ObservableType | str,
@@ -258,24 +415,45 @@ class Cyvest:
         Returns:
             The created or existing observable
         """
-        obs_kwargs: dict[str, Any] = {
-            "obs_type": obs_type,
-            "subtype": subtype,
-            "namespace": namespace,
-            "value": value,
-            "internal": internal,
-            "whitelisted": whitelisted,
-            "comment": comment,
-            "extra": extra or {},
-        }
-        if score is not None:
-            obs_kwargs["score"] = Decimal(str(score))
-        if level is not None:
-            obs_kwargs["level"] = level
-        obs = Observable(**obs_kwargs)
-        # Unwrap tuple - facade returns only Observable, discards deferred relationships
-        obs_result, _ = self._investigation.add_observable(obs)
-        return self._observable_proxy(obs_result)
+        alias = ObservableAlias(obs_type=obs_type, subtype=subtype, namespace=namespace, value=value)
+        identity = self._resolve_observable_identity_sync(alias)
+        return self._observable_create_from_resolved_identity(
+            alias=alias,
+            identity=identity,
+            internal=internal,
+            whitelisted=whitelisted,
+            comment=comment,
+            extra=extra,
+            score=score,
+            level=level,
+        )
+
+    async def observable_acreate(
+        self,
+        obs_type: ObservableType | str,
+        value: str,
+        subtype: ObservableSubtype | str | None = None,
+        namespace: str | None = None,
+        internal: bool = False,
+        whitelisted: bool = False,
+        comment: str = "",
+        extra: dict[str, Any] | None = None,
+        score: Decimal | float | None = None,
+        level: Level | None = None,
+    ) -> ObservableProxy:
+        """Async variant of observable_create supporting async resolvers."""
+        alias = ObservableAlias(obs_type=obs_type, subtype=subtype, namespace=namespace, value=value)
+        identity = await self._resolve_observable_identity_async(alias)
+        return self._observable_create_from_resolved_identity(
+            alias=alias,
+            identity=identity,
+            internal=internal,
+            whitelisted=whitelisted,
+            comment=comment,
+            extra=extra,
+            score=score,
+            level=level,
+        )
 
     @overload
     def observable_get(self, key: str) -> ObservableProxy | None:

--- a/src/cyvest/investigation.py
+++ b/src/cyvest/investigation.py
@@ -438,6 +438,17 @@ class Investigation:
         # Merge internal status (if either is external, result is external)
         existing.internal = existing.internal and incoming.internal
 
+        # Merge occurrence and alias counts.
+        existing.occurrence_count += incoming.occurrence_count
+        existing_aliases = {alias.identity_tuple: alias for alias in existing.aliases}
+        for alias in incoming.aliases:
+            existing_alias = existing_aliases.get(alias.identity_tuple)
+            if existing_alias is None:
+                existing.aliases.append(alias.model_copy(deep=True))
+                existing_aliases[alias.identity_tuple] = existing.aliases[-1]
+            else:
+                existing_alias.count += alias.count
+
         # Merge threat intels (avoid duplicates by key)
         existing_ti_keys = {ti.key for ti in existing.threat_intels}
         for ti in incoming.threat_intels:

--- a/src/cyvest/io_serialization.py
+++ b/src/cyvest/io_serialization.py
@@ -354,6 +354,8 @@ def load_investigation_dict(data: dict[str, Any]) -> Cyvest:
             "extra": obs_info.get("extra", {}),
             "score": Decimal(str(obs_info.get("score", 0))),
             "level": obs_info.get("level", "INFO"),
+            "aliases": obs_info.get("aliases", []),
+            "occurrence_count": obs_info.get("occurrence_count", 1),
             "key": obs_info.get("key", ""),
             "relationships": [Relationship.model_validate(rel) for rel in obs_info.get("relationships", [])],
         }
@@ -373,11 +375,16 @@ def load_investigation_dict(data: dict[str, Any]) -> Cyvest:
             "extra": root_obs_info.get("extra", root_data),
             "score": Decimal(str(root_obs_info.get("score", 0))),
             "level": root_obs_info.get("level", "INFO"),
+            "aliases": root_obs_info.get("aliases", []),
+            "occurrence_count": root_obs_info.get("occurrence_count", 1),
             "key": new_root_key,
             "relationships": [Relationship.model_validate(rel) for rel in root_obs_info.get("relationships", [])],
         }
         root_obs = Observable.model_validate(root_data)
-        cv._investigation.add_observable(root_obs)
+        merged_root, _ = cv._investigation.add_observable(root_obs)
+        # Loading merges serialized root data into the fresh root created by Cyvest().
+        # Preserve the serialized occurrence count instead of counting the loader-created root.
+        merged_root.occurrence_count = root_obs.occurrence_count
 
     # Threat intel - leverage Pydantic model_validate
     for ti_info in data.get("threat_intels", {}).values():

--- a/src/cyvest/model.py
+++ b/src/cyvest/model.py
@@ -276,6 +276,64 @@ class ThreatIntel(BaseModel):
         return _format_score_decimal(self.score)
 
 
+class _ObservableIdentityBase(AliasDumpModel):
+    """Shared typed observable identity fields."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
+
+    obs_type: ObservableType | str = Field(..., alias="type")
+    subtype: ObservableSubtype | str | None = Field(default=None)
+    namespace: str | None = Field(default=None)
+    value: str = Field(...)
+
+    @field_validator("obs_type", mode="before")
+    @classmethod
+    def coerce_obs_type(cls, v: Any) -> ObservableType | str:
+        return Observable.coerce_obs_type(v)
+
+    @field_validator("subtype", mode="before")
+    @classmethod
+    def coerce_subtype(cls, v: Any) -> ObservableSubtype | str | None:
+        return Observable.coerce_subtype(v)
+
+    @field_validator("namespace", mode="before")
+    @classmethod
+    def coerce_namespace(cls, v: Any) -> str | None:
+        return Observable.coerce_namespace(v)
+
+    @model_validator(mode="after")
+    def validate_identity(self) -> Self:
+        Observable(
+            obs_type=self.obs_type,
+            subtype=self.subtype,
+            namespace=self.namespace,
+            value=self.value,
+        )
+        return self
+
+    @property
+    def identity_tuple(self) -> tuple[ObservableType | str, ObservableSubtype | str | None, str | None, str]:
+        return (self.obs_type, self.subtype, self.namespace, self.value)
+
+    @field_serializer("obs_type")
+    def serialize_obs_type(self, v: ObservableType | str) -> str:
+        return v.value if isinstance(v, ObservableType) else v
+
+    @field_serializer("subtype")
+    def serialize_subtype(self, v: ObservableSubtype | str | None) -> str | None:
+        return v.value if isinstance(v, ObservableSubtype) else v
+
+
+class ObservableIdentity(_ObservableIdentityBase):
+    """Canonical observable identity returned by observable resolvers."""
+
+
+class ObservableAlias(_ObservableIdentityBase):
+    """Source observable identity attached to a canonical observable."""
+
+    count: int = Field(default=1, ge=1)
+
+
 class Observable(AliasDumpModel):
     """
     Represents a cyber observable (IP, URL, domain, hash, etc.).
@@ -296,6 +354,8 @@ class Observable(AliasDumpModel):
     extra: dict[str, Any] = Field(...)
     score: Decimal = Field(...)
     level: Level = Field(...)
+    aliases: list[ObservableAlias] = Field(...)
+    occurrence_count: int = Field(default=1, ge=1)
     threat_intels: list[ThreatIntel] = Field(...)
     relationships: list[Relationship] = Field(...)
     key: str = Field(...)
@@ -375,6 +435,10 @@ class Observable(AliasDumpModel):
             values["threat_intels"] = []
         if "relationships" not in values:
             values["relationships"] = []
+        if "aliases" not in values:
+            values["aliases"] = []
+        if "occurrence_count" not in values:
+            values["occurrence_count"] = 1
         if "key" not in values:
             values["key"] = ""
         return values
@@ -432,6 +496,20 @@ class Observable(AliasDumpModel):
                 namespace=self.namespace,
             )
 
+        return self
+
+    @model_validator(mode="after")
+    def dedupe_aliases(self) -> Self:
+        alias_key_type = tuple[ObservableType | str, ObservableSubtype | str | None, str | None, str]
+        aliases_by_key: dict[alias_key_type, ObservableAlias] = {}
+        for alias in self.aliases:
+            alias_key = alias.identity_tuple
+            existing = aliases_by_key.get(alias_key)
+            if existing is None:
+                aliases_by_key[alias_key] = alias
+            else:
+                existing.count += alias.count
+        self.aliases = list(aliases_by_key.values())
         return self
 
     @field_serializer("obs_type")

--- a/src/cyvest/proxies.py
+++ b/src/cyvest/proxies.py
@@ -22,6 +22,7 @@ from cyvest.model import (
     EvidenceLink,
     Finding,
     Observable,
+    ObservableAlias,
     ObservableLink,
     ObservableSubtype,
     ObservableType,
@@ -144,6 +145,14 @@ class ObservableProxy(_ReadOnlyProxy[Observable]):
     @property
     def level(self) -> Level:
         return self._read_attr("level")
+
+    @property
+    def aliases(self) -> list[ObservableAlias]:
+        return self._read_attr("aliases")
+
+    @property
+    def occurrence_count(self) -> int:
+        return self._read_attr("occurrence_count")
 
     @property
     def threat_intels(self) -> list[ThreatIntel]:

--- a/src/cyvest/resolvers.py
+++ b/src/cyvest/resolvers.py
@@ -1,0 +1,31 @@
+"""Observable identity resolver types."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from cyvest.model import ObservableAlias, ObservableIdentity
+from cyvest.model_enums import ObservableSubtype, ObservableType
+
+ObservableSourceType = tuple[ObservableType | str, ObservableSubtype | str | None]
+
+
+@dataclass(frozen=True)
+class ObservableResolver:
+    """Resolve source observable identities to canonical observable identities."""
+
+    name: str
+    source_types: set[ObservableSourceType]
+    resolve: Callable[[ObservableAlias], ObservableIdentity | None] | None = None
+    aresolve: Callable[[ObservableAlias], Awaitable[ObservableIdentity | None]] | None = None
+
+    def __post_init__(self) -> None:
+        name = self.name.strip()
+        if not name:
+            raise ValueError("ObservableResolver name must not be empty.")
+        if not self.source_types:
+            raise ValueError("ObservableResolver source_types must not be empty.")
+        if self.resolve is None and self.aresolve is None:
+            raise ValueError("ObservableResolver requires resolve or aresolve.")
+        object.__setattr__(self, "name", name)

--- a/tests/test_observable_resolvers.py
+++ b/tests/test_observable_resolvers.py
@@ -1,0 +1,230 @@
+"""Tests for Cyvest observable identity resolvers."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cyvest import Cyvest, ObservableAlias, ObservableIdentity, ObservableResolver
+
+
+def _okta_identity(value: str = "123") -> ObservableIdentity:
+    return ObservableIdentity(
+        obs_type=Cyvest.OBS.USER,
+        subtype=Cyvest.SUB.USER_UID,
+        namespace="okta",
+        value=value,
+    )
+
+
+def _resolver(name: str, resolved: ObservableIdentity | None) -> ObservableResolver:
+    return ObservableResolver(
+        name=name,
+        source_types={
+            (Cyvest.OBS.USER, Cyvest.SUB.USER_EMAIL),
+            (Cyvest.OBS.USER, Cyvest.SUB.USER_USERNAME),
+        },
+        resolve=lambda alias: resolved,
+    )
+
+
+def test_observable_alias_and_identity_validation() -> None:
+    alias = ObservableAlias(
+        obs_type="USER",
+        subtype="EMAIL",
+        value="Alice@Example.COM",
+    )
+    identity = ObservableIdentity(
+        obs_type=Cyvest.OBS.USER,
+        subtype=Cyvest.SUB.USER_UID,
+        namespace="okta",
+        value="123",
+    )
+
+    assert alias.obs_type == Cyvest.OBS.USER
+    assert alias.subtype == Cyvest.SUB.USER_EMAIL
+    assert alias.namespace is None
+    assert alias.count == 1
+    assert identity.obs_type == Cyvest.OBS.USER
+
+    with pytest.raises(ValueError, match="requires a namespace"):
+        ObservableAlias(obs_type=Cyvest.OBS.USER, subtype=Cyvest.SUB.USER_USERNAME, value="alice")
+
+
+def test_sync_resolver_canonicalizes_aliases_and_counts() -> None:
+    cv = Cyvest()
+    cv.observable_resolver_register(_resolver("okta-user-id", _okta_identity()))
+
+    email_obs = cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+    username_obs = cv.observable_create(
+        Cyvest.OBS.USER,
+        "alice",
+        subtype=Cyvest.SUB.USER_USERNAME,
+        namespace="windows",
+    )
+
+    assert email_obs.key == username_obs.key
+    assert email_obs.subtype == Cyvest.SUB.USER_UID
+    assert email_obs.namespace == "okta"
+    assert email_obs.value == "123"
+    assert email_obs.occurrence_count == 2
+    assert len(email_obs.aliases) == 2
+    alias_keys = {
+        (alias.obs_type, alias.subtype, alias.namespace, alias.value, alias.count)
+        for alias in email_obs.aliases
+    }
+    assert (Cyvest.OBS.USER, Cyvest.SUB.USER_EMAIL, None, "alice@example.com", 1) in alias_keys
+    assert (Cyvest.OBS.USER, Cyvest.SUB.USER_USERNAME, "windows", "alice", 1) in alias_keys
+
+    non_root_observables = [obs for obs in cv.observable_get_all().values() if obs.value != "root"]
+    assert len(non_root_observables) == 1
+
+
+def test_resolver_fallback_creates_source_observable() -> None:
+    cv = Cyvest()
+    cv.observable_resolver_register(_resolver("missing-okta-user", None))
+
+    obs = cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+
+    assert obs.obs_type == Cyvest.OBS.USER
+    assert obs.subtype == Cyvest.SUB.USER_EMAIL
+    assert obs.value == "alice@example.com"
+    assert obs.aliases == []
+    assert obs.occurrence_count == 1
+
+
+def test_resolver_ordering_first_non_none_wins() -> None:
+    cv = Cyvest()
+    cv.observable_resolver_register(_resolver("first", _okta_identity("123")))
+    cv.observable_resolver_register(_resolver("second", _okta_identity("456")))
+
+    obs = cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+
+    assert obs.value == "123"
+
+
+def test_resolver_registration_is_per_instance_and_replaceable() -> None:
+    cv1 = Cyvest()
+    cv2 = Cyvest()
+    cv1.observable_resolver_register(_resolver("okta", _okta_identity("123")))
+
+    assert [resolver.name for resolver in cv1.observable_resolver_get_all()] == ["okta"]
+    assert cv2.observable_resolver_get_all() == ()
+
+    with pytest.raises(ValueError, match="already registered"):
+        cv1.observable_resolver_register(_resolver("okta", _okta_identity("456")))
+
+    cv1.observable_resolver_register(_resolver("okta", _okta_identity("456")), replace=True)
+    assert cv1.observable_resolver_unregister("okta") is True
+    assert cv1.observable_resolver_unregister("okta") is False
+    assert cv1.observable_resolver_get_all() == ()
+
+    cv1.observable_resolver_register(_resolver("okta", _okta_identity("123")))
+    cv1.observable_resolver_clear()
+    assert cv1.observable_resolver_get_all() == ()
+
+
+def test_observable_create_raises_for_applicable_async_resolver() -> None:
+    async def resolve(alias: ObservableAlias) -> ObservableIdentity | None:
+        return _okta_identity()
+
+    cv = Cyvest()
+    cv.observable_resolver_register(
+        ObservableResolver(
+            name="async-okta",
+            source_types={(Cyvest.OBS.USER, Cyvest.SUB.USER_EMAIL)},
+            aresolve=resolve,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="observable_acreate"):
+        cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+
+
+def test_observable_acreate_supports_async_resolver() -> None:
+    async def run() -> None:
+        async def resolve(alias: ObservableAlias) -> ObservableIdentity | None:
+            await asyncio.sleep(0)
+            return _okta_identity()
+
+        cv = Cyvest()
+        cv.observable_resolver_register(
+            ObservableResolver(
+                name="async-okta",
+                source_types={(Cyvest.OBS.USER, Cyvest.SUB.USER_EMAIL)},
+                aresolve=resolve,
+            )
+        )
+
+        obs = await cv.observable_acreate(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+        assert obs.subtype == Cyvest.SUB.USER_UID
+        assert obs.namespace == "okta"
+        assert obs.aliases[0].value == "alice@example.com"
+
+    asyncio.run(run())
+
+
+def test_repeated_canonical_creations_merge_occurrence_and_alias_counts() -> None:
+    cv = Cyvest()
+    cv.observable_resolver_register(_resolver("okta-user-id", _okta_identity()))
+
+    cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+    obs = cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+
+    assert obs.occurrence_count == 2
+    assert len(obs.aliases) == 1
+    assert obs.aliases[0].count == 2
+
+
+def test_investigation_merge_combines_occurrences_and_aliases() -> None:
+    cv1 = Cyvest()
+    cv2 = Cyvest()
+    cv1.observable_resolver_register(_resolver("okta-user-id", _okta_identity()))
+    cv2.observable_resolver_register(_resolver("okta-user-id", _okta_identity()))
+
+    obs1 = cv1.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+    cv2.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+    cv2.observable_create(
+        Cyvest.OBS.USER,
+        "alice",
+        subtype=Cyvest.SUB.USER_USERNAME,
+        namespace="windows",
+    )
+
+    cv1.merge_investigation(cv2)
+    merged = cv1.observable_get(obs1.key)
+
+    assert merged is not None
+    assert merged.occurrence_count == 3
+    alias_counts = {(alias.subtype, alias.namespace, alias.value): alias.count for alias in merged.aliases}
+    assert alias_counts[(Cyvest.SUB.USER_EMAIL, None, "alice@example.com")] == 2
+    assert alias_counts[(Cyvest.SUB.USER_USERNAME, "windows", "alice")] == 1
+
+
+def test_aliases_and_occurrence_count_survive_json_roundtrip(tmp_path) -> None:
+    cv = Cyvest()
+    cv.observable_resolver_register(_resolver("okta-user-id", _okta_identity()))
+    obs = cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+
+    path = tmp_path / "canonical.json"
+    cv.io_save_json(path)
+    loaded = Cyvest.io_load_json(path)
+    loaded_obs = loaded.observable_get(obs.key)
+
+    assert loaded_obs is not None
+    assert loaded_obs.occurrence_count == 1
+    assert len(loaded_obs.aliases) == 1
+    assert loaded_obs.aliases[0].subtype == Cyvest.SUB.USER_EMAIL
+
+
+def test_root_occurrence_count_is_not_incremented_by_json_load(tmp_path) -> None:
+    cv = Cyvest()
+    root = cv.observable_get_root()
+    assert root.occurrence_count == 1
+
+    path = tmp_path / "root.json"
+    cv.io_save_json(path)
+    loaded = Cyvest.io_load_json(path)
+
+    assert loaded.observable_get_root().occurrence_count == 1


### PR DESCRIPTION
## Summary

Adds observable canonicalisation at Cyvest creation time through instance-local resolvers.

## Changes

- Adds typed `ObservableAlias`, `ObservableIdentity`, and `ObservableResolver` APIs.
- Adds resolver registration, removal, listing, and clearing on `Cyvest` instances.
- Resolves source identities in `observable_create()` and `observable_acreate()` before creating or merging canonical observables.
- Tracks `occurrence_count` and typed aliases on canonical observables, including merge and JSON round-trip behavior.
- Exposes alias and occurrence metadata through `ObservableProxy`.
- Updates documentation, JSON schema, and generated TypeScript types.

## Validation

- `uv run ruff check src/cyvest tests/test_observable_resolvers.py`
- `uv run pytest`
- `pnpm -C js/packages/cyvest-js run test`