### PR TITLE
feat(observable-resolvers): store resolver metadata on observables

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ source `ObservableAlias` and may return a canonical `ObservableIdentity`; Cyvest
 observable and stores the source identity as an alias with counts.
 
 ```python
-from cyvest import ObservableAlias, ObservableIdentity, ObservableResolver
+from cyvest import ObservableAlias, ObservableIdentity, ObservableResolution, ObservableResolver
 
 def resolve_user(alias: ObservableAlias) -> ObservableIdentity | None:
     if alias.value.lower() != "alice@example.com":
@@ -199,6 +199,10 @@ user = cv.observable_create(cv.OBS.USER, "alice@example.com", subtype=cv.SUB.USE
 assert user.subtype == cv.SUB.USER_UID
 assert user.aliases[0].subtype == cv.SUB.USER_EMAIL
 ```
+
+Resolvers that also retrieve profile or provenance data can return `ObservableResolution` instead. Cyvest stores its
+`metadata` in `user.extra["resolver_data"][resolver.name]` and recursively merges dictionary values across repeated
+creations and investigation merges.
 
 ### Findings
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -95,7 +95,13 @@ Register an instance-local resolver when you want `observable_create()` to resol
 the observable:
 
 ```python
-from cyvest import Cyvest, ObservableAlias, ObservableIdentity, ObservableResolver
+from cyvest import (
+    Cyvest,
+    ObservableAlias,
+    ObservableIdentity,
+    ObservableResolution,
+    ObservableResolver,
+)
 
 cv = Cyvest()
 
@@ -166,6 +172,31 @@ cv.observable_resolver_clear()
 
 For async lookups, register `aresolve=` and use `await cv.observable_acreate(...)`. If a matching async resolver is
 registered, synchronous `observable_create()` raises a clear error instead of blocking the event loop.
+
+When the lookup also returns useful attributes, return an `ObservableResolution`:
+
+```python
+def resolve_user_to_okta(alias: ObservableAlias) -> ObservableResolution | None:
+    user = lookup_okta_user(alias)
+    if user is None:
+        return None
+
+    return ObservableResolution(
+        identity=ObservableIdentity(
+            obs_type=cv.OBS.USER,
+            subtype=cv.SUB.USER_UID,
+            namespace="okta",
+            value=user["id"],
+        ),
+        metadata=user,
+    )
+```
+
+Cyvest stores this metadata on the canonical observable under
+`observable.extra["resolver_data"][resolver.name]`. Dictionaries are merged recursively across repeated observable
+creations and investigation merges; incoming scalar and list values replace previous values. Resolver metadata
+coexists with `extra=` passed to `observable_create()`. The reserved `extra["resolver_data"]` value must be a
+dictionary.
 
 ### Findings
 

--- a/js/packages/cyvest-app/package.json
+++ b/js/packages/cyvest-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyvest/cyvest-app",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/js/packages/cyvest-js/package.json
+++ b/js/packages/cyvest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyvest/cyvest-js",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "type": "module",
   "files": [
     "dist"

--- a/js/packages/cyvest-vis/package.json
+++ b/js/packages/cyvest-vis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyvest/cyvest-vis",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "type": "module",
   "files": [
     "dist"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyvest"
-version = "6.1.0"
+version = "6.1.1"
 description = "Cybersecurity investigation model"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/src/cyvest/__init__.py
+++ b/src/cyvest/__init__.py
@@ -29,9 +29,9 @@ from cyvest.model import (
 )
 from cyvest.model_enums import ObservableSubtype, ObservableType, RelationshipDirection, RelationshipType
 from cyvest.proxies import EnrichmentProxy, EvidenceProxy, FindingProxy, ObservableProxy, TagProxy, ThreatIntelProxy
-from cyvest.resolvers import ObservableResolver
+from cyvest.resolvers import ObservableResolution, ObservableResolver
 
-__version__ = "6.1.0"
+__version__ = "6.1.1"
 
 __all__ = [
     # Core class
@@ -58,6 +58,7 @@ __all__ = [
     "Observable",
     "ObservableAlias",
     "ObservableIdentity",
+    "ObservableResolution",
     "ObservableResolver",
     "ThreatIntel",
     "Taxonomy",

--- a/src/cyvest/cyvest.py
+++ b/src/cyvest/cyvest.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable, Iterable
+from copy import deepcopy
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
@@ -22,7 +23,7 @@ from logurich import get_logger
 
 from cyvest import keys
 from cyvest.compare import compare_investigations
-from cyvest.investigation import Investigation, InvestigationWhitelist
+from cyvest.investigation import Investigation, InvestigationWhitelist, _deep_merge_dict
 from cyvest.io_rich import (
     display_diff,
     display_finding_query,
@@ -62,7 +63,7 @@ from cyvest.model_enums import (
 )
 from cyvest.model_schema import InvestigationSchema, StatisticsSchema
 from cyvest.proxies import EnrichmentProxy, EvidenceProxy, FindingProxy, ObservableProxy, TagProxy, ThreatIntelProxy
-from cyvest.resolvers import ObservableResolver
+from cyvest.resolvers import ObservableResolution, ObservableResolver, ObservableResolverResult
 from cyvest.score import ScoreMode
 
 if TYPE_CHECKING:
@@ -322,7 +323,15 @@ class Cyvest:
         """Return registered observable identity resolvers in evaluation order."""
         return tuple(self._observable_resolvers)
 
-    def _resolve_observable_identity_sync(self, alias: ObservableAlias) -> ObservableIdentity | None:
+    @staticmethod
+    def _normalize_observable_resolution(resolved: ObservableResolverResult) -> ObservableResolution | None:
+        if resolved is None:
+            return None
+        if isinstance(resolved, ObservableResolution):
+            return ObservableResolution.model_validate(resolved)
+        return ObservableResolution(identity=ObservableIdentity.model_validate(resolved))
+
+    def _resolve_observable_identity_sync(self, alias: ObservableAlias) -> tuple[str, ObservableResolution] | None:
         for resolver in self._observable_resolvers:
             if self._resolver_applies(resolver, alias) and resolver.aresolve is not None:
                 raise RuntimeError(
@@ -335,27 +344,57 @@ class Cyvest:
                 continue
             resolved = resolver.resolve(alias)
             if resolved is not None:
-                return ObservableIdentity.model_validate(resolved)
+                resolution = self._normalize_observable_resolution(resolved)
+                if resolution is not None:
+                    return resolver.name, resolution
         return None
 
-    async def _resolve_observable_identity_async(self, alias: ObservableAlias) -> ObservableIdentity | None:
+    async def _resolve_observable_identity_async(
+        self,
+        alias: ObservableAlias,
+    ) -> tuple[str, ObservableResolution] | None:
         for resolver in self._observable_resolvers:
             if not self._resolver_applies(resolver, alias):
                 continue
-            resolved: ObservableIdentity | None = None
+            resolved: ObservableResolverResult = None
             if resolver.resolve is not None:
                 resolved = resolver.resolve(alias)
             elif resolver.aresolve is not None:
                 resolved = await resolver.aresolve(alias)
             if resolved is not None:
-                return ObservableIdentity.model_validate(resolved)
+                resolution = self._normalize_observable_resolution(resolved)
+                if resolution is not None:
+                    return resolver.name, resolution
         return None
+
+    @staticmethod
+    def _observable_extra_with_resolution(
+        extra: dict[str, Any] | None,
+        resolved: tuple[str, ObservableResolution] | None,
+    ) -> dict[str, Any]:
+        observable_extra = deepcopy(extra) if extra is not None else {}
+        resolver_data = observable_extra.get("resolver_data")
+        if resolver_data is not None and not isinstance(resolver_data, dict):
+            raise ValueError("Observable extra field 'resolver_data' must be a dictionary.")
+
+        if resolved is None:
+            return observable_extra
+
+        resolver_name, resolution = resolved
+        if not resolution.metadata:
+            return observable_extra
+
+        if resolver_data is None:
+            resolver_data = {}
+            observable_extra["resolver_data"] = resolver_data
+        _deep_merge_dict(resolver_data, {resolver_name: resolution.metadata})
+        return observable_extra
 
     def _observable_create_from_resolved_identity(
         self,
         *,
         alias: ObservableAlias,
-        identity: ObservableIdentity | None,
+        resolved: tuple[str, ObservableResolution] | None,
         internal: bool,
         whitelisted: bool,
         comment: str,
@@ -369,15 +408,15 @@ class Cyvest:
             namespace=alias.namespace,
             value=alias.value,
         )
-        canonical_identity = identity or source_identity
-        aliases = [alias] if identity is not None else []
+        canonical_identity = resolved[1].identity if resolved is not None else source_identity
+        aliases = [alias] if resolved is not None else []
         obs = Observable(
             **self._observable_kwargs_from_identity(
                 canonical_identity,
                 internal=internal,
                 whitelisted=whitelisted,
                 comment=comment,
-                extra=extra or {},
+                extra=self._observable_extra_with_resolution(extra, resolved),
                 score=score,
                 level=level,
                 aliases=aliases,
@@ -416,10 +455,10 @@ class Cyvest:
             The created or existing observable
         """
         alias = ObservableAlias(obs_type=obs_type, subtype=subtype, namespace=namespace, value=value)
-        identity = self._resolve_observable_identity_sync(alias)
+        resolved = self._resolve_observable_identity_sync(alias)
         return self._observable_create_from_resolved_identity(
             alias=alias,
-            identity=identity,
+            resolved=resolved,
             internal=internal,
             whitelisted=whitelisted,
             comment=comment,
@@ -443,10 +482,10 @@ class Cyvest:
     ) -> ObservableProxy:
         """Async variant of observable_create supporting async resolvers."""
         alias = ObservableAlias(obs_type=obs_type, subtype=subtype, namespace=namespace, value=value)
-        identity = await self._resolve_observable_identity_async(alias)
+        resolved = await self._resolve_observable_identity_async(alias)
         return self._observable_create_from_resolved_identity(
             alias=alias,
-            identity=identity,
+            resolved=resolved,
             internal=internal,
             whitelisted=whitelisted,
             comment=comment,

--- a/src/cyvest/investigation.py
+++ b/src/cyvest/investigation.py
@@ -43,6 +43,16 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _deep_merge_dict(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge update into base, copying replaced values."""
+    for key, value in update.items():
+        if key in base and isinstance(base[key], dict) and isinstance(value, dict):
+            _deep_merge_dict(base[key], value)
+        else:
+            base[key] = deepcopy(value)
+    return base
+
+
 class Investigation:
     """
     Core investigation state and operations.
@@ -422,11 +432,11 @@ class Investigation:
         if incoming.level > existing.level:
             self.apply_level_change(existing, incoming.level, reason=f"Merged from {incoming.key}")
 
-        # Update extra (merge dictionaries)
+        # Update extra (merge dictionaries recursively)
         if existing.extra:
-            existing.extra.update(incoming.extra)
+            _deep_merge_dict(existing.extra, incoming.extra)
         elif incoming.extra:
-            existing.extra = dict(incoming.extra)
+            existing.extra = deepcopy(incoming.extra)
 
         # Overwrite comment if incoming is non-empty
         if incoming.comment:
@@ -611,18 +621,9 @@ class Investigation:
             The merged enrichment (existing is modified in place)
         """
 
-        def deep_merge(base: dict, update: dict) -> dict:
-            """Recursively merge dictionaries."""
-            for key, value in update.items():
-                if key in base and isinstance(base[key], dict) and isinstance(value, dict):
-                    deep_merge(base[key], value)
-                else:
-                    base[key] = value
-            return base
-
         # Deep merge data structures
         if isinstance(existing.data, dict) and isinstance(incoming.data, dict):
-            deep_merge(existing.data, incoming.data)
+            _deep_merge_dict(existing.data, incoming.data)
         else:
             existing.data = deepcopy(incoming.data)
 
@@ -1340,6 +1341,10 @@ class Investigation:
             if field in dict_fields:
                 if not isinstance(value, dict):
                     raise TypeError(f"Field '{field}' on {model_type} expects a dict value.")
+                if model_type == "observable" and field == "extra":
+                    resolver_data = value.get("resolver_data")
+                    if resolver_data is not None and not isinstance(resolver_data, dict):
+                        raise ValueError("Observable extra field 'resolver_data' must be a dictionary.")
                 merge = dict_merge.get(field, True) if dict_merge else True
                 if merge:
                     current_value = getattr(target, field, None)

--- a/src/cyvest/model.py
+++ b/src/cyvest/model.py
@@ -402,6 +402,10 @@ class Observable(AliasDumpModel):
     def coerce_extra(cls, v: Any) -> dict[str, Any]:
         if v is None:
             return {}
+        if isinstance(v, dict):
+            resolver_data = v.get("resolver_data")
+            if resolver_data is not None and not isinstance(resolver_data, dict):
+                raise ValueError("Observable extra field 'resolver_data' must be a dictionary.")
         return v
 
     @field_validator("score", mode="before")

--- a/src/cyvest/resolvers.py
+++ b/src/cyvest/resolvers.py
@@ -4,11 +4,26 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from cyvest.model import ObservableAlias, ObservableIdentity
 from cyvest.model_enums import ObservableSubtype, ObservableType
 
 ObservableSourceType = tuple[ObservableType | str, ObservableSubtype | str | None]
+
+
+class ObservableResolution(BaseModel):
+    """Canonical observable identity and metadata returned by a resolver."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    identity: ObservableIdentity
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+ObservableResolverResult = ObservableIdentity | ObservableResolution | None
 
 
 @dataclass(frozen=True)
@@ -17,8 +32,8 @@ class ObservableResolver:
 
     name: str
     source_types: set[ObservableSourceType]
-    resolve: Callable[[ObservableAlias], ObservableIdentity | None] | None = None
-    aresolve: Callable[[ObservableAlias], Awaitable[ObservableIdentity | None]] | None = None
+    resolve: Callable[[ObservableAlias], ObservableResolverResult] | None = None
+    aresolve: Callable[[ObservableAlias], Awaitable[ObservableResolverResult]] | None = None
 
     def __post_init__(self) -> None:
         name = self.name.strip()

--- a/tests/test_observable_resolvers.py
+++ b/tests/test_observable_resolvers.py
@@ -6,7 +6,7 @@ import asyncio
 
 import pytest
 
-from cyvest import Cyvest, ObservableAlias, ObservableIdentity, ObservableResolver
+from cyvest import Cyvest, Observable, ObservableAlias, ObservableIdentity, ObservableResolution, ObservableResolver
 
 
 def _okta_identity(value: str = "123") -> ObservableIdentity:
@@ -162,6 +162,209 @@ def test_observable_acreate_supports_async_resolver() -> None:
         assert obs.aliases[0].value == "alice@example.com"
 
     asyncio.run(run())
+
+
+def test_resolution_metadata_is_stored_with_manual_extra() -> None:
+    cv = Cyvest()
+    cv.observable_resolver_register(
+        ObservableResolver(
+            name="okta-user-id",
+            source_types={(Cyvest.OBS.USER, Cyvest.SUB.USER_EMAIL)},
+            resolve=lambda alias: ObservableResolution(
+                identity=_okta_identity(),
+                metadata={
+                    "profile": {
+                        "email": alias.value,
+                        "status": "ACTIVE",
+                    },
+                    "groups": ["employees"],
+                },
+            ),
+        )
+    )
+
+    obs = cv.observable_create(
+        Cyvest.OBS.USER,
+        "alice@example.com",
+        subtype=Cyvest.SUB.USER_EMAIL,
+        extra={
+            "source": "manual",
+            "resolver_data": {
+                "okta-user-id": {
+                    "profile": {"tenant": "example"},
+                }
+            },
+        },
+    )
+
+    assert obs.extra == {
+        "source": "manual",
+        "resolver_data": {
+            "okta-user-id": {
+                "profile": {
+                    "tenant": "example",
+                    "email": "alice@example.com",
+                    "status": "ACTIVE",
+                },
+                "groups": ["employees"],
+            }
+        },
+    }
+
+
+def test_async_resolution_metadata_is_stored() -> None:
+    async def run() -> None:
+        async def resolve(alias: ObservableAlias) -> ObservableResolution:
+            await asyncio.sleep(0)
+            return ObservableResolution(
+                identity=_okta_identity(),
+                metadata={"lookup": {"matched": alias.value}},
+            )
+
+        cv = Cyvest()
+        cv.observable_resolver_register(
+            ObservableResolver(
+                name="async-okta",
+                source_types={(Cyvest.OBS.USER, Cyvest.SUB.USER_EMAIL)},
+                aresolve=resolve,
+            )
+        )
+
+        obs = await cv.observable_acreate(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+
+        assert obs.extra["resolver_data"]["async-okta"] == {"lookup": {"matched": "alice@example.com"}}
+
+    asyncio.run(run())
+
+
+def test_resolution_metadata_merges_recursively_on_repeated_creation() -> None:
+    def resolve(alias: ObservableAlias) -> ObservableResolution:
+        if alias.subtype == Cyvest.SUB.USER_EMAIL:
+            metadata = {
+                "profile": {"email": alias.value},
+                "groups": ["email-users"],
+            }
+        else:
+            metadata = {
+                "profile": {"username": alias.value},
+                "groups": ["username-users"],
+            }
+        return ObservableResolution(identity=_okta_identity(), metadata=metadata)
+
+    cv = Cyvest()
+    cv.observable_resolver_register(
+        ObservableResolver(
+            name="okta-user-id",
+            source_types={
+                (Cyvest.OBS.USER, Cyvest.SUB.USER_EMAIL),
+                (Cyvest.OBS.USER, Cyvest.SUB.USER_USERNAME),
+            },
+            resolve=resolve,
+        )
+    )
+
+    cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+    obs = cv.observable_create(
+        Cyvest.OBS.USER,
+        "alice",
+        subtype=Cyvest.SUB.USER_USERNAME,
+        namespace="windows",
+    )
+
+    assert obs.extra["resolver_data"]["okta-user-id"] == {
+        "profile": {
+            "email": "alice@example.com",
+            "username": "alice",
+        },
+        "groups": ["username-users"],
+    }
+
+
+def test_resolution_metadata_merges_recursively_across_investigations() -> None:
+    cv1 = Cyvest()
+    cv2 = Cyvest()
+    cv1.observable_resolver_register(
+        ObservableResolver(
+            name="okta-user-id",
+            source_types={(Cyvest.OBS.USER, Cyvest.SUB.USER_EMAIL)},
+            resolve=lambda alias: ObservableResolution(
+                identity=_okta_identity(),
+                metadata={"profile": {"email": alias.value}},
+            ),
+        )
+    )
+    cv2.observable_resolver_register(
+        ObservableResolver(
+            name="okta-user-id",
+            source_types={(Cyvest.OBS.USER, Cyvest.SUB.USER_USERNAME)},
+            resolve=lambda alias: ObservableResolution(
+                identity=_okta_identity(),
+                metadata={"profile": {"username": alias.value}},
+            ),
+        )
+    )
+
+    obs = cv1.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+    cv2.observable_create(
+        Cyvest.OBS.USER,
+        "alice",
+        subtype=Cyvest.SUB.USER_USERNAME,
+        namespace="windows",
+    )
+    cv1.merge_investigation(cv2)
+
+    merged = cv1.observable_get(obs.key)
+    assert merged is not None
+    assert merged.extra["resolver_data"]["okta-user-id"]["profile"] == {
+        "email": "alice@example.com",
+        "username": "alice",
+    }
+
+
+def test_resolution_metadata_survives_json_roundtrip(tmp_path) -> None:
+    cv = Cyvest()
+    cv.observable_resolver_register(
+        ObservableResolver(
+            name="okta-user-id",
+            source_types={(Cyvest.OBS.USER, Cyvest.SUB.USER_EMAIL)},
+            resolve=lambda alias: ObservableResolution(
+                identity=_okta_identity(),
+                metadata={"profile": {"email": alias.value}},
+            ),
+        )
+    )
+    obs = cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+
+    path = tmp_path / "resolution-metadata.json"
+    cv.io_save_json(path)
+    loaded = Cyvest.io_load_json(path)
+    loaded_obs = loaded.observable_get(obs.key)
+
+    assert loaded_obs is not None
+    assert loaded_obs.extra["resolver_data"]["okta-user-id"] == {"profile": {"email": "alice@example.com"}}
+
+
+def test_resolver_data_extra_must_be_a_dictionary() -> None:
+    cv = Cyvest()
+
+    with pytest.raises(ValueError, match="resolver_data.*dictionary"):
+        Observable(obs_type=Cyvest.OBS.IPV4, value="192.0.2.0", extra={"resolver_data": "invalid"})
+
+    with pytest.raises(ValueError, match="resolver_data.*dictionary"):
+        cv.observable_create(Cyvest.OBS.IPV4, "192.0.2.1", extra={"resolver_data": "invalid"})
+
+    obs = cv.observable_create(Cyvest.OBS.IPV4, "192.0.2.2")
+    with pytest.raises(ValueError, match="resolver_data.*dictionary"):
+        obs.update_metadata(extra={"resolver_data": "invalid"})
+
+
+def test_unresolved_observable_has_no_resolver_metadata() -> None:
+    cv = Cyvest()
+    cv.observable_resolver_register(_resolver("missing-okta-user", None))
+
+    obs = cv.observable_create(Cyvest.OBS.USER, "alice@example.com", subtype=Cyvest.SUB.USER_EMAIL)
+
+    assert "resolver_data" not in obs.extra
 
 
 def test_repeated_canonical_creations_merge_occurrence_and_alias_counts() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -319,7 +319,7 @@ toml = [
 
 [[package]]
 name = "cyvest"
-version = "6.1.0"
+version = "6.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- add `ObservableResolution` so resolvers can return a canonical identity plus metadata
- store resolver metadata under `observable.extra["resolver_data"]`, merge it recursively across repeated creations and investigation merges, and validate that `resolver_data` stays a dictionary
- export the new API, document resolver metadata usage, add coverage for sync/async resolution, merge behavior, validation, and JSON round-tripping, and bump versions to `6.1.1`

## Testing
- updated `tests/test_observable_resolvers.py` to cover resolver metadata storage, recursive merges, validation, unresolved cases, async resolvers, and serialization round-trips